### PR TITLE
update to 20.1.0, rewrite packaging for electron

### DIFF
--- a/dev.slimevr.SlimeVR.desktop
+++ b/dev.slimevr.SlimeVR.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=SlimeVR
+Exec=slimevr %U
+Icon=dev.slimevr.SlimeVR
+Type=Application
+Categories=Utility;
+StartupWMClass=SlimeVR

--- a/dev.slimevr.SlimeVR.metainfo.xml
+++ b/dev.slimevr.SlimeVR.metainfo.xml
@@ -65,6 +65,7 @@ work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
   </provides>
 
   <releases>
+    <release version="20.1.0" date="2026-06-21"><url>https://github.com/SlimeVR/SlimeVR-Server/releases/tag/v20.1.0</url></release>
     <release version="18.2.0" date="2026-03-05">
       <description></description>
     </release>

--- a/dev.slimevr.SlimeVR.yml
+++ b/dev.slimevr.SlimeVR.yml
@@ -1,7 +1,9 @@
 app-id: dev.slimevr.SlimeVR
-runtime: org.gnome.Platform
-sdk: org.gnome.Sdk
-runtime-version: '48'
+runtime: org.freedesktop.Platform
+sdk: org.freedesktop.Sdk
+runtime-version: '25.08'
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
 separate-locales: false
 command: slimevr
 finish-args:
@@ -17,62 +19,102 @@ finish-args:
   - --socket=pulseaudio
   # Add JRE bin on path
   - --env=PATH=/app/jre/bin:/usr/bin:/app/bin
+  - --env=JAVA_HOME=/app/jre
   #- --env=GDK_BACKEND=wayland,x11
+  - --env=ELECTRON_TRASH=gio
 # build dependencies
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
-  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node22
 modules:
   # We need LibUSB for HID4Java
   - shared-modules/libusb/libusb.json
   # We need the JRE for executing the server
+  - name: node
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/node22/install-sdk.sh
   - name: openjdk
     buildsystem: simple
     build-commands:
       - /usr/lib/sdk/openjdk17/install.sh
-  - name: slimevr-server
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/share/slimevr
-      - install -Dm755 slimevr.jar /app/share/slimevr/slimevr.jar
-    sources:
-      - type: file
-        url: https://github.com/SlimeVR/SlimeVR-Server/releases/download/v18.2.0/slimevr.jar
-        sha256: fd8409017e800eea8b00938efa3992be684769d6e3593c579ae4a2b422644790
   - name: slimevr-gui
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/rust-stable/bin
+      append-path: /usr/lib/sdk/node22/bin:/run/build/slimevr-gui/pnpm/bin:/run/build/slimevr-gui/node_modules/.pnpm/node_modules/.bin
       env:
-        CARGO_HOME: /run/build/slimevr-gui/cargo
+        XGD_CACHE_HOME: /run/build/slimevr-gui/flatpak-node/cache
+        npm_config_cache: /run/build/slimevr-gui/flatpak-node/npm-cache
+        TMPDIR: /run/build/slimevr-gui/flatpak-node/tmp
+
+        ELECTRON_CONFIG_CACHE: /run/build/slimevr-gui/flatpak-node/cache/electron
+        electron_config_cache: /run/build/slimevr-gui/flatpak-node/cache/electron
+        ELECTRON_CACHE: /run/build/slimevr-gui/flatpak-node/cache/electron
+
+    # Reference https://github.com/SlimeVR/SlimeVR-Server/blob/main/.github/workflows/build.yml
     build-commands:
-      - sed -i gui/src-tauri/dev.slimevr.SlimeVR.desktop -e "s|{{exec}}|slimevr|"
-        -e "s|{{icon}}|dev.slimevr.SlimeVR|"
-      - cargo --offline fetch --manifest-path Cargo.toml --verbose
-      - mkdir -p gui/dist/ && tar -xf slimevr-gui-dist.tar.gz -C gui/dist && ls -l
-        gui/dist
-      - cargo --offline build --release
-      - install -Dm644 gui/src-tauri/icons/icon.svg /app/share/icons/hicolor/scalable/apps/dev.slimevr.SlimeVR.svg
-      - install -Dm644 -t /app/share/metainfo dev.slimevr.SlimeVR.metainfo.xml
-      - install -Dm644 -t /app/share/applications gui/src-tauri/dev.slimevr.SlimeVR.desktop
-      - install -Dm755 target/release/slimevr /app/bin/slimevr-bin
+      - mkdir -p $TMPDIR
+      - cmake -S bindings-provider/ -B bindings-provider/build -DCMAKE_BUILD_TYPE=Release
+      - cmake --build bindings-provider/build --config Release -j6
+      # fix paths so electron-builder finds them
+      - |
+        case "$FLATPAK_ARCH" in
+          x86_64) EB_ARCH=x64 ;;
+          aarch64) EB_ARCH=arm64 ;;
+        esac
+        cd bindings-provider/build
+        mkdir "linux-$EB_ARCH/"
+        mv {libopenvr_api.so,slimevr-bindings-provider} "linux-$EB_ARCH/"
+
+      - ln -s $(pwd)/pnpm/bin/pnpm.cjs $(pwd)/pnpm/bin/pnpm
+      - pnpm i --offline --frozen-lockfile
+      - |
+        cd gui
+        pnpm run build
+      - |
+        mkdir -p server/desktop/build/libs
+        cp slimevr.jar server/desktop/build/libs/slimevr.jar
+      - |
+        VERSION=$(git --no-pager tag --sort -taggerdate --points-at HEAD | head -1)
+        [ -z "$VERSION" ] && VERSION="0.0.0"
+        VERSION="${VERSION#v}"
+        echo "Building version: $VERSION"
+
+        cd gui
+        mkdir -p gui/dist/artifacts/linux
+
+        . ../flatpak-node/electron-builder-arch-args.sh
+        electron-builder $ELECTRON_BUILDER_ARCH_ARGS --linux dir --publish never -c.extraMetadata.version=$VERSION
+
+      # Bundle app and dependencies
+      - cp -a gui/dist/artifacts/linux/linux*unpacked /app/main
       - install -Dm755 slimevr-wrapper /app/bin/slimevr
+      - install -Dm644 dev.slimevr.SlimeVR.desktop -t /app/share/applications
+      - install -Dm644 gui/electron/resources/icons/icon.svg /app/share/icons/hicolor/scalable/apps/dev.slimevr.SlimeVR.svg
+      - install -Dm644 dev.slimevr.SlimeVR.metainfo.xml -t /app/share/metainfo
+      #
     sources:
+      - type: file
+        url: https://github.com/SlimeVR/SlimeVR-Server/releases/download/v20.1.0/slimevr.jar
+        sha256: 2dde96d4009b6c91a4ec25f4f7ea322d1eef5e16622c1003098ffd4a3b34b495
       - type: git
         url: https://github.com/SlimeVR/SlimeVR-Server.git
-        tag: v18.2.0
-        commit: 0236a05f265f3fbeeb1c71083acbb486878da064
+        tag: v20.1.0
+        commit: 81a46c2ea50ef7699a338795352ee8addece19fe
       # Patch for not checking if git is clean
       - type: patch
         path: clean.diff
       - type: file
         path: dev.slimevr.SlimeVR.metainfo.xml
       - type: file
-        url: https://github.com/SlimeVR/SlimeVR-Server/releases/download/v18.2.0/slimevr-gui-dist.tar.gz
-        sha256: 3e29eef83bd7a260f6631bd204b3454bfebf28a91bc2c4300c0f967757e70f34
-      - cargo-sources.json
+        path: dev.slimevr.SlimeVR.desktop
+      - type: archive
+        url: https://registry.npmjs.org/pnpm/-/pnpm-10.33.0.tgz
+        sha512: 10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319
+        dest: pnpm
+      - generated-sources.json
       - type: script
         dest-filename: slimevr-wrapper
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec /app/bin/slimevr-bin "$@"
+          - exec zypak-wrapper /app/main/slimevr "$@"

--- a/dev.slimevr.SlimeVR.yml
+++ b/dev.slimevr.SlimeVR.yml
@@ -43,13 +43,10 @@ modules:
     build-options:
       append-path: /usr/lib/sdk/node22/bin:/run/build/slimevr-gui/pnpm/bin:/run/build/slimevr-gui/node_modules/.pnpm/node_modules/.bin
       env:
-        XGD_CACHE_HOME: /run/build/slimevr-gui/flatpak-node/cache
-        npm_config_cache: /run/build/slimevr-gui/flatpak-node/npm-cache
         TMPDIR: /run/build/slimevr-gui/flatpak-node/tmp
-
-        ELECTRON_CONFIG_CACHE: /run/build/slimevr-gui/flatpak-node/cache/electron
+        XDG_CACHE_HOME: /run/build/slimevr-gui/flatpak-node/cache
+        pnpm_config_cache: /run/build/slimevr-gui/flatpak-node/npm-cache
         electron_config_cache: /run/build/slimevr-gui/flatpak-node/cache/electron
-        ELECTRON_CACHE: /run/build/slimevr-gui/flatpak-node/cache/electron
 
     # Reference https://github.com/SlimeVR/SlimeVR-Server/blob/main/.github/workflows/build.yml
     build-commands:

--- a/dev.slimevr.SlimeVR.yml
+++ b/dev.slimevr.SlimeVR.yml
@@ -24,7 +24,7 @@ finish-args:
   - --env=ELECTRON_TRASH=gio
 # build dependencies
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk21
   - org.freedesktop.Sdk.Extension.node22
 modules:
   # We need LibUSB for HID4Java
@@ -37,7 +37,7 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
+      - /usr/lib/sdk/openjdk21/install.sh
   - name: slimevr-gui
     buildsystem: simple
     build-options:

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,0 +1,8567 @@
+[
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.21.5",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+        "strip-components": 1,
+        "sha512": "94f0c6c82d493c3a2ef2419ccb06346082f35a58619d18dda1fdd495ca2a6264bd125f35f0b2df2497373d75e0647ac70802acfd9d92799b4326be4cae4c6d3b",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.25.12",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.21.5",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+        "strip-components": 1,
+        "sha512": "f1bc17edaf05821220aeea5cc5be1a5266032e9f295f4eab1a1e47a834fb6c1fbc45d7a596cea61efac51c75b624038f6546e78d4a4a4cb83a102cb3bdab3601",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.25.12",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.21.5",
+        "only-arches": [
+            "i386"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+        "strip-components": 1,
+        "sha512": "d32f4aadd5676cc336fef1bc29f5346f285437e1050a7cbdfbc836d36818a924953289dbb027cb8d43beac2722ee933458112dcfea0afcf2301e4cf193285aac",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.25.12",
+        "only-arches": [
+            "i386"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.21.5",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+        "strip-components": 1,
+        "sha512": "baa64c4cbaffcd1fde7788c81a7c122e468798f8ce8c9be79ba4d5562b406b4f122d2f59d1533cc08471ee059b241e7f279e18b883089c3aae5b262f40b66483",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.25.12",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17",
+        "sha256": "ab95956c7df0d1252400d97a9b62c7c2e807f41c38629471dc0f41723aa7ff17",
+        "dest-filename": "e7cc9a63a1f512565da44cb57316d9fb10750e17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs/register-scheme-https:/codeload.github.com/devsnek/node-register-scheme/tar.gz"
+    },
+    {
+        "type": "file",
+        "url": "https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec",
+        "sha256": "2a19ba0c85efdd5dcdc9b2fbc8f2a19faec63423bc931ef7db6de4482541df73",
+        "dest-filename": "9e7de2a6d917591f10a66389e62e1dc053c04fec.tgz",
+        "dest": "flatpak-node/pnpm-tarballs/discord-rpc-https:/codeload.github.com/discordjs/rpc/tar.gz"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v40.9.1/SHASUMS256.txt",
+        "sha256": "f285e30904bd8b8a8383e51b5519a401136d8475c000b0f08eac3460b74c4905",
+        "dest-filename": "SHASUMS256.txt-40.9.1",
+        "dest": "flatpak-node/cache/electron"
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v40.9.1/electron-v40.9.1-linux-arm64.zip",
+        "sha256": "c9a7284dfaad01f89aaa3e26e57c85a433e15022567a85f39490cd9af840737e",
+        "dest-filename": "electron-v40.9.1-linux-arm64.zip",
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v40.9.1/electron-v40.9.1-linux-armv7l.zip",
+        "sha256": "d6fbb3db24be299133f3e979a39f86841f3f40abf693ea6d14cee087a3d6be79",
+        "dest-filename": "electron-v40.9.1-linux-armv7l.zip",
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "https://github.com/electron/electron/releases/download/v40.9.1/electron-v40.9.1-linux-x64.zip",
+        "sha256": "ceb3c8d92e7e789269e43639d3ee00c1c6a147a866d09202d4edf23c203c861a",
+        "dest-filename": "electron-v40.9.1-linux-x64.zip",
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+        "sha512": "ba44cf561a86e2337332ba36a80f4748249254937768deed95bfa17ea602b77111d325aba1e036551dfc30dace1cb43f7158fe0da20c69dd24142b565a8c21fc",
+        "dest-filename": "7zip-bin-5.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+        "sha512": "52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f",
+        "dest-filename": "@alloc__quick-lru-5.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+        "sha512": "f4d8427988eaf7edeec6076da76d0b4a225726f37415e0ad346a49c6e3056752afddc59435be833a127052f7150b328647ae9cc389e3c0cea1ac92ea80ec1b73",
+        "dest-filename": "@babel__code-frame-7.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+        "sha512": "4f534226a4ff8fdf9c9fc7ef92dee3b706cb05f2c2ff5cb573b36d09e5c5460cc64ec69f8baf0c46ff32ce46126a9067140e8bdd4d9549cd367220f3a0026126",
+        "dest-filename": "@babel__compat-data-7.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+        "sha512": "08639f389a968e0daa5bf31beb336c0e6faee6f150f03c577db334f73ebda7967afa61358a43f68d45f0fa3e363dfd574d8103d919e2e5ff799e961ebb030340",
+        "dest-filename": "@babel__core-7.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+        "sha512": "aac685fbd41c9b642ff1244830cb1c02f1b83b7949d05d46b8ca391d1fc1a74d8ba293609d9042fc491b7af1c5786b3896cfe83f3f6ff81b26cdb91b7bed1d53",
+        "dest-filename": "@babel__generator-7.29.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+        "sha512": "258b65b3786a8b5e5f731e4669234bed209327630d9a3ae41d7838152a4e03f82bc4af0ac326796ee6c7b02abc1570a4b9aeb186e69a062b7eddbefe55945f70",
+        "dest-filename": "@babel__helper-compilation-targets-7.28.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+        "sha512": "f96e9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887",
+        "dest-filename": "@babel__helper-globals-7.28.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+        "sha512": "9795e464aeebef06bd2ee706c3d2f0672c8252c71be31dfb2564cfcfbb30c0513fd05310006a62594667f2ef43ce448158470adb98e6bee6dfa70d9d9c031d6f",
+        "dest-filename": "@babel__helper-module-imports-7.28.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+        "sha512": "ebba1714062bd9c0cb0d518b5d3100063741259e9dac4954488ed62a9ef436ba72212b28de9946f52006105eb2ef36e16bfc0ecd40725964c9bc40d534850670",
+        "dest-filename": "@babel__helper-module-transforms-7.28.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+        "sha512": "4bd83367f6f3f37191cac23b8000f8c0f4ff008dee0a763ef719fe331fca3ecd89c07248cf55bc3d9920d9cab2b7744d38133c7a3717855eb2f0e83b972fc3ba",
+        "dest-filename": "@babel__helper-plugin-utils-7.28.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+        "sha512": "a8c952c4a6e946502b89d0c4c64f769d2a1bc837693e28d4ab60d6ea80e752a77488e1b19908f2aa13088a123dfb3bf82cfc997518ded9c6af58f6c26d69b778",
+        "dest-filename": "@babel__helper-string-parser-7.27.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+        "sha512": "a92b3889fc33289495dfdb9c363b2f73a5951ece9bed2d37b0e87639c1c5f541df54fa965802d4b0d515ce1481888b63459a0b1f1ee721aad58ea295bac519d5",
+        "dest-filename": "@babel__helper-validator-identifier-7.28.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+        "sha512": "62f8c9a30f45c5b84514a0d2b859d509ed96c57935cd6736d9f15e3d5344696244bbc22b65595d6ba374b87c3366b50cd6297b342f4c969e0c68961b61df494a",
+        "dest-filename": "@babel__helper-validator-option-7.27.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+        "sha512": "1e81ae52ce2c09935ecd510a755730aa664df06a078ab2d470b69854d04ad89d0369d1ad75caa0af70426ef1fcf97528e0d1a3365dd53ad4a310a373a9f1602b",
+        "dest-filename": "@babel__helpers-7.29.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+        "sha512": "e06811cf2ffe7ec05aef6fd165526618a3e666ef41ca7f28e0ca0ba6635ed66f197d89f3e5e9872d0cf753880bb9de99c25d1164872088b0fb52aef2485b832c",
+        "dest-filename": "@babel__parser-7.29.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+        "sha512": "f19e131a273ac56ef414a4e10391d810a2b206938eb2e713383d438d4ddf6710e0f8adf30497173059edff8c908999dfe7e32238c49743d3da10afc8961d4378",
+        "dest-filename": "@babel__plugin-transform-arrow-functions-7.27.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+        "sha512": "e94ce40acf9e8c6759e661450bf38252bbf4dbc69bd9fa75ce76660998c03812a204ada35c3d4ef813d27d7f17daa8c9ef97d904c4a7427dd1ab69ab0492b69b",
+        "dest-filename": "@babel__plugin-transform-react-jsx-self-7.27.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+        "sha512": "cdbc284ec06bb9378a07d852abbde16baea215e247b9a16451bc2fa84967ca0a0d6e3fe31d1b127a8928c1914ddc267ae08bc4a9c9a69157bcf4e3d773b95d03",
+        "dest-filename": "@babel__plugin-transform-react-jsx-source-7.27.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+        "sha512": "2620d2847e39cca1d6c867b864d551ac28c1cfc361f53326646d648784132bc8420535818bc0dafa2eecd5f270eff958a4ce1c71ea5235fab367f42f001062e6",
+        "dest-filename": "@babel__runtime-7.29.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+        "sha512": "600e8c6b62ac09d19bf960ba5290551491972f9f0c0c0ea8c8e35b8f217ffb9b0183163f7709212e881b313d865d7c94f38fc8851c3fd83d4eb3507f822cfe05",
+        "dest-filename": "@babel__template-7.28.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+        "sha512": "e073e242bd17efec1a1dfc973d9a563df58bfc9edd70dd66c7d80be9675054c6cf9c5dfe66148cb3cb42c4dee81dd74913d7e1344efe9717679727a629f251b8",
+        "dest-filename": "@babel__traverse-7.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+        "sha512": "2f07591e949c338433f17c3688a4b34be71f825673246be87d0202cbb5bbbf871aaeee046809b252e3ba046adbc90da6615d755b453c8f998185dd7875ddc1d0",
+        "dest-filename": "@babel__types-7.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@clack/core/-/core-0.4.1.tgz",
+        "sha512": "3f18628f851783c292afbacf7a4e99a309bee4cdb6adb7768359dfa231c9931a7962416a899dbe60b10cfd7195233bc639c3349ea8c8171ae90f05916585988c",
+        "dest-filename": "@clack__core-0.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.9.1.tgz",
+        "sha512": "248a7269ba1865e5989723f41fe3a83cfc5dea7aae786fc298dea2c4188d16c2031d111ebe321fd27d0e861e60af90bca440e49f382fcfea4827c74c8735887a",
+        "dest-filename": "@clack__prompts-0.9.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+        "sha512": "d1ca783ec590ffd6afa9354c0ad67e1a2ae2908037ea292f8ed1f0794e3f8fcc8bb6039b234f8950f858152720c25b5ebde181d6bb770a6f1484dd385dac838a",
+        "dest-filename": "@develar__schema-utils-2.6.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+        "sha512": "2e24aeb337bd4dceea174dec2c2ba3179899a7b2bebd13440c167ce854fd69002fdefc4c2e2854bcabe9b025a24360c9ab5b55724a292a6d6bc689a035473d86",
+        "dest-filename": "@discordjs__collection-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+        "sha512": "c3041d82379aa18162686f9ab5bab1e9a243a6a5bb247028d07ad09014db633337fcf2771b079022980494d706676e830943973326b061dd1817bbedafe7d95e",
+        "dest-filename": "@discordjs__rest-2.6.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+        "sha512": "dcb28fec5dbe6ad97dbc91616818e7e2739a4966a167fc968cebc0e1ee699d792ddaac974421cbc68050cbcd4616d2c60aaecaf653e6f51e75eccd54fbff7442",
+        "dest-filename": "@discordjs__util-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dword-design/dedent/-/dedent-0.7.0.tgz",
+        "sha512": "3859809b32a20d487d9bb59131872810e3c8edbe6d4b985da909ad283c05f99b2c549bfc6be187a3d54eb45b26970de1f11a21ffd43315622c8d2159c9050c76",
+        "dest-filename": "@dword-design__dedent-0.7.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dword-design/endent/-/endent-1.4.7.tgz",
+        "sha512": "c8ad62bc02ccabd132b3a3bd4a03be8c1a516d004baee14bd85bd63163dca2a898d613c31e5798d36562afa8cdea3eed0e2328837b6356da8a6f87965dd2a8d7",
+        "dest-filename": "@dword-design__endent-1.4.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dword-design/eslint-plugin-import-alias/-/eslint-plugin-import-alias-4.0.9.tgz",
+        "sha512": "19b0d9d0724e9cb81cf17da218cf925bfd98d998bca89f7afb3b0958ee2785f1261d228f702dcc52575514baeb1f2d73e51f8c11b6bab69ef8e795365180746d",
+        "dest-filename": "@dword-design__eslint-plugin-import-alias-4.0.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dword-design/functions/-/functions-5.0.27.tgz",
+        "sha512": "d7a03ded12ad9f6d712d623b63b561173e16096ba2f932e2b7f279fe5efb043a5698f8b62f38234330db69f0c3c3b394798e861008bf3388dd6ee421b086d212",
+        "dest-filename": "@dword-design__functions-5.0.27.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+        "sha512": "8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
+        "dest-filename": "@electron__asar-3.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/asar/-/asar-4.2.0.tgz",
+        "sha512": "9e95b5356e72cbc101f5763fbc4c3db147609aad2c2448664816fa6eac85380c3509292b86f02f3ba416956f02748328f15375964745df8e65fcc796d0bad8d1",
+        "dest-filename": "@electron__asar-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+        "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+        "dest-filename": "@electron__fuses-1.8.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+        "sha512": "424ce9836b3d1a7555d88d818d192c522e375397bafb369031c8e8272d02f82e68c5a2a5f9f99c9060d016d469669655d0d41e92e659fad1b3ec403d4d59d0b5",
+        "dest-filename": "@electron__get-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+        "sha512": "17e9ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409",
+        "dest-filename": "@electron__get-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+        "sha512": "8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8",
+        "dest-filename": "@electron__notarize-2.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+        "sha512": "299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
+        "dest-filename": "@electron__osx-sign-1.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.3.tgz",
+        "sha512": "bbdbe94c744c90e602b3fd452e249500567b15b8ec5caf9b42ecef88965afa51bb047665d67cf9dbf21c1afc1adec93cd3f7dcde596eb4191b0aad74561f1640",
+        "dest-filename": "@electron__rebuild-4.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+        "sha512": "5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
+        "dest-filename": "@electron__universal-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+        "sha512": "75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+        "dest-filename": "@electron__windows-sign-1.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+        "sha512": "caae8e909e29f360807cf974bbd99079b40728f26463b5ab22e936d3971362761efa4d99f18061d7516b6d11bf1fa8a18aba9c69c3a09760483bca323102de5f",
+        "dest-filename": "@emnapi__core-1.10.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+        "sha512": "7b0bd8964f3ac54a06234cd044dabf982fb5e91d5078394a432db52a2de84985cd80b6f8e465753fa03433efecea7c82b8d0ea7b9569698f380735c6c156f014",
+        "dest-filename": "@emnapi__runtime-1.10.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+        "sha512": "b93208ece605fbf31eb3f32b708398a79c8eb5230b056488a0b3e9720c22a6888a6e58ba937db6b5ca05b31a082313c3a96d35490180824a38133662d8136fdb",
+        "dest-filename": "@emnapi__wasi-threads-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+        "sha512": "d520e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+        "dest-filename": "@esbuild__aix-ppc64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+        "sha512": "1e19b077a0889d9dddc29b864c5f1f246eb2a169ac4e813ebd8803e27cad655c5cbb5ba51e9510440075509f3e375026dcccf8fb1381ca84284997f80fe0a990",
+        "dest-filename": "@esbuild__aix-ppc64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+        "sha512": "bc23efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+        "dest-filename": "@esbuild__android-arm-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+        "sha512": "549fac2af340fc613b09c69c73d0a16bb6e94bc9f2cd5bf48dd560c0d0da478803302ff64d345cdf7229f2aacd61472990e1d44f9399d1b51c34d55943d44b96",
+        "dest-filename": "@esbuild__android-arm-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+        "sha512": "734b97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+        "dest-filename": "@esbuild__android-arm64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+        "sha512": "e800262c6ef3c03d59d79f6308a3ef03165de32fd54ced15929ad8cbedcdd85b49f3e0505855d4f8ec40448c00e3a739b5d0fd4ac28667fd6872a052fe000a1e",
+        "dest-filename": "@esbuild__android-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+        "sha512": "0fb68f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+        "dest-filename": "@esbuild__android-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+        "sha512": "e636dbfb68610c7c79a61611d81cbc193584ce7e88f54a91d752b07f6da229b36962bb26441d7c697ffd8af73971a6dc522013ff033e60867a486f503ba6bc92",
+        "dest-filename": "@esbuild__android-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+        "sha512": "0f0a97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+        "dest-filename": "@esbuild__darwin-arm64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+        "sha512": "377ce5fa5c470a27e022570c50fe74d7a11291e4232e3ffde7d471c4d608b61220f82407227ba316e5de59b58c8274e8e1ca795d51ea14f9a9caef49eb90b562",
+        "dest-filename": "@esbuild__darwin-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+        "sha512": "b1efc98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+        "dest-filename": "@esbuild__darwin-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+        "sha512": "1d0f646b82b1db5a875f0b654d455b2893809e61b58a95e17564e635788fccf7d62a95ea01255c59d9dfd9b9cbef7c208cdac55c06b7c98bc149df69cdf108a4",
+        "dest-filename": "@esbuild__darwin-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+        "sha512": "e49711c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+        "dest-filename": "@esbuild__freebsd-arm64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+        "sha512": "800d01c7be7dfbb26f7b4dcad52d2f90ebb92e0ffce5da2edc4b1e38651eb3c7e554e1b16e10c387f8996a87a4d7563c9adc8a3c6177bcff178679031009b37a",
+        "dest-filename": "@esbuild__freebsd-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+        "sha512": "27de643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+        "dest-filename": "@esbuild__freebsd-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+        "sha512": "4c66cedba630db1b07cf1b5b5451845c1147d054403fb82d70f13b3f9c8fef01b2edc5cada83bb4723a12f934b8aa4e5061e3b5e1988517b867225c4a9815f05",
+        "dest-filename": "@esbuild__freebsd-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+        "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+        "dest-filename": "@esbuild__linux-arm-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+        "sha512": "94f0c6c82d493c3a2ef2419ccb06346082f35a58619d18dda1fdd495ca2a6264bd125f35f0b2df2497373d75e0647ac70802acfd9d92799b4326be4cae4c6d3b",
+        "dest-filename": "@esbuild__linux-arm-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+        "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+        "dest-filename": "@esbuild__linux-arm64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+        "sha512": "f1bc17edaf05821220aeea5cc5be1a5266032e9f295f4eab1a1e47a834fb6c1fbc45d7a596cea61efac51c75b624038f6546e78d4a4a4cb83a102cb3bdab3601",
+        "dest-filename": "@esbuild__linux-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+        "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+        "dest-filename": "@esbuild__linux-ia32-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+        "sha512": "d32f4aadd5676cc336fef1bc29f5346f285437e1050a7cbdfbc836d36818a924953289dbb027cb8d43beac2722ee933458112dcfea0afcf2301e4cf193285aac",
+        "dest-filename": "@esbuild__linux-ia32-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+        "sha512": "b877f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+        "dest-filename": "@esbuild__linux-loong64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+        "sha512": "87ffff2ebe5af6b89bfefd461aa5d51b38cbe1332f553bfeb350cfa3141dcfb97f018bfa2c34b1748c33c64acf5b8dfca145e20edc0cd74a3d3e6c12ffa67436",
+        "dest-filename": "@esbuild__linux-loong64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+        "sha512": "21a8ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+        "dest-filename": "@esbuild__linux-mips64el-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+        "sha512": "8b246b3353f3cbd1853032ec5e7d621d49b5f2784a9cd316b1c8e6a78fa1a5a7dc663aebd966d3fff776d316869635c30581ea45c97c1e7c5b5fab9a03f78657",
+        "dest-filename": "@esbuild__linux-mips64el-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+        "sha512": "d611d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+        "dest-filename": "@esbuild__linux-ppc64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+        "sha512": "f6678cfe5457c4c8b93d252a117442b558c46411b007b3ff0f8c93f141bf9b021dcded9a578568e94e600f7f91b281d72a41c27d2c592b3983b2c565463d5040",
+        "dest-filename": "@esbuild__linux-ppc64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+        "sha512": "d877570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+        "dest-filename": "@esbuild__linux-riscv64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+        "sha512": "66beca478860294a560306f57f7a39ca04f4e0ccea56b18419718b9e3d796100c912b62efc11a0fb09859480ce749a743e607494bbf1148397660151add8d1d3",
+        "dest-filename": "@esbuild__linux-riscv64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+        "sha512": "ceeb39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+        "dest-filename": "@esbuild__linux-s390x-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+        "sha512": "32c2a770e7204cdbddb6221273f8d9b3f65ff1dd1c97fb77818597f09f6e6c19d53b0964eb9508104be004e4538a58e5a085a70732ece2a8733e425c8ad23322",
+        "dest-filename": "@esbuild__linux-s390x-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+        "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+        "dest-filename": "@esbuild__linux-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+        "sha512": "baa64c4cbaffcd1fde7788c81a7c122e468798f8ce8c9be79ba4d5562b406b4f122d2f59d1533cc08471ee059b241e7f279e18b883089c3aae5b262f40b66483",
+        "dest-filename": "@esbuild__linux-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+        "sha512": "c57c1c4eae0685133b27d03c1afe5ba1a9c78516bf43d28b5667325c709368ce3029f2295a475788ca20fcab27c73274035fa70fece879cbb3a8f9824720468e",
+        "dest-filename": "@esbuild__netbsd-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+        "sha512": "5a88b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+        "dest-filename": "@esbuild__netbsd-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+        "sha512": "2dde694e5ccfcb763019e7383ae1e1d5a095091bce5dd1fc0e04637c3cbfa2e995a2f9ae4b359f9d2260f95b5a901f429b483134ef41cd6923ea6b4ed4531791",
+        "dest-filename": "@esbuild__netbsd-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+        "sha512": "7c5f7a4fa2ac068fe991023de74140454f5aa463534a5646b2fd6364102570b2f530b8cb34858f0648f93654b3f1a03360a83e78daa49eb509db8401c9b791e4",
+        "dest-filename": "@esbuild__openbsd-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+        "sha512": "1cb34dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+        "dest-filename": "@esbuild__openbsd-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+        "sha512": "319c975246478d0c54bf32bbacdf032774919ab56b91ef19c91bac1e53fe92ec2a4dc7d62f2a8c384dec49c3cfc9e21737f9832487c65ef70ca8281829e92843",
+        "dest-filename": "@esbuild__openbsd-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+        "sha512": "ae6d185aca94491ae39dc497180ed9bfbf0d6e7c385cbebf773af6d1ccab41fed999172ca2fa5c4417610f8dcdba4df2ed72285b63b1315bf0b91be4f577404a",
+        "dest-filename": "@esbuild__openharmony-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+        "sha512": "ebe823985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+        "dest-filename": "@esbuild__sunos-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+        "sha512": "df0192083cae4c7414cedd2757b6e8703cbbdabda5237dd02f78240cd1a4a1ddb612c625d38b0c7f4a8b6fc96e34a4ce9a017f7831033f9045370a01287e38d7",
+        "dest-filename": "@esbuild__sunos-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+        "sha512": "67480e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+        "dest-filename": "@esbuild__win32-arm64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+        "sha512": "acc98baeeafae00efe0ca9674aec2a51d44ac9ddd413ba0f2599a7963a84a6d7ac28cf30c7d27c831e6ed3ef4fab47d0416f2fa9e29e6f035775f3b23fef01b2",
+        "dest-filename": "@esbuild__win32-arm64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+        "sha512": "4965c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+        "dest-filename": "@esbuild__win32-ia32-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+        "sha512": "1e4aa79a606809b0b0c5428a34f062c62583182a50195b2b41f26854660b3d3e355d617c947b84e4de9685589ada7e28e502b9338b58af6d7cdbb7cd862e1bc9",
+        "dest-filename": "@esbuild__win32-ia32-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+        "sha512": "b5077fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+        "dest-filename": "@esbuild__win32-x64-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+        "sha512": "6a5242d2e099a5316b48bd020838dc8257815cf9c2ac40214c120ba5e029eccfce160a2ab407ad7c1cd7d31334d0c52c5553e956394fb8c6d112a9d90976939c",
+        "dest-filename": "@esbuild__win32-x64-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+        "sha512": "a61ad898d898a6947bce714476a81f5875d1e8d0a46442bb8705831d95238adff6fd4d2be97be40e5d12627a0ce751eaec584219d2c34facf1082398d617b1b1",
+        "dest-filename": "@eslint-community__eslint-utils-4.9.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+        "sha512": "12b8924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b",
+        "dest-filename": "@eslint-community__regexpp-4.12.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+        "sha512": "9c99762864e5adff468cb8a6808aeef95fe6ce048ad000420d046fc70e418d444bed67c7e6ea169a2cdb1fb401e8c9a730177c7080bdb9c7969deccbd556565b",
+        "dest-filename": "@eslint__config-array-0.21.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+        "sha512": "801af137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483",
+        "dest-filename": "@eslint__config-helpers-0.4.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+        "sha512": "c8bfec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5",
+        "dest-filename": "@eslint__core-0.17.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+        "sha512": "e08949c745f4a9fb55b0de44fbfbc6ba34d1205b70b8b6cdb1551eed33bacd83c34753ba9c5c2fc2120a10a4ab97a7597219980484dacf12a85183a376d8e546",
+        "dest-filename": "@eslint__eslintrc-3.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+        "sha512": "9c4ec3108721bed8854f0070e0b7dbbb9f4f1be902a1f863b0a6825b3c53a6de257d18d132a1bab8c073297b847325e1387a14a7dae2026eff69660685767d73",
+        "dest-filename": "@eslint__js-9.39.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+        "sha512": "56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+        "dest-filename": "@eslint__object-schema-2.1.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+        "sha512": "e37feab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c",
+        "dest-filename": "@eslint__plugin-kit-0.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+        "sha512": "e406a9fc6691ba980dc7f7de181c0b2d356ff0e4057efde9ab694f4733e0f51f883819c3820853196ee5ec4b955cebe0e5c73fc52025456f2b06b8c80b736fab",
+        "dest-filename": "@exodus__schemasafe-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@fluent/bundle/-/bundle-0.18.0.tgz",
+        "sha512": "f167f0bbdabc17d83614d9eff3683a0a1fc4d405b5c30963b143a8947e4d12d74976fd2c653b96bdf08cedcded781f5dccd68903cae7e2486989da68cc759810",
+        "dest-filename": "@fluent__bundle-0.18.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@fluent/react/-/react-0.15.2.tgz",
+        "sha512": "336925a974d42530fca365439babc45c0a44fe949cd7a62d07b0d267f43c70f605eb71600e4beab952c78f3cc6d4fbeb2bd26528928fce5df027b85302a48ae3",
+        "dest-filename": "@fluent__react-0.15.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@fluent/sequence/-/sequence-0.8.0.tgz",
+        "sha512": "795e5094411557fc11dc01502d73baef1e323d13d05f2aa47b473ccae732312796dfa07779c672545958d54a6bceb7c557c88f241e1301e843cbf74b19bbd0d5",
+        "dest-filename": "@fluent__sequence-0.8.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@fontsource/poppins/-/poppins-5.2.7.tgz",
+        "sha512": "eae4323e6b1ea3816023ded6221038c9646535aa0b938bd20cafcfc91c1daaa65be73004b9cf8aba7b7c25331cb07614106601b4dd7948d90c6a331da944949a",
+        "dest-filename": "@fontsource__poppins-5.2.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz",
+        "sha512": "93f30406cb5f7f8b2db688721295f10a60b732a6d49fd56f1c6959f1f6ae2f391bc17995ac47b2cd2fb8ba1aef024f43594f7fee8b585b1c83a31e274ff2952d",
+        "dest-filename": "@formatjs__intl-localematcher-0.2.32.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+        "sha512": "efd0effb798317b8bed9a8e3ed2932a52287865d5c6e59f53866afaabb05ee9ea66d4bf5d71a6aa5a70fb060c24d1bc24a310421ecf679fd4dbde4952f76f402",
+        "dest-filename": "@hookform__resolvers-3.10.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+        "sha512": "e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50",
+        "dest-filename": "@humanfs__core-0.19.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+        "sha512": "ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711",
+        "dest-filename": "@humanfs__node-0.16.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+        "sha512": "6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c",
+        "dest-filename": "@humanwhocodes__module-importer-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+        "sha512": "6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+        "dest-filename": "@humanwhocodes__retry-0.4.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+        "sha512": "3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10",
+        "dest-filename": "@isaacs__cliui-8.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+        "sha512": "c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3",
+        "dest-filename": "@isaacs__fs-minipass-4.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+        "sha512": "da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c",
+        "dest-filename": "@jridgewell__gen-mapping-0.3.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+        "sha512": "2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711",
+        "dest-filename": "@jridgewell__remapping-2.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+        "sha512": "6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
+        "dest-filename": "@jridgewell__resolve-uri-3.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+        "sha512": "71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
+        "dest-filename": "@jridgewell__sourcemap-codec-1.5.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+        "sha512": "cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03",
+        "dest-filename": "@jridgewell__trace-mapping-0.3.31.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+        "sha512": "d43a4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16",
+        "dest-filename": "@malept__cross-spawn-promise-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+        "sha512": "f503ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
+        "dest-filename": "@malept__flatpak-bundler-0.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@mgit-at/typescript-flatbuffers-codegen/-/typescript-flatbuffers-codegen-0.1.3.tgz",
+        "sha512": "b1ff6f6a8891fd2474769579ebc1a1b282db77aeb9f52b49e0697d8eccd92ff6ec249685e5598b61b239ece488e090e6f8be9dde8b15325f6691c868c7d8fafe",
+        "dest-filename": "@mgit-at__typescript-flatbuffers-codegen-0.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+        "sha512": "65559471fc18e04ff23e2b50265e3cd458c5a372b6d83eaa1740ee147e98fe76e7135d46639ba0b83c593065cf43c590d35dbc317403ed39df1f22b8a16a0825",
+        "dest-filename": "@napi-rs__wasm-runtime-0.2.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+        "sha512": "beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada",
+        "dest-filename": "@nodelib__fs.scandir-2.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+        "sha512": "46484f3e9db3aea0c0400ff68cd867ced70f025bfae17761229edaef8e78039a2f23b06e93182decc5fbb9dc00bb7ce0d437293d4d2bcf7555d5279aaaf638f8",
+        "dest-filename": "@nodelib__fs.stat-2.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+        "sha512": "a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
+        "dest-filename": "@nodelib__fs.walk-1.2.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+        "sha512": "9e7e68cdd8d8429502665586bb170963f2a9c64590b380dc6cc0a62a88e3cab6031001b2e027b5f4d378bf931db9a7d3c0995b29cf7d500f1885256aabdc8f64",
+        "dest-filename": "@nolyfill__is-core-module-1.0.39.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+        "sha512": "4bbf4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5",
+        "dest-filename": "@npmcli__agent-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+        "sha512": "ff11a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1",
+        "dest-filename": "@npmcli__fs-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+        "sha512": "3a560e95922c7c45599b91c2491f1a4a0d364f695b5163ac090a0f29f4d72700f3707401ad50467465dbf3d76fd8ac364e865a46db9da7c3b764862868e8ca94",
+        "dest-filename": "@octokit__endpoint-10.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+        "sha512": "89db0882035750a924d3e044c549f5750f76b1fcac26b8ded374346efd1ef8a3cbaefcaa645f0c9c1a45cfc50d7d80f007721eed9d130728d67f3c6deefb1e68",
+        "dest-filename": "@octokit__openapi-types-25.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+        "sha512": "5848bf474266abe2092b275694a0e6af23dc99d6125632f77a46a210bd4bf5ea35b149ea309fa0aea982f5c8e4ec203bf9bdbf4f7f7bb4ee5df182ce1f7a98a5",
+        "dest-filename": "@octokit__request-error-6.1.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+        "sha512": "abcc9b772b419b16ba2a881694d6bcd7caf4935c25ab3342fb23647100c4087bd0a3c566b2dae0d7c270a891dd25d5221c3dac8e5c018129bd90790e29eda2c8",
+        "dest-filename": "@octokit__request-9.2.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+        "sha512": "d72e83813cbc26899ca6edf737ea79c39f25eb1cade7902bd88f7544f888034c422415f250085709c99968359200d8a16bb47d6baa89276091a2618f67a7f8ea",
+        "dest-filename": "@octokit__types-14.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@openapi-codegen/cli/-/cli-3.1.0.tgz",
+        "sha512": "c3d38efb7ac529690074a7e39e3060e698ac040297b5901b0cf353bb8e9571def2247d49b0c1fd483a3244ddaf3196484788abd692cc9fc3a89bd933b93005ad",
+        "dest-filename": "@openapi-codegen__cli-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@openapi-codegen/typescript/-/typescript-8.1.1.tgz",
+        "sha512": "2869c5ca841ce2586d555bd7ea59366ed17d1830d46eef09be7e42f3d687bb2200e27a2bfd196dedfed01da62979c1435fc459acf7181ab0d9f0e14d52410e94",
+        "dest-filename": "@openapi-codegen__typescript-8.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+        "sha512": "610c524b7e2d3c5ffa646eebfc887dc72fa43ff5b079d88452caa6b5fd1cb825794cf3cac3f3d01d186e794a3a25d78525aa95de9ca39b419d623668b5b46dfc",
+        "dest-filename": "@parcel__watcher-android-arm64-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+        "sha512": "67665dae7c325efbef76d4472e6338927c9d21d53d69d3b70f89ffd1c562a45deb462c0ffb7fec7f3a40c00fea2852fa8b532875a69b914ec86e978c06089510",
+        "dest-filename": "@parcel__watcher-darwin-arm64-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+        "sha512": "1e0bce7f75bd7618ad85cc0e597f6e0d9ca7d655bd47eeed3d9e2cba0f8d1ab188a38464d610172c46dc1f54d04aac6db343585d794e5aa569bd2d52152e1f46",
+        "dest-filename": "@parcel__watcher-darwin-x64-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+        "sha512": "bc9562f3277fab327110a1e479e9a1ef0dd8027e91242b58944e073cca159c2a485c4cd2af112b056e5224180a2db5d4dd6748a648c14de50db720559fc4d19e",
+        "dest-filename": "@parcel__watcher-freebsd-x64-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+        "sha512": "f498987c1ea1e81815e740827dab1f2dffeebce709b24312c1c747d4f1c7f6bbd2d48acdcbccda77a21454f5547e65ebfaef8a9bd23171f30bce074eb9dcfd11",
+        "dest-filename": "@parcel__watcher-linux-arm-glibc-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+        "sha512": "55ede05021b9ee7b94512ca306afcc00cd02cc0aedb883b1b01750f9fb73ea1a3c9fbb358bd13536693fc663f7db7af660bd1238db3512ec2a069daed64e5fc6",
+        "dest-filename": "@parcel__watcher-linux-arm-musl-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+        "sha512": "7f683f0d3dcd8463dd066316628c62c6a62bdeffd45dc98b398cb5e81c744ccdb44dc85dbb0af811a09b9b1875df6d53001a8f183a52f03fe080e4da9638a338",
+        "dest-filename": "@parcel__watcher-linux-arm64-glibc-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+        "sha512": "a9bea768c0c695b0b07612e3ea182854a265da874bdf8cf6b2a902ed9ea4ce2afc6f95bae56603a4b07a474e8a69bbd9760a0723fcf191ee1bdf3474c006c34c",
+        "dest-filename": "@parcel__watcher-linux-arm64-musl-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+        "sha512": "91b4f9c2f350971ecd6868f33c5bbc9d5216d6b5aa57bf343bb66d923b9668f520a6fd8d305a636044558b45188f59ac64dc82cc695a09612dcdcf9ec633066d",
+        "dest-filename": "@parcel__watcher-linux-x64-glibc-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+        "sha512": "d49445782fa1ed1757c25747cd3b2676d611fcabbc4b294b81353fade32ea9d543ec2b4bc1fd1547516a7a9ad9d1e1d090ed2faac6ef14b5d49989bfb8d28906",
+        "dest-filename": "@parcel__watcher-linux-x64-musl-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+        "sha512": "dee93279b8dce9e1a5c3dc91b7aefc0f1545eeb8d76ad5a21ef4d7aa98592efa3b682e4d744805b9f5708c57d8e758a36045a95dba85e63b6b2b6ef9cf9d83e1",
+        "dest-filename": "@parcel__watcher-win32-arm64-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+        "sha512": "937e722e9d59330c1e7b7133fe9c418b971fe00a012985e3d34099f348d4cf987ca6ba62690b2244f290331a0bb2d36ea9edaf47844d3c4004723105ce1133fe",
+        "dest-filename": "@parcel__watcher-win32-ia32-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+        "sha512": "85b42561c0aae5d9405fd431fa415bd051ee7babdb8e57f416b37348a7582b600f51feed19f1b14029368a11111266d1e9931cd0c5400f94485ffe358295334f",
+        "dest-filename": "@parcel__watcher-win32-x64-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+        "sha512": "b66999de543101efe4ffeacd9d74116b0278363c4eda1aa238b4c7bd6721b466542e9e11c857a1e9a5385dd3980457b6284d684a1413bf801b94eb3688eacd9d",
+        "dest-filename": "@parcel__watcher-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+        "sha512": "93610d9e606e804febcd07c471d58770263efc533754bcc7f5c604b1b76ca2aaefcc029185465e44d84066f07c3a2b502754c179ddf2a96b5d8f34bac09281c2",
+        "dest-filename": "@pinojs__redact-0.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+        "sha512": "fb55648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e",
+        "dest-filename": "@pkgjs__parseargs-0.11.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@react-hookz/deep-equal/-/deep-equal-3.0.4.tgz",
+        "sha512": "4297125133f5234948f3f1af484bdc964a041915a36d8c6e51669e731afc78945c7a2bc6175f301e827069e8f6358c4c9fb4aa84a699f49610be67404e2486f0",
+        "dest-filename": "@react-hookz__deep-equal-3.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+        "sha512": "21cea6d94feb3234e48444486bfd19b5724fd7b4148b609b584edcab1e09e7c33c680dd04df5bed94950e29b2f4d7f483b545f35584ade97297637a3ecbfaddb",
+        "dest-filename": "@remix-run__router-1.23.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+        "sha512": "f9dd05e0c28c09b795509c06f7ab90e12800ce764d4aaf7723757ef4d1c0e0ea6fa86f26442a4674a98af25fdd974da1d820831f05b616a8a59d3c837009ea8c",
+        "dest-filename": "@rolldown__pluginutils-1.0.0-beta.27.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+        "sha512": "77a1629c404b74888afb5b80094b6d24a7e0651117ac5d107364a62c823b5b6003f057e267d5a377eac3fe246e7f9b39756aebd468305c2bcfa8eb83aae3a8c0",
+        "dest-filename": "@rollup__rollup-android-arm-eabi-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+        "sha512": "6231bf130203bef608d58bd86c7bc3cff0581ed918e328142171e74dd2e11be84a2101418a8b1f5a20025a8aedb0a3ca53ff9d53041008a40cdeaac37bc73d04",
+        "dest-filename": "@rollup__rollup-android-arm64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+        "sha512": "9a30a917b1a6911b52270a27f91ab537cfa923ef25ef0e60f59def5a3e13eda6e0b82e02cf08b762efe915a2ef0374d378c5639eeddcb6282eb2a5947e3673bf",
+        "dest-filename": "@rollup__rollup-darwin-arm64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+        "sha512": "85a67b849d494f87bd86a9284fd47fd7d5d6d902aa8df255bfe8b9006839ed2fa72e4f6542727517f79996844ede8f52732f42337c10f65f9d917b5c06037913",
+        "dest-filename": "@rollup__rollup-darwin-x64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+        "sha512": "733c3dd30a50ab766c0150658a76630184ca76e3a34f2c251bb7c479629403ba029a903cc5d4e4c59665c0d24a5aa20b96ad307a1a1970961f06f3b284f4d0eb",
+        "dest-filename": "@rollup__rollup-freebsd-arm64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+        "sha512": "295076aeab314c7b81b5f39ec92132cc4381ee5b6507fbb1dfc8aedab050ce48dbc115659210062040e28989ceda414e909a7e67ba545cacab45116e1542adfa",
+        "dest-filename": "@rollup__rollup-freebsd-x64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+        "sha512": "2fedf842a8a5fafe6e0b4cc4b9b5bbb81ca8efc58e088ac1bdc8baf44eec1404919745fb6ff301e82a9dd65932fc2b5c4954f27566b6599c05b967b18d2e68ea",
+        "dest-filename": "@rollup__rollup-linux-arm-gnueabihf-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+        "sha512": "9fcdcef2bb78bf7e21805ce591bd7272788987b211e51088aadea6cf5551243ea99a1462d025dd99f9cbbbd748512e9bbb387ad08bc008cf38d857dbdf177a1a",
+        "dest-filename": "@rollup__rollup-linux-arm-musleabihf-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+        "sha512": "36a97bb13780ce14c08dadd05de008e3cfbff868c127e426007d77b279f400948d2f9d09b03aa8b72b9d1f231b3b645b264b246cc6c525f20929603a4752c225",
+        "dest-filename": "@rollup__rollup-linux-arm64-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+        "sha512": "fa953298385dd32b3d19c2993cf5a516267aeec4d6579514eb33896add36335f8f8ae4860f38b246e23fa4fb9ede1a14c26dae19fc5d2feb6b4fa67daf19e530",
+        "dest-filename": "@rollup__rollup-linux-arm64-musl-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+        "sha512": "552be0bd078872c12f6386ca0c710359ca56e18c3b06d94a1b51944f81730549442902b4ad61d806a42de859b6b5a5d2fb56d7bc94fa9080aee59c2a2829ef95",
+        "dest-filename": "@rollup__rollup-linux-loong64-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+        "sha512": "e0baa1528989ab07bae3582c3e9eb12df86a58c6d0574e0ab4fa7bfdd229d27ccfc4090d63501bc0be56d0c42971a94b624d3bbda5bd2a9d4f06176965861c13",
+        "dest-filename": "@rollup__rollup-linux-loong64-musl-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+        "sha512": "b4b410f5a3ef901c4e73f1144fa8f7a7278c0fa1dbf1017605306709058ffeebb596173d008ac88ca9cb60c12ba08cff26fb4662023d745dc0c4764d6841f4af",
+        "dest-filename": "@rollup__rollup-linux-ppc64-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+        "sha512": "44cc45849c1cf5f4973fa3ea980cf871bbf7900caf0f57ad2458d3c7838da853fd0e44e45ec00c538bf7572739060cc2f9a9f3ee74bff6da78a1bb0a7ea9031e",
+        "dest-filename": "@rollup__rollup-linux-ppc64-musl-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+        "sha512": "40a80597e61cd5e124e8c98e05f447605ea54f18a2895dffcff051adb4a25b623b0054d7a0116f74c132825a213e3fffda6652e210cea9e0741f5002877b016e",
+        "dest-filename": "@rollup__rollup-linux-riscv64-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+        "sha512": "4408d78cfffc73a66dcdab59700d51690afa3b54d18730be69d9fc6190e70a1962647be2a888e6bc5c077318b824a3d20c0b7a5217ffeefa9c073409cb43c326",
+        "dest-filename": "@rollup__rollup-linux-riscv64-musl-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+        "sha512": "c1cba872968e95a2f508e058880f3d3bac9f8e5a77470283793200d2133b3a99a1475063a3d8f7d46d6e415a43953bf0c469f69d0b3ae5f0452f950577be8571",
+        "dest-filename": "@rollup__rollup-linux-s390x-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+        "sha512": "efb3e9b0541408e89947df8b404160f460a5c9f90d5e3d4c3fac119f362cd047966cf707b34d805eee31b946ccd738709f7c2a6a2ce57b7004620e5a7a8a2186",
+        "dest-filename": "@rollup__rollup-linux-x64-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+        "sha512": "e5c2004db939bf29c08eaaa6c818e5722309975f91fc2c17f682e4fc4ca21570d677de4aa4776b3894fffeb9d497871472c92b7748c20b0df0a599e1207743f7",
+        "dest-filename": "@rollup__rollup-linux-x64-musl-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+        "sha512": "725d30d3d5ac0a2d7b99c996aaa8257b3f4693c8ac81e5afa146775a2245612477ce3050736279fe28528e997e54b8cfaa343fd6125172a05f2e3b2c4444082f",
+        "dest-filename": "@rollup__rollup-openbsd-x64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+        "sha512": "e02bf6dd9ace3516cdb5b65adfb98b4ae797502b4decc5dc70286d2a952740d805d35d2b8eb8df1f1dd0c644b63c8ecba864f9c57c98b356bb2dbcc0c13d2208",
+        "dest-filename": "@rollup__rollup-openharmony-arm64-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+        "sha512": "8b5a24598900e052480adafb2a96331694531e0cb98dd0db66259fbe7cb6d6220a932e581318835cffb36d7ce6ddd51c169904798347810e5fb86db7e893ead2",
+        "dest-filename": "@rollup__rollup-win32-arm64-msvc-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+        "sha512": "bb4f66dc2bb02f34a103411828c3621607238f3c2ab5430b9ae0892de6568e3398037213d838b4f4a6b11814cff71573b56c885a355db01d84f60a0c8d9bd342",
+        "dest-filename": "@rollup__rollup-win32-ia32-msvc-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+        "sha512": "93eeb4d15f5997508cede6712603324d4ce6ae6841ff45d99c5e29472a4a025020c6679d500fb5bfd47e5ce16fe7a5b84a51c4cdf78cb73ba32c90f6d94cf9ce",
+        "dest-filename": "@rollup__rollup-win32-x64-gnu-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+        "sha512": "9563278b1abf433c7285357a363409e12168d49e8fbce5fcbd4c7959be1b04fb046fef3167cf41cfa90e5e97d78fd6a4f401d3415433960cc111cd52c8cdbbc5",
+        "dest-filename": "@rollup__rollup-win32-x64-msvc-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+        "sha512": "cede8e76a683a0e9c9d5962c0981adf58996cc35e5e2f41d293c897afeb680585118a771ee6713e7857d2888e0f9ddb08bd117b0fbc03ca7bb8bb5a37d5581f2",
+        "dest-filename": "@rtsao__scc-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@ryuziii/discord-rpc/-/discord-rpc-1.0.1-rc.1.tgz",
+        "sha512": "abd62053c463f53a352d6ce8e2ef1c5ce1d4a2b124079299e5c756f342a862d014c7e9d0cbbc18084162361f24726a85a90f26dc5b31d485f1dd4a55ca691a4b",
+        "dest-filename": "@ryuziii__discord-rpc-1.0.1-rc.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+        "sha512": "72f1b3c5b6daeac6afdb36641fc18f7f6a0693dc98a03e6aacd59dbbd7d17a189f82715924c57e9eecb69ce376ae844ee32410fafecc2bf3e4b65fc781fb145e",
+        "dest-filename": "@sapphire__async-queue-1.5.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+        "sha512": "c73bc1af54357389427bb8bab119eba1fc5e3b54133ff2ca43a03aab2d22078c79c9f8927c044c1101208688f34cd00b0d372ff049f4e2a60d21ca3dfcaf5e65",
+        "dest-filename": "@sapphire__snowflake-3.5.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.29.0.tgz",
+        "sha512": "33793270c63a7f7298f5af230d869cfb21b4137660595592c653840b93216325fe83b9aac64c2b6f72c5432bb14a6fe6f820a031309a3ce39a076b705cfe8442",
+        "dest-filename": "@sentry-internal__browser-utils-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.29.0.tgz",
+        "sha512": "63b211b0d792f7d70438dbb59995997371ef6e3367bb9f478329a6d2cc0514a6dd81b0a0753ea5f39927da82ecbaae04c3c0f0fe92ff4a0a70b25f5481816952",
+        "dest-filename": "@sentry-internal__feedback-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.29.0.tgz",
+        "sha512": "b72a58e09ae90104063ee4b277f043f3e9cd09bbd3576515bcacebfa22a02349b5a9ce03cfcb4767835f6a2b3667c7989ffa4bd64a9540de44453989a1815d23",
+        "dest-filename": "@sentry-internal__replay-canvas-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.29.0.tgz",
+        "sha512": "e39355c3d3f007d4d0f33fb127a1ba65afb0990d514c0df985e052cd1e94e1b9278fc2e6034e24da2c27a1bbf10811105de2df70910ed6f1606a0328a8c64c07",
+        "dest-filename": "@sentry-internal__replay-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.23.1.tgz",
+        "sha512": "975cfc02f23a93d23edb3e3d3a0bcfdd29730753342f0db82ad71e88989b35a4b2430c6c22da13f7f5dfb59ffc041b64a2c56634e4d084bd5e52c4a4b92bf52c",
+        "dest-filename": "@sentry__babel-plugin-component-annotate-2.23.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/browser/-/browser-10.29.0.tgz",
+        "sha512": "5dd6f2211e85e2aa11f59d490964e0ba755c4c98d2f69d9387ebf8c18b38304f9974b0b8b6e28a99181883761d4885829f50817c881d23ac2a11349fec7e8d8f",
+        "dest-filename": "@sentry__browser-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.23.1.tgz",
+        "sha512": "240eaeb4d8b030abfa25f8f41e69340c8fd7522cd21e0ec78619051132a146560485901d932cf56ad0c18349dc28d81104ac8779261670c16d532a36e9507beb",
+        "dest-filename": "@sentry__bundler-plugin-core-2.23.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.39.1.tgz",
+        "sha512": "922346352024838e8b3466ad7cd1f9b5fb2623f90201a3c0eb6290b85665a1989e993373872f7fe8d24ff0767f1b11acf060ccc6273ac0dad5f4291512014b25",
+        "dest-filename": "@sentry__cli-darwin-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.39.1.tgz",
+        "sha512": "0e410d6f1c91c54adf2e724b5d3038b3950bfc6a1cb54e429b8111d5e07b5cdee9f56b1a98525dff27f62a996d923132893ba996fd3201b763975297def2a611",
+        "dest-filename": "@sentry__cli-linux-arm-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.39.1.tgz",
+        "sha512": "e556d52436ada250eb58e81a7dfb0433bce78ecd1c47c6c7b7d06ad264ad337b41a258007920c713cf4d8078207d947e0c9d9558ecb8be00b090e6eb503e8d43",
+        "dest-filename": "@sentry__cli-linux-arm64-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.39.1.tgz",
+        "sha512": "a57595a0a5c246b63b37cbdcf47ee6113895f590b3fb34a75fae49402cd9c6062b6b240f25373e34f467653758764e51940ba95da1627012361b038246a55192",
+        "dest-filename": "@sentry__cli-linux-i686-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.39.1.tgz",
+        "sha512": "2306b2359cbe8adec5586e0cf4b6b2c94986d5affc913f7efc8126ebbb13e7eedd90c20c7299870ea2fcad670fa23397b9329a38106391574d3014d7cb499794",
+        "dest-filename": "@sentry__cli-linux-x64-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.39.1.tgz",
+        "sha512": "360967368a874a613e0f3ff01de2154675766cb331eed227dc843cbd718ee47580d9ff336091a4b5b90bab52e0db73da4267992cf1a58dade00507d96121b5d1",
+        "dest-filename": "@sentry__cli-win32-i686-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.39.1.tgz",
+        "sha512": "c6fd11d8231ffd7d45b5eddc31689ed4d5ee1e653240f0c17c2c88b7a93a44f14fc4061481caa030fce763054cc16100d56e373da3a44a7dddf19ca5b036844f",
+        "dest-filename": "@sentry__cli-win32-x64-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/cli/-/cli-2.39.1.tgz",
+        "sha512": "2486f77bdbe1d3e3a64342b199ec4c5e0f6866c47f1bb1ccc31b7905420a01767d9b5ed7965e044d74d19d15014f7b1fec4a4d1809a5424d7112654df6961961",
+        "dest-filename": "@sentry__cli-2.39.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/core/-/core-10.29.0.tgz",
+        "sha512": "a254360d4f5d03f070b33dcfb40f4a35744ca8159141290fc3e331c161285352b5aad88cf4bd23ea56c415be62498ddded6603e4c07ed5de423ae823481ac7b7",
+        "dest-filename": "@sentry__core-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/react/-/react-10.29.0.tgz",
+        "sha512": "606684517b9bce297baacb03d64a21d5fcadd1a4bcb4707ad7febea0d4a127ac593e0d37001e366cd32bdbfcbc7c8171dfa91bdcc882039b05a07fee6c5d0b9d",
+        "dest-filename": "@sentry__react-10.29.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-2.23.1.tgz",
+        "sha512": "6afb63b48434d7db195b716496998d36c40e9d8663087a6757180318495f65bf80691e00bed1cd9715cb269fa2a847d22be5e893c3096ab26a22009a59c178d1",
+        "dest-filename": "@sentry__vite-plugin-2.23.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+        "sha512": "b74f6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03",
+        "dest-filename": "@sindresorhus__is-4.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+        "sha512": "4d5eedf062986895ac9f4d2d143a81c3cf94aa6afc0347d1535b6f4d08726731afd2c24219140bdc918c237b9cb8aa375c865d50ff8bc7bfe0876b7795ec32ee",
+        "dest-filename": "@sindresorhus__is-5.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+        "sha512": "9cf2b9d991efa2df09bbfd00e2e7125f575c3d5dbfd5c971d242dc1f9c039ab1389da2aca3b4d40bfbe85325353bd393293ad1e8c622a7a2cfd28804310f633d",
+        "dest-filename": "@stylistic__eslint-plugin-5.10.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
+        "sha512": "3a670ff7a085b0d3b06bae6d6a641ac9171faa1365710dd80963aafb459bf8200ce2e07b90e32b5d8e351a3e1ab6d871ac684b43da60ed5936ea20296fcf2274",
+        "dest-filename": "@swc__core-darwin-arm64-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.26.tgz",
+        "sha512": "9624d34e9292bfcf62bc8c5c67e894d5c46281ef58ec990e8d59c9d98b2dce5f83b16347aadef02d34e09bfbbb804aa69804b624aaf23832d09f7ab552d14d3d",
+        "dest-filename": "@swc__core-darwin-x64-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.26.tgz",
+        "sha512": "63f83e9b723c09e0687f903791658e4ba400d87388532b45e4479381fc1c00af86293fed19eed7aa8e6cbc1b5aa9f954e68776cf36cc4d6aa48a73d781158680",
+        "dest-filename": "@swc__core-linux-arm-gnueabihf-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.26.tgz",
+        "sha512": "d7d22fc323df04dfebcfdb3ba9784e4d0996d3ddb6fa98e945452f21e6eef8230cef99d7e98b83cc7b06c7c8529a7e5d4bcf5235a30287596052e5ea9befba8e",
+        "dest-filename": "@swc__core-linux-arm64-gnu-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.26.tgz",
+        "sha512": "88d95bbd3228e36e6b90acc32cb5852469c55ebde6c844d47480c7723ba23cd644f1bd28826700ba2942e321095fb1521c66e796ca097024f6c5fe1bdd526699",
+        "dest-filename": "@swc__core-linux-arm64-musl-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.26.tgz",
+        "sha512": "02eb843ad1be6172888c852ea7846cc58364971e97541dd62967e1c46ea19df3eb9fbbe9f3d44d38b6dbcb2a6b823e9293b93dba5c06553244944be604d3d208",
+        "dest-filename": "@swc__core-linux-ppc64-gnu-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.26.tgz",
+        "sha512": "25c303590bd6d41721532460f04d231e24f1ec2418a54af9b8310bd5d9cf0c40ab123044186db29e62775d7ef4b165ea97425a82a475b7756900d60559d527a8",
+        "dest-filename": "@swc__core-linux-s390x-gnu-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.26.tgz",
+        "sha512": "156ed5ecc6e9ab8f8f03b06202aefa2c9b3c31d36e512ca5cae4557d0464848c9e59a745ae867e28e3e08e4bbc67f7d7ce7831051bec93e3c6181d2df2619c8c",
+        "dest-filename": "@swc__core-linux-x64-gnu-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.26.tgz",
+        "sha512": "c3c7aba8c1ec55c746c147c9c45e8b6a24ee3e82a7c8b39c51b84b731897ae52ede4c2e3b6581c21e518fcd58afe83e8caa9201fefe2f293899cc4f1be5f3765",
+        "dest-filename": "@swc__core-linux-x64-musl-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.26.tgz",
+        "sha512": "b8309608da548aa91bbcf9acb8f5139ff3fb6a0f52a8d5c3d894ff5b7754bbbc99da4af337e9e69a8436c515fadff27a45888723b693e23a3b67efa5b258e53c",
+        "dest-filename": "@swc__core-win32-arm64-msvc-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.26.tgz",
+        "sha512": "da4d5ac754269aa2c49e90b4b910b0ece5e105fcaf74fa844415eea436ac8d86c2853e9948efee85adbc069dfc730d2f88a206efd2f6eda4c391b90006c316df",
+        "dest-filename": "@swc__core-win32-ia32-msvc-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.26.tgz",
+        "sha512": "694b9879c48419ae12512772096688fef93c8ddb1e89f627b05d46650c76fa988bf0622e4ffe50ad57057e67ace08c32ec52155f1b730f4eb7cff15fa59ecaef",
+        "dest-filename": "@swc__core-win32-x64-msvc-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
+        "sha512": "b609591b2c7c3793c2fb1d4d77f26b671aa9aa5719a12b86f604c328ee80b854e8162541dee4bc1ef6ca16e3bb837949cef15ff6b8806fde31b3d1d4d948401d",
+        "dest-filename": "@swc__core-1.15.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+        "sha512": "7b6051e25b09924465299fea0873f0f59692c5cd0c55477b82d6ed681eda32f1de25561ef2c381f0305990fd83b4848719292ef6c08ae93e9c9d8d02b57ace09",
+        "dest-filename": "@swc__counter-0.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+        "sha512": "97233077b586806efd452ec4111655dd3f3031d98fab7c70ca0fb59e600ceb8908871e7297e8ee3b63d82076fbbd388f80f0a3f0b623b0d5764f9c224075046b",
+        "dest-filename": "@swc__types-0.1.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+        "sha512": "e0101f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb",
+        "dest-filename": "@szmarczak__http-timer-4.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+        "sha512": "f8f9905f43e20183cc79561edb7ecb24062f38c616d63dab1f96113b24b76f8093549ba6df81df46f2af033a331c0406d139c735d51f63d9c2794c9102cfff73",
+        "dest-filename": "@szmarczak__http-timer-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
+        "sha512": "87dc1e81b6433eeaf11b6db1652a16b5dcdce35fce94d11440444da88ff47cec1ad9a565586bbb0b7e44ff1e8b0f20f7960b73b454928ca672b9533487185b80",
+        "dest-filename": "@tailwindcss__forms-0.5.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+        "sha512": "c37d5d77c1cec7793dbcfb5c421e501cff46c0a7206cca7cee3e7caa2eb1822067145b4a1008025a70f0e2a513f1a1f0902a7c6cabdbfca18a5961de74fd0002",
+        "dest-filename": "@tailwindcss__typography-0.5.19.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+        "sha512": "dc9bf75901b4042707ec6fbb95ffdb3fc43205f24e5de63e4f4f118a7dc66756ec86fc256cfb7b36b0c7304cc674a20e98ecef2109b18e4dbc604417eb493ba5",
+        "dest-filename": "@tanstack__query-core-5.99.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+        "sha512": "398d9b0aa3de993d4b96a27c6360946aee0a10b9c88611bd3a5dd99dd3db767074f79a516cfa35707b974e7760f22230b681d3830663c9a0e7434c43d2663003",
+        "dest-filename": "@tanstack__react-query-5.99.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+        "sha512": "bc99afbf017162e1a71766b146d3d8a1c6a0e8295b6f9612ee42cbf923bf4de545cc7a83216acd298b5cb0f3226e30f1f4ef9bbbea6c032f4d29f5a495ab2c50",
+        "dest-filename": "@tweenjs__tween.js-23.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+        "sha512": "5ca2c0eacc9e05468fcf1e23deac0cab3ceaf95e2ea3bd819e56ce8e6ba58cbad1a9db1ddea9f3bd9668c6f307676de776c452e1ab9f53a24e658a426d4e93d4",
+        "dest-filename": "@tweenjs__tween.js-25.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@twemoji/svg/-/svg-15.0.0.tgz",
+        "sha512": "6523de7f607a9c16989df81d4db032e23816f79a3ba62db13c6c06094f96313c68ec9e81d6530f4d6c12abfc13ba232af8dd24850f7409cbd8a75c05a10a68ff",
+        "dest-filename": "@twemoji__svg-15.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+        "sha512": "f6d4da3c92d289e8d92b1f819a8838b92b9bb5ea93bc5ad5ad44709261e2c41a341b8b1e0f4cd4c69f7c1350f35012712d0dcd3f05eb18a0e2563c31fc3a4fb2",
+        "dest-filename": "@tybys__wasm-util-0.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+        "sha512": "aa8429ad9bf3e70405270303a9eb1e4575afdeba8cbe18296d715f5725a16f1f57e3b3ce200ea2ffe75779f12664aa0080e69375a22035232a30853ad72472cc",
+        "dest-filename": "@types__babel__core-7.20.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+        "sha512": "b9f15dd978bdd8e0153d8b32f8fe27eff53b7baf1f7b1d3e11ef20486f4a5fb7a8d3ce025a2438b1dc64b6f765d1b38fba95ed5493d8d7dce4e84c16a9443c96",
+        "dest-filename": "@types__babel__generator-7.27.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+        "sha512": "87f354692c86e44cb1048a7c611c68e1131edbfa9082fca8c11c1533385884108e35b5bc3d4b20e2590532b86066151ee73dcbdcc88b0eebf227f09a3dad80f0",
+        "dest-filename": "@types__babel__template-7.4.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+        "sha512": "f0fbdc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1",
+        "dest-filename": "@types__babel__traverse-7.28.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+        "sha512": "210dc46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab",
+        "dest-filename": "@types__cacheable-request-6.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+        "sha512": "2925609909b33303e59ad9633a899aca847cf56e05ca70808b713c3cfb3bbe60d53def38853faf18f2a425f4e19265ecd31d2301a6bd53cb96f1b6dfc92d9f5b",
+        "dest-filename": "@types__debug-4.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+        "sha512": "e7609c515345c9f6f503600ba1c430fc377505014d992764b82dc1919ea2aa174c7d0cfb25638546e2459683b38e4fba5a28d4e7a9bda0a5c501773ba374e8c2",
+        "dest-filename": "@types__estree-jsx-1.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+        "sha512": "7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+        "dest-filename": "@types__estree-1.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+        "sha512": "74d2957c777f8e4d12911fdec4a1a3da0824078e4c024cef5826aa2d45209328c84e418dcc7f07fb2530afe04b25406364e7bdc3c5f7c209978590d1835103e8",
+        "dest-filename": "@types__file-saver-2.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+        "sha512": "9c49f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4",
+        "dest-filename": "@types__fs-extra-9.0.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+        "sha512": "58fb3e6db430e5a0a3fb1ea568d1962c7df0be21eda02bff3f7fa8b4185b3a12601bcaada5d00c9530b12edb13580ecb1f53a1fdb1421ec067d133d2e66df411",
+        "dest-filename": "@types__hast-3.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+        "sha512": "2f72e08a62c75ed1a45a290a9ec3e0d3f545c7d38665a0be78dd6ee2bf8e0755d1a87de6781200542db3af559d307f911e69d192a962400387349fc4d23fded1",
+        "dest-filename": "@types__http-cache-semantics-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+        "sha512": "e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
+        "dest-filename": "@types__json-schema-7.0.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+        "sha512": "7512e30961d8838a1a03bedcc4eeb8a0efbb2700b09c8ce464f76bac2ef58d0990b6584ce79ea9c0aa396d4ceabd99dd9156de14b2088bef530b8d09345e6135",
+        "dest-filename": "@types__json5-0.0.29.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+        "sha512": "050e5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422",
+        "dest-filename": "@types__keyv-3.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+        "sha512": "90668d6cf87593b005ce0a6e77f80c76f226e71b840b291147e26758a427a3d4c05d56ba5885421933ef6067a42032f8bb009941261b53134149bd5a528efda0",
+        "dest-filename": "@types__mdast-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+        "sha512": "1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+        "dest-filename": "@types__ms-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+        "sha512": "035b2b7b6ea47bb1c322e63f336de777d81f07e9eb9a1b58c8c20d6e3235cc727162d78a47aa92317e7a16c9a331c0dbdd231c8c983906245180e082ff2043d2",
+        "dest-filename": "@types__node-24.12.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+        "sha512": "13a3826919807b858399636c2fff5132a7649330c26357adbad91f95693873e01c8c3534ecf733d5f4304d7d13433f8fc6a9fd8b82f54d4dd41698e7adc0e0c4",
+        "dest-filename": "@types__plist-3.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+        "sha512": "17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+        "dest-filename": "@types__prop-types-15.7.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+        "sha512": "3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
+        "dest-filename": "@types__react-dom-18.3.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.11.tgz",
+        "sha512": "d1071d18b75d4c4468b425e8dd516551258edf3b6b6b0f2767a7b7cc94a01bb6a9c15e71b7ea49512f1ec0f06a4f8358075a29b462e9acd43316578863ce2efe",
+        "dest-filename": "@types__react-helmet-6.1.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+        "sha512": "c57b866afc8419a1500e006fe14566f3f66c1beab1790edfefbc8dad6de7fb527a5c0b2d532e6b6077881cf8752b3b0673a22408876eea5436c56ceed630532e",
+        "dest-filename": "@types__react-modal-3.16.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+        "sha512": "cfd557a42ecc5ab85f5a2a62b6335d8026aea0c2d174820b42c00457e65eb08cc1abfa149719349b702966e3050977674b853b2ab23e977591504190f0ad502b",
+        "dest-filename": "@types__react-18.3.28.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+        "sha512": "1fff8bf94913577dee7f8f4f1f9a420140553cd8f69c30574cdfaa4b574ec32ca0db897709c89c89c080edc6be1ccbc9059705825e6bf1ef9147a7a5b1be0bcb",
+        "dest-filename": "@types__responselike-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+        "sha512": "1668097eef8c39c437ef4483d1ebfb108f1394201f29853e0789b94f7c977350a244df7883f4993edb02924e74e9a503b65327159bdab03c071d4719504698b8",
+        "dest-filename": "@types__semver-7.7.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+        "sha512": "8c806f5964a10af941a8134866dd0a02c856a6f4a3864c2412ee1951c012a00be19ab800508dadd5d5eb8d22f8c5754b0781739cfac8b17de7297165fc3b78bc",
+        "dest-filename": "@types__stats.js-0.17.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/three/-/three-0.163.0.tgz",
+        "sha512": "b8874386c5d1a508815247e5052fe2d65dc95f5e1f5ba3adf5cb1e77ad277db64d5c70d346c9d5db19d35705dc81bbd389ba00478216fadfa54cbe5fd6ba88a8",
+        "dest-filename": "@types__three-0.163.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+        "sha512": "0a604a88be8d368fceaa098c9fde4593d5a1969da6b6f22ff8a36940a3761784a3beb11eb2e6d34561984a0f819d664e9e509a493535b0ca6c04ece06d8867b0",
+        "dest-filename": "@types__unist-2.0.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+        "sha512": "928fe0205251bf5efb5e066c65c0709ea24de71fc689e9fca8d3a7d03e5b414ff303355ff59b7706571488baa157dcb801193419b4f7b675223cd8274d7cdcfd",
+        "dest-filename": "@types__unist-3.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+        "sha512": "4650e6f4aefea39b2dbf40a8f22f19446c436eb4f1849b608ea8c5c9587fb5743297fad8b532a59d3bd9f3ca124de611116babc31db426ce244ee282b05914b6",
+        "dest-filename": "@types__verror-1.10.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+        "sha512": "87c7e011dfc3a684bd081ae31105d1f9d203adaa290047eee30615358dad10fc24eb4b2d3d686f64c7f8168a3915a92e43b1c56686bc59c79a5857abbcad8ebe",
+        "dest-filename": "@types__webxr-0.5.24.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+        "sha512": "4e1545e83095840f24506cbe69acc543891743b1354f2ec0df2a4539ed0870957c3bf339d751bdf405b6e22acaad6e7a5ade38c86f7e8a3f056aaa011a4b815e",
+        "dest-filename": "@types__ws-8.18.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+        "sha512": "a09a1fb6fd0b4ae683644dcb7b80db297f8a4bd1b7e8dcce7926a9f745082b4c8c03f36128986a9521ad3433913516886d07f38d70eb41ad32b49ea63511b3fd",
+        "dest-filename": "@types__yauzl-2.10.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+        "sha512": "682daa739b6141a86eb4a8cff9c97c72037d0d67b7654a95928df408c4991e71441f284e628652ce41ad008da6730677f31788983b9c238767aac1e2398bae0b",
+        "dest-filename": "@typescript-eslint__eslint-plugin-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+        "sha512": "fd96ffc5a2037f17899ef8ac86319d711e239abed2f9b75af0f28d85119d9630ccf9e957865bcdd05c8f4ac3272e6254ad51bd68f3ba7687fcd308cc6b0b004a",
+        "dest-filename": "@typescript-eslint__parser-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+        "sha512": "0aae947e9659935e7eafcec1908879ac3a62dfc5b86fe4a39dbf304023cf0c3c1e4bf2d10858c2c958846f31e4e429377f64037e09a5c6a49aed2edc943b657e",
+        "dest-filename": "@typescript-eslint__project-service-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+        "sha512": "4a09b2bc33dec5611341e93eab3667ac6ebce3821a3b4d9457238b848e30a68f3676964963dfba61908a00c1735dbeea871dfb9852b541c3d0d7cb6e77ebe8e9",
+        "dest-filename": "@typescript-eslint__scope-manager-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+        "sha512": "dd247e46e922a43be490aa7f7748cfd1dcb3ba5b370db1a6c03a5511ce70aa4e5fdfc2854e16a4a8000ed17322ad6004fa44f4d284dab936f330518fa00cc1d0",
+        "dest-filename": "@typescript-eslint__tsconfig-utils-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+        "sha512": "67b125a0d47f077f3d16f69b746793a365ccb385bd4e3b4f88ef4302c993d32a26d1bc253f2463909d6e09d5b50efaebad83f9d00259f57737b01c9903df9d72",
+        "dest-filename": "@typescript-eslint__type-utils-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+        "sha512": "f53ba45f20130507ff26af403105dfbeeae4f86e51d8cc1fa901834761b31b3dbc1ef63f95734a1a1918fba20eb9bc1caae8a45a4e5c8e580fbc3dae000ee1b5",
+        "dest-filename": "@typescript-eslint__types-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+        "sha512": "10b1aea287ee861a02bcd6d08c5162a1b15c1a07030849b44e159d98ee19d14ccba8f5d2dca16f9c467e4877b0c0e6078ccd3db64cce597353bfdbba1aab72bb",
+        "dest-filename": "@typescript-eslint__typescript-estree-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+        "sha512": "4197e31cd1333d8f3e974f9f21732fb90dac265a65078ce00d9bc0f8d9af66c66fdc443039c7350ee214d552544d667f44aa2e04c843c8d681331e2c5afaf344",
+        "dest-filename": "@typescript-eslint__utils-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+        "sha512": "7f558ed8bc7c6bdb7c0c04667160143c96eed06db46c9963f0be33ef62b4d1331e240a322ebfed1e123fa736012eb4787575a47313b571661910e5fc0ca1d3a8",
+        "dest-filename": "@typescript-eslint__visitor-keys-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+        "sha512": "5a6a0df2a688028ed64d859b019b86f0f604867e5f933edd66ba93059eddb6dfff94bd86c26b3521c9d0e721ea8c37d7f05b798f86330ccdb77fcef305f0def6",
+        "dest-filename": "@ungap__structured-clone-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+        "sha512": "a692d15201d5686456531d11d14b74e8c8e8f6005a064837bfff00c6eb062e1b08a2d6c12ee464e75ac0cea2c2f20aba372c80a23117825363cdfe91f78f0337",
+        "dest-filename": "@unrs__resolver-binding-android-arm-eabi-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+        "sha512": "942c6456d6f8c29d6ff84a0df878c81bd7082333e45f93ad334de9418906f94e4eff02f9dcb0b841b21e6b38222aa96e19e5447819596a11da942681bd4d5ada",
+        "dest-filename": "@unrs__resolver-binding-android-arm64-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+        "sha512": "80f540d548d1bb563f22c07f75012ca76575a66e3839febe2d6bdb2dcf520e4d5cd8a8610d10c152440261559ee9fdbab896f77ce2bcb1a58c82d5fc22b324de",
+        "dest-filename": "@unrs__resolver-binding-darwin-arm64-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+        "sha512": "705ccfeeb58a777959682b03cded3b417d520b6e253bc98fb72f6f74ff9855adcc19d5603e615ce7ddf5edbda2a17b6008c2868822f12781d0b3ada8cfa19f45",
+        "dest-filename": "@unrs__resolver-binding-darwin-x64-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+        "sha512": "7eab4681a937cd7e03081e8f169b07e7e2a6b7ff02222e01af2e2b6f5868e80bf64074d110cfb8ef2dbcd94aa2bb76511792108a8250e6a59157a8ddb80fa21b",
+        "dest-filename": "@unrs__resolver-binding-freebsd-x64-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+        "sha512": "bbdda6be5718b69f4c44a98ff99bcc9ad3cddf8fbfde5307972323ef05c90de5f1b8cd15833cf4f8f3c936cae8d66dc864f602848927f78e305bc4d88062851f",
+        "dest-filename": "@unrs__resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+        "sha512": "70835aa18db3ecb542adf1e421c9af8fba2c4ceb66e95553d7a6f9a10752e1b7a26d7d92601c2060b9aa8418c0d6de7509aad2681b97e5836c58b8eca9f5b90b",
+        "dest-filename": "@unrs__resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+        "sha512": "df8830ecf8c3181f4981e3c9126844a81856bc28a2582b97b0bf6162984317b72b5bb520234e60c81022e8c179f2e19c30e88ea92276c9b11e0af1dcab404299",
+        "dest-filename": "@unrs__resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+        "sha512": "472308c7a51fe778613ad24321a9926d3b2403df6c3c74bdeb0c5513f6c9b5e3c926da5d2865ced7063dd2845d5ee60e18e4eeaa34fc00271c31ce0ae90993df",
+        "dest-filename": "@unrs__resolver-binding-linux-arm64-musl-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+        "sha512": "0fc55a7bbe00e3f6be9991f415b3a41492fd0d22b647a4c53c2f4cfa30966226bfab67a29c2b9b5f5d2979ca438939a4255507fb2f0adc1642972703f2709284",
+        "dest-filename": "@unrs__resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+        "sha512": "7ebc4be0eaf3396555b0e73debe5776aa4c8425d4ed938e013157810a811634f4027d95e669120f0093da6169d6ee5f4040e24f14e6ab6f31241018699a26a71",
+        "dest-filename": "@unrs__resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+        "sha512": "989e6fb8368867e97f69cbf4d6c1e85dfa67cab34a3a4ff7683a0474b3bf5ed9fd1ee6650c3ea32b11e590df19856c8b26c441c5fbfd198336bad43548284a7b",
+        "dest-filename": "@unrs__resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+        "sha512": "9042e8f1e6c156d6fdb00eeb31ed42a61e101eb781ca1699d901000ddf4dcc842c60d429b7d52433d8aaaf69611abe5a7e1f3ce5dfdc07941e4d749b6474d83e",
+        "dest-filename": "@unrs__resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+        "sha512": "0b76401ee80a828bd5e58bc032cc61ab482d5eec0449429ce4c844b630692e81cf2d833e8aec128f795f945c0adc33e6ebcebad2b67b1bc04c7304aba3b843e7",
+        "dest-filename": "@unrs__resolver-binding-linux-x64-gnu-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+        "sha512": "ad5d184a8ca12b69d9e2f12cc13fd0c2acea417c3923a0a3a1a60c397d13a819568688d47fc3fde26bc8ee7b894de68292476cdd0138fb34bc2a8f86757b99b4",
+        "dest-filename": "@unrs__resolver-binding-linux-x64-musl-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+        "sha512": "e6ee1191fc499be360ec85a09338b7aab14ebcbbd06273c19a399943cfaccd32bf6f7d5f4029e578d9751a012dee722c65121fe4f2e13f04f458cfaae39c7f51",
+        "dest-filename": "@unrs__resolver-binding-wasm32-wasi-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+        "sha512": "9d1733e48978967d243217cbf12de12e4c48f39057b37a3c118a1ab6db0935db17e18514f3d88e9159fb834547491c45b9531d3384358c4a4821dd488629bf53",
+        "dest-filename": "@unrs__resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+        "sha512": "0c2108eade62d4d980669ea91689e90f99bb8ba685ae9a1f729e0b0368bc208abad09ca8dbc85a98a07136b65cc8ec15399920b11a7d3b6b1758158ff0c9ef21",
+        "dest-filename": "@unrs__resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+        "sha512": "96b5b6d3485975b7d1b73b5bca0c9aabfea33fa00a13ca903762af3dc27ec7bc220f4dfc62d9d8b59f3620c349ebd18989b57b6f02f7cbd1602bee70fe962dea",
+        "dest-filename": "@unrs__resolver-binding-win32-x64-msvc-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+        "sha512": "814bbd8707d6bef1030419a0b40a30402a23c19989e6670b9f76ae7de0ac8ad8a3b37f9fd8db2b3ed94058847a38f8aa96397de8654251b2ded07caa22955aa0",
+        "dest-filename": "@vitejs__plugin-react-4.7.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+        "sha512": "5df7baae9093c52c5f6ecc22fd6fcfcfbce9d56592367e00d1e5b898b91051ec02ad75ed323df594283e890c93921fc292eb194aaf5e0df96eeed8c40d7518ea",
+        "dest-filename": "@vladfrangu__async_event_emitter-2.4.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@xhayper/discord-rpc/-/discord-rpc-1.3.3.tgz",
+        "sha512": "221e3c1878ae6bb4ed66028ef9fd2e64f842790a9bf387d8daa532b3fa0c87c51b51f89491424b54299dfefd802b4fe9577ddeba1d1aa925e8efef4b88f4b01b",
+        "dest-filename": "@xhayper__discord-rpc-1.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+        "sha512": "f64fe01c5ea7fe9022ffdb6aaf79b76aa92e88da2c613bab2cb52d73bc50f6cc41ff09bb58fca00aff0661aea64b47cb2441e1a8c0b5013621cfef94fe5447aa",
+        "dest-filename": "@xmldom__xmldom-0.8.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+        "sha512": "00ed9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282",
+        "dest-filename": "abbrev-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+        "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+        "dest-filename": "acorn-jsx-5.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+        "sha512": "51527213d32db4eb014080cac35b246fd9c0c10b91e70b860f7fbcd8ae89809966fd8f8a23dda836c30d199098743b15b511d26a4d29715e439e8e7ee2387db3",
+        "dest-filename": "acorn-8.16.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+        "sha512": "45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d",
+        "dest-filename": "agent-base-6.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+        "sha512": "32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+        "dest-filename": "agent-base-7.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+        "sha512": "e69e964cdd03753195424e958dc123bb5f4881a1ee75a95c7da6c3ef284319e03a6dc42798bf82a6f78b26aff786f7f07756a87fa2f7f3a3ae824c7a45fc8c21",
+        "dest-filename": "ajv-keywords-3.5.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+        "sha512": "216ae8b26ff2ae7e377a22aa91f9078aced08a80e579a5d01dd0d53ca834152c3077f0eebf25fbf5366714e9d8a41edd72c140326b45ced66e5cf0ef49e3e417",
+        "dest-filename": "ajv-6.14.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+        "sha512": "3e55cf78458c5cc67bb0f60e1ea983c8227371f36b52bddf18d2ad7b35f5e3291738422fc8af3577eab2771f3d298e4eef514a30f690daf05f04523934747adc",
+        "dest-filename": "ajv-8.18.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+        "sha512": "06f53c9d8806401c5c98cb84794126353beb3158c93521fb4605b6e2f5dec4de157a7eaa0afcb84e7b67be59f09cc2d356571141075b458f0d2a7688a1e58336",
+        "dest-filename": "ansi-escapes-7.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+        "sha512": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+        "dest-filename": "ansi-regex-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+        "sha512": "06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+        "dest-filename": "ansi-regex-6.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+        "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+        "dest-filename": "ansi-styles-4.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+        "sha512": "e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+        "dest-filename": "ansi-styles-6.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+        "sha512": "ed4be629a95646dd708232f546b1b1a12256ff44191487a0a5e1af646f648e9f2fad1bb9e574c76f09eaab61a95e6f6e2db72e8719b722a5fd381e0c651d5bd8",
+        "dest-filename": "any-promise-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+        "sha512": "28c45e154af4078b7e0fe381923477298aafa1ca765da4b33b9e54701ea681031ddca6dc13e9964f2bd557b0ffcec7446cd9d5e9a71952eb64887417bd3af547",
+        "dest-filename": "anymatch-3.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+        "sha512": "8fcee8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb",
+        "dest-filename": "app-builder-bin-5.0.0-alpha.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.9.0.tgz",
+        "sha512": "7ffd46855ac37c11fbb12ce10308976b5ae947fee907b02fe70a148e6b7e41813443236face022634e6b9e0b51fcf2b8ff50734baff35686286c8c0302caed04",
+        "dest-filename": "app-builder-lib-26.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+        "sha512": "e7c4bd403a86d17c76ed8c0f4adf5f2718af8d8978df6602c1f0cc7d9fbbd5102a52b65e7fb2eb2906772c72cec024b814b341a653f9df7671f3de5278e087bc",
+        "dest-filename": "arg-4.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+        "sha512": "3d88f214e2ca43dcb9ec9bd0e902e8f1d02036ab3087c33544c25875076e4fac5b59280adfa3ff67fbfea7cf3ca4cebd8cc31f4bc5ddf05e88d6443f23d1d41a",
+        "dest-filename": "arg-5.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+        "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+        "dest-filename": "argparse-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+        "sha512": "08e44ea676a86a9d44d85d34d12eb6afa03ad2e1d99e696fa2685fc93d8395372b6353ab04a9f65211fbaa7e704c2f7332f0f4018edcb1d3d237028ffbb5a243",
+        "dest-filename": "aria-query-5.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+        "sha512": "2c713ef01b91ed16060cabe7ae672e4aaded0dc2aff4e1445d0b7f1e96d9858ed5ea1d339545eeb67003f361a2171f6b76278232392fb5cb0fa81c20525d488b",
+        "dest-filename": "array-buffer-byte-length-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+        "sha512": "3351d0c885dc046b55cb006df1655d8a6fa5acd68aed51e9f7d42de6948dce25f39ca1d588805b5d6b5f453a4416917f73815d7f1340b020b03e9e69841609b7",
+        "dest-filename": "array-find-index-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+        "sha512": "1667820807a7cc7d0a1f7f3548f4f91599a203f4e6a6776971a4a185f80437d7825639c506aab7975c6b238db2f3e3cf2c8ea1ca9ce8bb8197c34d161e63c12d",
+        "dest-filename": "array-includes-3.1.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+        "sha512": "095bdde851e0d59dcf3a904bc4ee84eb3afead228443d2faad91c0698ee52df84ab166140413ae32cd1ef68db8a28a63e87fa0791097d1827e4c92c12b6787c9",
+        "dest-filename": "array.prototype.findlast-1.2.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+        "sha512": "17f4ca013933b1e504c4f95fbe6c102862133370c64cafaf900b026680dce5d695ca06c90678c45026e0900bd516c81f5df5f8608a99ff6ec6de4ded757ad3c5",
+        "dest-filename": "array.prototype.findlastindex-1.2.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+        "sha512": "af01bf8dad677b22ea0ae199e5862bce703ad83e266578348b5708b242142928aa1770a37bdff05c096cf41f6cd566b67e898cb08bfc73307c8d970f9b109716",
+        "dest-filename": "array.prototype.flat-1.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+        "sha512": "63b5ade7578a252ca2f34845ac909e3c618da3992d242b2516e6e8a89b1b7f9ec208f726e73ced96e3e5738fda0fcb16b0abe5c1ab5ece957853579f93c9298e",
+        "dest-filename": "array.prototype.flatmap-1.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+        "sha512": "a7a171f01edbed984bfe0994b00cb40f5e5686f0dc730de69c635b6698b7a66789771b56b23da311a23863aa28dd78877f3b9280fc0a734e0c62de8a82f0bfc0",
+        "dest-filename": "array.prototype.tosorted-1.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+        "sha512": "04da0263a4975cf43b805da8a483f818113e5f0ed4fa91cc60abb38e008ddc6c22688474f5451e29f85ec88af2efb42dac20650b428ad2ae7f4c447fb588773d",
+        "dest-filename": "arraybuffer.prototype.slice-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "sha512": "35f27853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b",
+        "dest-filename": "assert-plus-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+        "sha512": "387ff6139160db487668fadb7be40bf09650164a34619685fa3e269d0ec11a17dabceecea522daf1ad32f6c070a261dd49b9214d2f1340d6b205f9d6e43c1bbd",
+        "dest-filename": "ast-types-flow-0.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+        "sha512": "67bb4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd",
+        "dest-filename": "astral-regex-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+        "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
+        "dest-filename": "async-exit-hook-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+        "sha512": "86c535f007bc0834d1e8a82ef4361fd046c2aff6b98862f4af2b500e86d471da5838aa2493c2c48d5a619d7903920a62d30615b2aad7b8fd1b67125a4ea760a0",
+        "dest-filename": "async-function-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+        "sha512": "86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+        "dest-filename": "async-3.2.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "sha512": "39e8bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+        "dest-filename": "asynckit-0.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+        "sha512": "faafedec492fd440d8da5e8675ae8b2e25f5e2b53d4d5db459ade87de426c0f1596ce328f435eb2db3a315a69c9645ca5a27486a8a7000e6d00eac16b46523aa",
+        "dest-filename": "at-least-node-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+        "sha512": "90d3a30ea021ee9c745d6348fb841bce8891fe74e41c058db9ddaebe726ab83d7fc796bb11064c253d00733a8ad109faee863f4d34352db50a6a3669a7723db5",
+        "dest-filename": "atomic-sleep-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+        "sha512": "14c84ea19578faa47a6935002ca5f6ac4a861bea32013bf006df48233551e6b31ad874563e4c5ff8ff8f0092c3d48fc7e7f208f87b99701258105069ab7f689e",
+        "dest-filename": "autoprefixer-10.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+        "sha512": "c2f52306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd",
+        "dest-filename": "available-typed-arrays-1.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+        "sha512": "cc1428b998b10d36e8de3306a872b278fc58c6bd5ee56f1475398143bb0db5a03d3366c4df675ac713cb4bf8e88e128e1f143b2d6c0f8df8b07ff7e16895b396",
+        "dest-filename": "axe-core-4.11.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+        "sha512": "a888f41bdc196cc18d2e32e68353d3eafda613d007db3967003243ff6b42e84d348609a150e7c407a82b7873c07cb452b9f1ea44e2144e4c3a13e337947d0f4d",
+        "dest-filename": "axobject-query-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
+        "sha512": "83ef32c47519eb445cc9a5297cdcf2e7a3ad596fb1f5cc847bd8fe0ab6a7a8b8aa6e3bb6c9ffc2cba66d60ae34119c6dadd1e59739556602e670e5024e527b26",
+        "dest-filename": "babel-plugin-add-module-exports-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.3.tgz",
+        "sha512": "87c87a1fbd59bdd2c967166b62469e477d01a234da57b3bd19fa9a718d7848d8f908d07ca1c2fdb7274dcd30b426b9cd37bbd8dde261c029a40e3eedb8451aa9",
+        "dest-filename": "babel-plugin-module-resolver-5.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+        "sha512": "d313ba99877b241d987acc432a995a7d1a6c88eccfb7d574d9d74f08b6d8d716063ce5f6e0d4f2379d2a9d4c6008f712a183212a902e0538d0a1164202450347",
+        "dest-filename": "bail-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+        "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+        "dest-filename": "balanced-match-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+        "sha512": "04bae011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+        "dest-filename": "balanced-match-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+        "sha512": "00aa5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58",
+        "dest-filename": "base64-js-1.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+        "sha512": "a8290d2e2dac7c13a7f17859434157b13d4a8bf628e4ff7486b9116a6545452eff295f61a5f0381e4a16354d79dbef30d333e39f1a39a6cc7934bdcf48682fe6",
+        "dest-filename": "baseline-browser-mapping-2.10.19.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+        "sha512": "09e87eee8c79a9eecb26e2c7a18d1f7a1de91ee5031c071151ec8bd95620859c1fa64348cbffbc39c8346b752e4a86336af9b2970b8b59039fde19748e330c23",
+        "dest-filename": "binary-extensions-2.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+        "sha512": "a76abfb7f9a1bee3a3fd478b955eb9eba183fe0ba8c25af4847c42948d16f66ecc59890bd45d212e8fb401ec6cf4748f0ad4754974344c3dcc30aad765a8db89",
+        "dest-filename": "bindings-1.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+        "sha512": "d56d3b70cf604ba0dc2e97ab65f1528fe6d62ed68f1923875a13e21b35e6bd525b44b746f36b07fca9fc12d5b556a595039e0029fda1e64e416e721bc05de1eb",
+        "dest-filename": "bl-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+        "sha512": "774208fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
+        "dest-filename": "boolean-3.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+        "sha512": "3163c67c3c67cb3294eeb34e5bd48ffdce74be2df1ae6aee6bffba85f3db092d8004d59fc76e2f3e2773bc2ee4ae353f453a36df9b15efbeb29a5b0cb462a3f2",
+        "dest-filename": "brace-expansion-1.1.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+        "sha512": "4cdd64099020760c1e261596a60298ad068c34770350b1e45b0408b2976d8d5e18e5abab45d6698c0aa7eb25f714fa9303d9e01c2738849c4c00c8067ef7bce7",
+        "dest-filename": "brace-expansion-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+        "sha512": "559ce72e0b70867f8c69cb7db5f8b0c7ae1f03d7ab1c7fcc0971147c1ff46d7ffa173ea7cb91064d7625b4ca1caa0e31140419b673b70c75965e2f118ae37b71",
+        "dest-filename": "brace-expansion-5.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+        "sha512": "c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc",
+        "dest-filename": "braces-3.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.35.0.tgz",
+        "sha512": "b0ba1a76e9a945fb23a6b3fc5f3563a507348caf32a87071d0fb544c6623d9f7ed4fe3ffb7ebb20c041d3201803ca0f4d758a7fcef9860687b7c8b34a06fef8b",
+        "dest-filename": "browser-fs-access-0.35.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+        "sha512": "e3cc52ae2658620fbca979daf64c2a8c8573b90c62f8a616a76fb99c262760a3d3af42ef0fcf49aa4d8eaf9a20c73d0d50c7c88e1876948517fcbc97f41e2822",
+        "dest-filename": "browserslist-4.28.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+        "sha512": "54ef47b7ffa9dd237b48a5aa72b804ce319b4522584f1f90d694d00b4c2b5aa1f1d2fa49ada43a1ad1f1f2dbdc835ae52b56f2854e6071cc603a08fb0744c391",
+        "dest-filename": "buffer-crc32-0.2.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+        "sha512": "13e5d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d",
+        "dest-filename": "buffer-from-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+        "sha512": "10773220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
+        "dest-filename": "buffer-5.7.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.6.0.tgz",
+        "sha512": "93d579235f0f5cb7a92d9f235663f3b07fa0542559fbd68c54bc8267464b3a44f6292ca205b94308237c5b10db8cea5f2c634766aa893c1996d0761eab196091",
+        "dest-filename": "builder-util-runtime-9.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.9.0.tgz",
+        "sha512": "f9ea1c99b762b27c9be3407d9c0a7f29111f60b5ef19a831579d0a66ffd987869f96caf57dd63d431b3a406d49b71d6f1f9779350de121c7a6522e114a514afd",
+        "dest-filename": "builder-util-26.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+        "sha512": "b63c0ce5ec4c83a046448fa43664e7b4db2f7594b55fc045612ead9c9da1747d2457133afde559db1cbe16a4ad496bd89ad7c53032c8c6eae8ac7c0329f0f3e5",
+        "dest-filename": "bundle-name-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+        "sha512": "6fa225bacf9cdd1add0e4f8984b2940107f3ce02c43f2eb0717a92edfff17b51044efb033fa18e446ed216e3ace9c203e5892a7215bf2d765b5f96dcf23ed971",
+        "dest-filename": "cac-6.7.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+        "sha512": "85db14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015",
+        "dest-filename": "cacache-19.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+        "sha512": "dbf90db1c3e1a5cc6b3a280c6736e2585eddcfc8a585bfe72075371326625d65e97aafdabbca89f1585d7ed324b72de7ec68fa1c819a9501bca2204d07700980",
+        "dest-filename": "cacheable-lookup-5.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+        "sha512": "faa272c78c622ab6bc999adcc218cc44c5210f9351d51f1eb0f933218c57f7a26279c168c405c5bb3fc6a51dfe7afe0f13559a9878a9efcc15d2f7263d0b69f3",
+        "dest-filename": "cacheable-lookup-7.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+        "sha512": "ce40d3e56005e21492a148327e0e6d148c73f1740afb6e56fd32d5a2325330a05ac5ebcb041b4bc60aa0b80b95401f0f556efd1558c7714f8627db556c367d99",
+        "dest-filename": "cacheable-request-10.2.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+        "sha512": "bfea7aa2782cae9d324c66c95e38313e8c36f832fddc30123f891708329bf3f6f046db7d384177c218209240e418dce0716cb65da1786bc9d98250bbb8496c72",
+        "dest-filename": "cacheable-request-7.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cached-iterable/-/cached-iterable-0.3.0.tgz",
+        "sha512": "303a8ce93a4155e6d90f8503b66945a7c12356d45cb01eb1b7d691756ca68e4d1f5955141a09adfd5ee8d07d20908d9392fbfc074b9c8e27599b898ba2c7655b",
+        "dest-filename": "cached-iterable-0.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+        "sha512": "4a9d5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+        "dest-filename": "call-bind-apply-helpers-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+        "sha512": "6bf872fa936c1544d1f88cfc4c226f5ee74a54b027cff0f2792528d74239caf143409045536b3dbaa429a12ac996ba0750aa0aab383e7a9c723fd96a15dcdf05",
+        "dest-filename": "call-bind-1.0.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+        "sha512": "fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
+        "dest-filename": "call-bound-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+        "sha512": "1e95fae68d479ebf471f6e688c2d581acec70902ead0608e89b49a58447478da6027f675319bf699373bfb187a58e3f16d155c9a06efe21194fae490ff6c4565",
+        "dest-filename": "call-me-maybe-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+        "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+        "dest-filename": "callsites-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+        "sha512": "40e4af7af86c9628e0630471e91bfbcca74c17c95b466c7eb901b1dbebc373e288fde067b32f648ade5a8f6dc0806bb7a5ae2df408306e75d6a92fa2398fb668",
+        "dest-filename": "camelcase-css-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+        "sha512": "eaaf07169fa5390b5c7fbc012beb847a7c729955a418a9231690afc395b6e5c98cc040d4e39a75c5014142ff090e530caf2ede371c81691faac6099351990845",
+        "dest-filename": "caniuse-lite-1.0.30001788.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+        "sha512": "9b30d25c83da170543bd9007a99f5595bc85e32c9746e5fa22f074e96bcf624a8954edb8917d4f3e1bfd6dfa4a345672c581669a0a34dc75220fc8a496625845",
+        "dest-filename": "case-1.6.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+        "sha512": "7b2ac5d23885a58fb776b4fadfcddfd6a8646c6b0b4a27cd02303ad4852366398b0968c8b58e8b07d7edf588680e0c1f99c941db386ee752dcefef796fc35102",
+        "dest-filename": "ccount-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+        "sha512": "a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+        "dest-filename": "chalk-4.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+        "sha512": "ecdcc12f4acde9f3145be7fb03a228e21e34a90946fb11a6b4cc5f6e71ff2bb4c0b6df094165502beea0d145ca31e549a3257912490db04ad0f29543ddb2c76c",
+        "dest-filename": "chalk-5.6.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+        "sha512": "d6fedf810463ea19d2c05a6ad44bb4ca7aff083130d2b5e8d81eb5a97acb35d1d998f2a06fb7ea4b56b6270174ac84a8f6aefb8c323c54c107a00a67f2a0e864",
+        "dest-filename": "character-entities-html4-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+        "sha512": "4693e9d1ab13ffab9f466fff009570a558996c633f3248d017125c710447988485ff6d8d06db07a805a62fefe99a43d6a08509756c9e565793975c3274701355",
+        "dest-filename": "character-entities-legacy-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+        "sha512": "b21c7ba10d00c1e9ff05121d92392fcf9e0f9c4108fc48f05c3488669f3afca29d6da7c78750dffd16060619f885b7b6fae282f459d3e540847723f3dda8bd85",
+        "dest-filename": "character-entities-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+        "sha512": "881678178c116f239156cbb48cf57b81790eb066231873e6032bfe1e21c6f208b93ed0bd288da3d7ebfcfed9626d1be3a165f4dbbca9986fe7d07b4ee6deee9f",
+        "dest-filename": "character-reference-invalid-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+        "sha512": "ed54f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f",
+        "dest-filename": "chokidar-3.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+        "sha512": "420ceef247c1be8f9c038f7ada39cfd4a912e83a29e4d4ba83b4792c5609af86fc51bf783cf417524b02c3d3ef5e87973d145d751342e42d4941447648c1ad9c",
+        "dest-filename": "chokidar-4.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+        "sha512": "f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa",
+        "dest-filename": "chownr-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+        "sha512": "d51e45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b",
+        "dest-filename": "chromium-pickle-js-0.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+        "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+        "dest-filename": "ci-info-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+        "sha512": "efb3d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42",
+        "dest-filename": "ci-info-4.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+        "sha512": "b1a1d83b384842ceb0cb6b15c5333a6d40ec40ee05e7457d450db6a81a447425be23efd69a47b61ce97a952e9d4e97715616fcf3f23af87b3ee37f1cde57d4a3",
+        "dest-filename": "classnames-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+        "sha512": "23fcc7030b0a7fd16a1a85cce16591002a1bf7e48dba465377de03585e7b138b68a2e46e95b0b171487a44a5043909584c7267ce43ccc92bcf35a6922cd7cb67",
+        "dest-filename": "cli-cursor-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+        "sha512": "6828f83b9c0acacce33260d3e2d663f77931cb274dfcae733d64827baff4015fc0035a6a7b9641230d1ad997cf415ee52f9ff26f91ec52b789e94140175b4443",
+        "dest-filename": "cli-cursor-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+        "sha512": "f4a0dca04570c945eb8dc24dbc70f434573f862c1efd63d560895e421d8ed4dd99ae8e6058967f2bedc31a7f30f0ffc5e85c4e833c82e5bc43c872200923e11a",
+        "dest-filename": "cli-highlight-2.1.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+        "sha512": "cb0a95fb9326c8be04ef26d780acace03ba065b5f4142e8b9f0ae18eeca42239caf64f0e41a710edac462a78c35d63619ecd31a2dddb648e61e791fcca8f5c26",
+        "dest-filename": "cli-spinners-2.9.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+        "sha512": "9fc7ce8b1c030fa6ff39b8a7cd3ae9d59285cdb82f299beecff4ef7a39cb9f56907c2eabe765c4c7ce459ae0bedc723e24cedca0145752f36a114d8f1d5ac7a6",
+        "dest-filename": "cli-truncate-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+        "sha512": "9cf75a15d43487f1848a06cf0a5cf5d43d2ffd9244c3199e55919e328dd9e52b4fb544e403da35943e90c288ab622483cdb7309f65dc8f0982a7af16d484b84c",
+        "dest-filename": "cli-truncate-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.4.tgz",
+        "sha512": "09790c43153ab3d1a494eff57fbd7876428132ed65a294b558517407ca380313f2911d61a68cf14a2519e5951e0637cf8025aa6dc34eb59545841f0b91fa75f9",
+        "dest-filename": "clipanion-4.0.0-rc.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+        "sha512": "39c444ebc70eb15317a7562fa2797f7f39103b28cb4aeffc6e13c37d0b747b4fc46f6f374ca3f6d05b3632aa0fb2bf52c00e7de6b44203e40ccd873d9c13fe25",
+        "dest-filename": "cliui-7.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+        "sha512": "05278d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+        "dest-filename": "cliui-8.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+        "sha512": "44ea0bf788c91f675454c2f663fe4f10335a48781e39d48389c5324bb8b3705eb71bab1373f1538cbb9be1bf0897d4bc4b46de39f62dd13680e6abc52bec34c0",
+        "dest-filename": "clone-response-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+        "sha512": "2501d9d90316ea5dda1ff8fac42a904e163ff4e1f80fff65b37e1c8245018847a87114d4d38b477ca3c1b142b53ea64251033b1a20342085c94ae5c723ae0a6e",
+        "dest-filename": "clone-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+        "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "dest-filename": "color-convert-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+        "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "dest-filename": "color-name-1.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+        "sha512": "21f103c70a1622391e5cbd5e5dc0e2a30e146ca8e12ddabafc4b92551f4630deca547debf6043cddeef786ccf535dd53de28dde71bf5c1c59160ef83ea4088db",
+        "dest-filename": "colorette-2.0.20.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+        "sha512": "1503783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+        "dest-filename": "combined-stream-1.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+        "sha512": "16ee2125dbf37b29427d03e9f5219689da73accb3bb53ae5bba55bf1719a446724f1048d649269e77f16adbeb42dac787cfc11eb8562638ebc3885136d194666",
+        "dest-filename": "comma-separated-tokens-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+        "sha512": "feb15e0a934941b852663195c0ef51155df13ea6e71114bc326210cc2b43ff397a82926e57f6cc2ee37dda81b717b77ca031071d1aee8d25cd52bf1fa639ed2b",
+        "dest-filename": "commander-13.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+        "sha512": "1fecb4268fd3d5167da8f3f8121d6991c41c2d1825ada25a48ba323ad1f1bba01aa648d6542cb64a2b75410e31dc39e0f2a0e54ac6447adee0e4fab4e8cbd383",
+        "dest-filename": "commander-14.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+        "sha512": "34e2a6f31864cc08f3171f01dafe4e0074febb9a5141cd9409ad95abd8d82ffdf5a36c22f66c4103b2c816cdec5795520b8f73ea91217db3142ef4a12a3dba58",
+        "dest-filename": "commander-4.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+        "sha512": "3f40b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66",
+        "dest-filename": "commander-5.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+        "sha512": "291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+        "dest-filename": "commander-9.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+        "sha512": "a490e1e7fe30ac49d75ff556459bebb8018793329daf8eb3d753a54cf37e56b0139565a148a7b03422757eeb423b90bb7890779cf305640d4b798b5c15ba19d8",
+        "dest-filename": "compare-version-0.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+        "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+        "dest-filename": "concat-map-0.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+        "sha512": "2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
+        "dest-filename": "convert-source-map-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/convert/-/convert-5.14.1.tgz",
+        "sha512": "ce9d54c959d32fb83f4feb30d416f5c82203648479d1e2859d8257b2644fd925ecdd17f396280edc959cd99b6acdd257d3fef1c1f99afc9f23ebd243e4c07668",
+        "dest-filename": "convert-5.14.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "sha512": "de5ab3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69",
+        "dest-filename": "core-util-is-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+        "sha512": "897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
+        "dest-filename": "crc-3.8.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+        "sha512": "75c2855f78e7d0ca486978e2b2846f7b12095442b36aaef3dab64ac5ff8c4abf5391d9879ac5389b695c2e88eb8ff14797c9a4e55c4c99803e7ed4643ffde829",
+        "dest-filename": "create-require-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+        "sha512": "f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+        "dest-filename": "cross-dirname-0.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+        "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+        "dest-filename": "cross-spawn-7.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+        "sha512": "08eb67e0444e5b97411a513fe0f88a9e1eab66900fc437852da104c2de22d748e90cc16dd84850192efd4269ab3be88a087bf43d4fc7ace5848628c5775c7df5",
+        "dest-filename": "css-mediaquery-0.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+        "sha512": "fd36ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56",
+        "dest-filename": "cssesc-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+        "sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+        "dest-filename": "csstype-3.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+        "sha512": "b1d412141efe9657d47101d440edfe07c111463d0e6b8c3d3ce58c23fa6e1adb9fee0172c069a468b084967b9d7d388a655f8dbc7a8bd227f376b23c468ec448",
+        "dest-filename": "damerau-levenshtein-1.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+        "sha512": "12628ee55dce2d7875aed2b6c205d16a7b1a2b5fe6b557535048842345bc464be04f4e647f1687dbd3e588b9e92cfef7c983bad78d90ef640d6bc5b1fc0e42a9",
+        "dest-filename": "data-view-buffer-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+        "sha512": "b6e8466c4e827d333dfb900d19ffa841bef62b2ff4facdf1294a47bd285f8b3d91c4c16014f8ec5ee44b05532dbccb35e5ac1ee394916fcdc3eb01f87b0eb095",
+        "dest-filename": "data-view-byte-length-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+        "sha512": "052f0f7e6b431a7ae061d3a89c665074b66c95621e08614ff6da5a9f4862d42a3666bd8d2800ecbc6600f17c6e1bfe145a027a0a3b6ff9826707a30cebd40695",
+        "dest-filename": "data-view-byte-offset-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+        "sha512": "524ab4a306d05f16bf537106b6c755064475c3b28e43980806a747da192f927cd93d8bc1c5bfda6ba13c2fbb668c5b64c1906edd45c16e32203e8fc4cf8c5a36",
+        "dest-filename": "date-fns-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+        "sha512": "d8fd29d29146cc74b910c9e1771422eda24dfa23217ae7745211b87651350cb025bcbf091e32494d7fc24a6e095f057429ae671a4df30b999c6f96d4414c7130",
+        "dest-filename": "dateformat-4.6.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+        "sha512": "0858f3618022e1385f890be2ceb1507af4d35c7b670aa59f7bbc75021804b1c4f3e996cb6dfa0b44b3ee81343206d87a7fc644455512c961c50ffed6bb8b755d",
+        "dest-filename": "debug-3.2.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+        "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+        "dest-filename": "debug-4.4.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+        "sha512": "1ada50601dbcdcaacfa7a9d1c39d2add4f7f55f3aeb5939ed74dea94dec13cfe80776ef16273885afe253f3a3c1c200bfa6319a1f27d284cb7d1faba31f68ae9",
+        "dest-filename": "decode-named-character-reference-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+        "sha512": "696df9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309",
+        "dest-filename": "decompress-response-6.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+        "sha512": "648c299debcebab4bc6e94f8d7ddaca80a3058cefa2432921d8ccc2edcb7059192b3082aea905a1f70e10925b9c5501920267229d3813e3c30c39c1f813ffa3c",
+        "dest-filename": "deep-equal-2.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+        "sha512": "a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+        "dest-filename": "deep-is-0.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+        "sha512": "dec52a6cc11cefb5eaa5d34eec547246883e796de987e19809b8feacafae63244cbb0b15cb4acc895b4f9fe40994a16f58fff53d8a5aa6a627d0c7b6927167f8",
+        "dest-filename": "deepmerge-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+        "sha512": "c75542c5d5f8b7ef3055f775b28ffdc3ebd0e2fc7b94a776429e6d0d1bad12bc2647ce4e8267d7ed194b44c59a7d1318ee16c489721bb9d36b8ce00f6bf84bf1",
+        "dest-filename": "default-browser-id-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+        "sha512": "1fd2cc2ebe73c086d2c6b9af8a41ae23fe4a1a167c136cc7decb643203392e93960eeb463362596a3e3ad147677f56bef78eb373b60182ba845b06e4ef31ef1b",
+        "dest-filename": "default-browser-5.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+        "sha512": "785b9a2e8cbf4716a5bf692bfa5a8c9549eb0d657ede3e299633882602c8848d39f0841f589eef5e1c84207bbe1ed0bbdfc9251802d8c4e2833b46d03f7b60f0",
+        "dest-filename": "defaults-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+        "sha512": "e2dbedb5ea571b555a606ad189b93913025dd6de2e76e9d239531d2d200bea621dd62c78dfca0fc0f64c00b638d450a28ee90ed4bd2dc0d706b1dcd2edd1e00e",
+        "dest-filename": "defer-to-connect-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+        "sha512": "ac132f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+        "dest-filename": "define-data-property-1.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+        "sha512": "0ecd3da8d87ccb0de48528e22638942276865fdc65a990d8ec956bc86c5dc55ecd3debaa41fa653a943aeb224566eb778cb6b9ccec245f0d60f44236b8a8783a",
+        "dest-filename": "define-lazy-prop-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+        "sha512": "37e31e5d8a2aaf7a4e827f317f244f44437b8076a42d88e1b07856193ddf58088be08900b74883c35e108a2126d9b137d1ce575f9ab416d000dc22b97fdfc152",
+        "dest-filename": "define-lazy-prop-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+        "sha512": "f109902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+        "dest-filename": "define-properties-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+        "sha512": "45e1012a421f7b8c9ae3bc253d87ff82ee626fac941b4fc07b3d09419433f789225ad450bd92106d389e86c9f01ef2d25899d076155ea98b9eec877574aaf4ab",
+        "dest-filename": "delay-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+        "sha512": "672483ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+        "dest-filename": "delayed-stream-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+        "sha512": "d237bea8f28710ca21bdf453084a370ab3c6e9c033018826ccacb1462612483912e9e1897725499bb59a600e4409a003f702c1d93e0411eca603968555c61708",
+        "dest-filename": "dequal-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+        "sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+        "dest-filename": "detect-libc-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+        "sha512": "4f4348b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee",
+        "dest-filename": "detect-node-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+        "sha512": "456988aa17057f5951601bcd9abeea4cdbb20adffbfe7b368dba69d7e3da96013fac341c053d1f8a848c52927dde2ae55210b986b838718a9ee94fb42265b4ac",
+        "dest-filename": "devlop-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+        "sha512": "831b727ea320ec62b285099bd39e8aeccdf1b33cbf9b21fcc3e078453f905c142cbc039d7375f29aa0c33c7c750603e0b1d000e522227e89daf3d62d4404c3cf",
+        "dest-filename": "didyoumean-1.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+        "sha512": "5f4ee7b6d25093091f29fbd33c6fca4a713638c75c5026a8ebe797177c269c84119f668f0071f75710db0ce75e82477a25b3ec5ea4a1a6f10e1df013fa708dc1",
+        "dest-filename": "diff-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+        "sha512": "db130298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55",
+        "dest-filename": "dir-compare-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.46.tgz",
+        "sha512": "01eecd71a80c1be14fc70b90c4608f10798b08a326f1804c3d612e1792772fe296ae51f85c6477528568e0d7bc6f08611d76e97fe0f10ea39e5b68c116ea5709",
+        "dest-filename": "discord-api-types-0.38.46.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/discord-rich-presence/-/discord-rich-presence-0.0.8.tgz",
+        "sha512": "22954c3e3bf5e42f54be9a71bebac676fe9bcd01ce5b53f5bcba0c1f5e47bdd270189ddd05dd9b9eb27add4cb7e984547eb00cc462e2c140c79dcbc2f00b8f69",
+        "dest-filename": "discord-rich-presence-0.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+        "sha512": "f87972b728e53ca9c81bc5ee446f16be604ff31b3c3fbd72f9228a4ba6575a81202ee78fc6d0e8504887ed691d78f5ab439241a44e9aa15a9f65f2544248d7c0",
+        "dest-filename": "dlv-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.9.0.tgz",
+        "sha512": "e6e4b2834c98f8944c306c058c8c1e6ae91890219c652670bc7e553e504788a91310fd5ad7fb95f9bb38cbe540c4f320ce0ebb601e02175bc3e14ff67777217e",
+        "dest-filename": "dmg-builder-26.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+        "sha512": "65dce6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9",
+        "dest-filename": "dmg-license-1.0.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+        "sha512": "df999292ee195cad2f7c2b87103030b79e5d8368cd6a31d9d6876f17ef124abf3612c658e109977ee5aca3ca0477ccd185539b48dd7c68cd028d2768057ef323",
+        "dest-filename": "doctrine-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+        "sha512": "cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+        "dest-filename": "dotenv-expand-11.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+        "sha512": "b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
+        "dest-filename": "dotenv-16.6.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+        "sha512": "28837f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+        "dest-filename": "dunder-proto-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+        "sha512": "23cf1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58",
+        "dest-filename": "eastasianwidth-0.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+        "sha512": "babbd2c5543a5c97284e973eff1da95a186e397e1a96308d429c33c3e89f66f5756a77599009a225cdd1ab5a0610042672388b71ec8c5cecb597c9acf2ab367d",
+        "dest-filename": "ebnf-parser-0.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ebnf/-/ebnf-1.9.1.tgz",
+        "sha512": "b96d94292b2eb72f40349dd807221013800d903f27a943ceeebe85c1c73500328f7bd15175c3e9325dd5129bade094af28127827cea7a480b630b3f4a58902bb",
+        "dest-filename": "ebnf-1.9.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+        "sha512": "51e26615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
+        "dest-filename": "ejs-3.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.9.0.tgz",
+        "sha512": "273b316b72a3bfde194590caee973c6f3bb98a09701ac0ce04c593a8ba56c76b0212f6f74cb5bd3cc5aa3a3a43c22cea90c069f068cfeab71e2f34182c5215a3",
+        "dest-filename": "electron-builder-squirrel-windows-26.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.9.0.tgz",
+        "sha512": "ec111e1b3f17964ed0be2b63ef49c60106aaed64086766a6b03becc8a4996f182d2f6a4cf5f9bfc2866bb67d21a080fa165ef0927e39e9d2b73a6b4537382238",
+        "dest-filename": "electron-builder-26.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.9.0.tgz",
+        "sha512": "82ccbe53b25f0ee0f594f3ab09778408342852c5a315a877b3516fde9a8a9e3749b8a6030ef19dbc2ef890b1d51ba9e5e46d2e43b60dd1e7ed090e2b52686f57",
+        "dest-filename": "electron-publish-26.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+        "sha512": "22cfb40411c9e0dadda40622a5eaeb9a9e77a4bcb01bfc95ffa948313027871bf38ff0a69f943fa204870ba00a7bb5fef243cbc71164d1cb39a1cff78ff7f122",
+        "dest-filename": "electron-to-chromium-1.5.339.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-vite/-/electron-vite-5.0.0.tgz",
+        "sha512": "387a7fbe3765b9b36584d90f90bffedc90f7e228b9a2feccd06a6e5c455d41ea9d437ba5bd547b0e0feb3412df4b95cf205c20a012c37fdb238eb2fe0ae0f245",
+        "dest-filename": "electron-vite-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+        "sha512": "6cedf2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+        "dest-filename": "electron-winstaller-5.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron/-/electron-40.9.1.tgz",
+        "sha512": "76052a1a3a5325e2d94046ef6509678ccb4f0947ce19104d248623c3cc82d9937d3b5412d7bdabd3db6b84b91efab0bc2422c119b7f60de53adc002b774b5b85",
+        "dest-filename": "electron-40.9.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+        "sha512": "b68508f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec",
+        "dest-filename": "emoji-regex-10.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+        "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+        "dest-filename": "emoji-regex-8.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+        "sha512": "2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
+        "dest-filename": "emoji-regex-9.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+        "sha512": "11305aba8c354f7e58fd664c922a3d8e2334679c631c7989e179a364eab597f757cf796bdac467f3b9c9cb6d11ba9a928751769b71c73d2a7c4a120f409ac9dc",
+        "dest-filename": "encoding-0.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+        "sha512": "a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a",
+        "dest-filename": "end-of-stream-1.4.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+        "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+        "dest-filename": "env-paths-2.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+        "sha512": "c54b683e432081bcf430fc8f8885abd4aa7869e5898c367a48cbd44618a68dd660b11b83a65179fecf617201a1c97321b3eeafa67ba8899da4162bb714c9d2f1",
+        "dest-filename": "environment-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+        "sha512": "d9b9a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214",
+        "dest-filename": "err-code-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+        "sha512": "d85a47f50e62d91470c843f50329577ba9d82d1e4e85a2536709a570fd1d2fff8909b820ef2c84a3fb042ba1de19945fddd1695b04e16911d50295d2916df17a",
+        "dest-filename": "es-abstract-1.24.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+        "sha512": "7b79d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+        "dest-filename": "es-define-property-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+        "sha512": "65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+        "dest-filename": "es-errors-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+        "sha512": "b0f666a8705ee892224df379ab6a448bffd3c31980147c23fd712e6234eeb1eefc8bc2b16aa3134f3c4fa052aecd1a43a5327ed0d01ba5f7a79261f6ade3edbb",
+        "dest-filename": "es-get-iterator-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+        "sha512": "1d52c0096d53a691988c9f07ebf8ea1ffa6a3ad291c3ac0c96b076df17c4c66156c45aae0085829b0a0bb0ec8df7a2b86b929b98e7f902df5950edc665b7ad03",
+        "dest-filename": "es-iterator-helpers-1.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+        "sha512": "146807da1f3328d8a6f658e3edd6a79053dc20220af42a796e6f9cda041261e3e1a5a1b9f9eb2b2ce0e2848a2b9fe3dee85189cd6857428b4fbfbde34da95d5c",
+        "dest-filename": "es-object-atoms-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+        "sha512": "8fabd6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+        "dest-filename": "es-set-tostringtag-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+        "sha512": "77d4fcb9cb04861f018b5c285c27fe4c828321138b1b958293183c81e0426ef936da4cf00b91b63a75d530ee8552cbd09605145d0da2b5ea615832ea0f36de0b",
+        "dest-filename": "es-shim-unscopables-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+        "sha512": "c3ee662771ae14bf8d8d5b4996fc9d4a1a84d5e3778773db23bff92c0b1824fff6aadb8c5e37cbd8ba47491aa8e1be1e485e4afc31f5257294007481d945b9d2",
+        "dest-filename": "es-to-primitive-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+        "sha512": "526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
+        "dest-filename": "es6-error-4.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+        "sha512": "48ea7d3e1aafaa7ee3b445313d67567d6a0b9b2b7655a27a329bcff42a26cb531c78c5ea13a6f1bda4eee226b1a5860fce19f2dbc2dcf8cf3bfdcd9c3caea50e",
+        "dest-filename": "es6-promise-3.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+        "sha512": "9a0dce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+        "dest-filename": "esbuild-0.21.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+        "sha512": "6db3c1618aed65b92de8eb3a1624cb093171beae2db7724a6a5975bd1c2c840ddf755cedb0b01ab45699a1b864042f3f06b3deb686b4a24b18a0a5e81b8af226",
+        "dest-filename": "esbuild-0.25.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+        "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+        "dest-filename": "escalade-3.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+        "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+        "dest-filename": "escape-string-regexp-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+        "sha512": "fef798ef925b30ae23d728efb94c6e56c892fe1affe221ecf454d3e9c8137b1c5d1342f2fe095c7010249681ff0e87e48d16d95376e7a23dfc98e9a1919d251f",
+        "dest-filename": "escape-string-regexp-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+        "sha512": "b51acaa85c8268a89cb7984e776e38b0be844053727273109c17be8fcbaa18d5d8cec22619b19453889bb686819afe452f027070524d7a0d467958d07db32b0d",
+        "dest-filename": "eslint-import-resolver-node-0.3.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+        "sha512": "035ac761bd3ace330603174b4a43767d73c1c2e49a43488ee4cfe17724b40238f5541691a74b0f0f7767d4584c13773f265b8615bc12c7209fa9d49bb502c01d",
+        "dest-filename": "eslint-import-resolver-typescript-3.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+        "sha512": "2fc8d2593cdeecada64e0d2fa2cfd1b8b452e6ca289a4b033e824b5c8b250bb73c5a6badddbc7b08fa498a30dc059b7143996b6d474cfacd0e94d6f3d0308337",
+        "dest-filename": "eslint-module-utils-2.12.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+        "sha512": "c21384d47168fea243c97e129d7ccfe0deb33969fbf5686709463f88347498f7d064ef30718138242973236a19ae10679cc5020421d984ee95432a0153de6664",
+        "dest-filename": "eslint-plugin-import-2.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+        "sha512": "b1c0779f3e16986ef9a55f3edde45440e1d994d49484536adfbc67a6046408210b5375ccbd70312e4d5ea965b2136d8a8b8434d459ecc3d040ddc2470cf827d9",
+        "dest-filename": "eslint-plugin-jsx-a11y-6.10.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+        "sha512": "3b47749b4e1ebda37310fa125bee7d31ecdff10b742277e01880499e90b4877347fd68d4011ec120a51fcac0bab68766b6267f034a14552f0671ed16841ac7b0",
+        "dest-filename": "eslint-plugin-react-hooks-7.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+        "sha512": "42d7aea744aa535e6476871ec4534024cbc22447dadb150a355e020b5c6c54cac822a132dd243faeacb10963737eb777fe5772e873250f67b42435690e0daa20",
+        "dest-filename": "eslint-plugin-react-7.37.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+        "sha512": "b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+        "dest-filename": "eslint-scope-8.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+        "sha512": "c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a",
+        "dest-filename": "eslint-visitor-keys-3.4.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+        "sha512": "521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25",
+        "dest-filename": "eslint-visitor-keys-4.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+        "sha512": "b43e34787c40df98743c421935e223907a034786238c9a77e1b88cd260efa6505efff981f881c2a870c657ba7117eecc9254ef8a085c08f3d90bbca75b28dd4c",
+        "dest-filename": "eslint-visitor-keys-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+        "sha512": "5e83237413b07bf7ac56012f2e636c0f72111e49bb7db288506beb95e9682575198031e283620f58d9e2bfe1b08f2257cee36a56396be7ee32554663c9c2707d",
+        "dest-filename": "eslint-9.39.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+        "sha512": "8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+        "dest-filename": "espree-10.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+        "sha512": "029e86d16430714fcb1ecbcbc0e3757c0417f59a7403663a63f709065f6bfc96d6f74672838ff36c6eb3cca6b639300b10b6ab60798abb41a1a4ce443beed3d2",
+        "dest-filename": "esquery-1.7.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+        "sha512": "2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
+        "dest-filename": "esrecurse-4.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+        "sha512": "30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+        "dest-filename": "estraverse-5.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+        "sha512": "845b6a20365321467d0572dbf32e29606ca4ebec1e9088af3554dc9af93c3683a1f957919f9cba7041f36d446b59b7e9d5f22a7558a98a5ce3fa57da69d3599a",
+        "dest-filename": "estree-util-is-identifier-name-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+        "sha512": "915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
+        "dest-filename": "esutils-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+        "sha512": "9a5b1347219a3c18cf79d93a06fc3e6aa6ec5c3b680320339b930eec9814fb2551c8c4393bc6c3e0a71c8bb052f397fddef79e81e08f90bf11e062c29678cb17",
+        "dest-filename": "eventemitter3-5.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+        "sha512": "8f95b4fff5bb7fc531027f215d59f01bcb4bc1d894cb81492dc4aea4283a99a058643a7206f4c0a4aecacae2386ca8fc28e875af6607fbab9cb98b49bf56d364",
+        "dest-filename": "execa-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+        "sha512": "57286779b5dc8855760c449cfa9e81fb2d0b8d29b492b5383a024de38a85021058d1327ed55eb5b580f6fb01eeb19e85f67e4afaf97c934b13cbb3c47d5e2aa6",
+        "dest-filename": "execa-8.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+        "sha512": "67e92d4f14f0bfd20b7e0282937d8e5f79ff7687be39c2d346da8af6970bf89b0fdc9d7f556f14be5e198cb94aa9e5b8af32b8a1eb03386304311219aad3f823",
+        "dest-filename": "exenv-1.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+        "sha512": "66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708",
+        "dest-filename": "exponential-backoff-3.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+        "sha512": "7e3aae0b9f5c0fb0b25babab3572b4141b9f9197288861bcd304ee3ee8d7e7dd1c0794ed967db4136501e12fd601156a8577df665d8b3604be81074f2088a6fe",
+        "dest-filename": "extend-3.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+        "sha512": "183854f67b70b8ac865dd6415204c87bebd79d68f47e9a5412d3032f4fa275de52b5af131a91ecb27fdebac03d9ab3ebf6a343ca6e92c406198cdbc29fff5106",
+        "dest-filename": "extract-zip-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+        "sha512": "5ab937e5ef327422838ff02b0a5a3556b3d598df33a61e55e00b47c08b8786f317b0a7fbdd44f704e0fe6b30485bedf0389e058441fbcf2689085bc286362f30",
+        "dest-filename": "extsprintf-1.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+        "sha512": "9c6aadbcbae3e70d27691ead0cf7c1e1c526602aa8bb3c908b3e82e72fcbb5c0e594976b71ce966965ba897c8820e12b4dafd74726e3dbc69ab1d9f82e4564e9",
+        "dest-filename": "fast-content-type-parse-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+        "sha512": "e7c6a95abd065220c533cfb769facee9e6302419fd6408433b31b72feffd96569bfe16820114b65087df7e63aead82f06e00d1b3c9f4adfafaa8000f100b8043",
+        "dest-filename": "fast-copy-4.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+        "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+        "dest-filename": "fast-deep-equal-3.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+        "sha512": "ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e",
+        "dest-filename": "fast-glob-3.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+        "sha512": "1515ac699456109d4449535b0d69ac025a8393dea03d07b3ccb82169fa792781942a36c2cf73a4007b99b394ee3c4b646d5404472b0ba7dc6fe9cdb87c19bc03",
+        "dest-filename": "fast-json-parse-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+        "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+        "dest-filename": "fast-json-stable-stringify-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "sha512": "0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
+        "dest-filename": "fast-levenshtein-2.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+        "sha512": "5be28973676620b94fa650ff1f82bd97d2dc00701f3ed3fa058f38b952d743a12f733f4b720df7636cf52156e54fac5d639e0f5d854712ffb45a9abc228eb390",
+        "dest-filename": "fast-safe-stringify-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+        "sha512": "88f79e0ca25259fe0810e6ac555ae49d7a5a055d08029cff829ed2d9b6fb6782e58db976306251a889d9894ad0c15d7a729cf0fc3dd2e63e49ba58ff813e7600",
+        "dest-filename": "fast-uri-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+        "sha512": "1864e8c49ff0d71df6b3f0f610a343ee44e29789fc39593ff66c9c4dce150f36b5de53afa54653197de61520ad57d92c746055cefb320152ccea61c54e1c57c7",
+        "dest-filename": "fastq-1.20.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+        "sha512": "704d6ab01fd5c32428cd9faad5d1b147c2c160d65ea1f84475434648c6d00f71b0da50335fd65bdee214e846dcfc59b28e8f405967e79f4014087aad7afb3ff2",
+        "dest-filename": "fd-slicer-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+        "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+        "dest-filename": "fdir-6.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+        "sha512": "70f254e3b39a02809b834a41bf3b20a533e19a1a88e5e26387f248bbcb4f8f9abe4fb88bbd6fc901852a984eca381e11d59c8487305a210a50a5aadd045e73f0",
+        "dest-filename": "fflate-0.8.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+        "sha512": "5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+        "dest-filename": "file-entry-cache-8.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+        "sha512": "d19b7eb372fb55fd5b8b0599dbd6804625582f1ee23069c4525f71df77db07f8f78d1f35bbf3b62dba8af819b508348d0ca56d27f623c18ed351de5291e2d02f",
+        "dest-filename": "file-uri-to-path-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+        "sha512": "e608b2d8f90b618d5c3f7f69d7b11c87edb19694d12fd1cbb2939f1209b42fa0b005705382c2b9a2ed09b7362e7a9c64690fedbe1085209e6e5e8d0eaccd83c4",
+        "dest-filename": "filelist-1.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+        "sha512": "62c1a97b75872caf19622e2d583836272dde6d1cf6ad7a300f19e57786e4401d3471cff5670f405a70b48bdced0c98ad8afb50bda23d29a2f22ab73e8415b4ca",
+        "dest-filename": "fill-range-7.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+        "sha512": "65f669d6b432a78832bb1aadd59aa314655e541be6a5444ca9d2165db3d17c1f7b05fe81cdd2bfc5221bca5108373434901e6d94341f9fd1e43575d6b2a4ea2e",
+        "dest-filename": "find-babel-config-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+        "sha512": "d720fa4662c8d5705fc6e82f391c25724e9fef9b582fe891d23ab0b0eacec4c672198a94b83849d25e005dd3b5897fc54ecf5c040304935816484c759126f296",
+        "dest-filename": "find-up-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+        "sha512": "efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+        "dest-filename": "find-up-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+        "sha512": "7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+        "dest-filename": "flat-cache-4.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+        "sha512": "73b0990038d1725ea3d0f96f172d19a9743aeea48465fad53f29e69cbfb6ccf73e36d32fac5f18d1071e328ed0aa748f73bfae5a350801bbc24395882a531575",
+        "dest-filename": "flatbuffers-1.12.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-22.10.26.tgz",
+        "sha512": "b1d3b77a67ff0652df3a8816e8ac07b97835e803d1fc4f3a8cd69c0d77d22273f3b7c492133c651dca837a47ccfc82750860b96ef0e4b1f36e7cd852f21d4544",
+        "dest-filename": "flatbuffers-22.10.26.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+        "sha512": "3e30ec7bb47385c3e4209c32e6deca3d641267d7006f341771a7ec7ad4280fbb0e2514251a290d6f1ef2669d8ea2d0e7272ac371bc91ab74ed6f5f2260eaa4c4",
+        "dest-filename": "flatted-3.4.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+        "sha512": "74ac75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6",
+        "dest-filename": "for-each-0.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+        "sha512": "8085e32aab45b96120cc544903d58241e4892d90e380950e302333c6dbc5abfdfb2a88ccd41146b9faac0b2d2be2a4909982ec65831ec91ab321638cba9d37b3",
+        "dest-filename": "foreground-child-3.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+        "sha512": "c8361280d32b6aabe7c621173b8862f3cf986716870ba40acdbe4df388910930de44eed900ba62aff95599ffee5d4867c14af63b81d4f2cfe7eb1fb23634241f",
+        "dest-filename": "form-data-encoder-2.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+        "sha512": "f118a944ba25dfb6cdb366e1a15ebb7e24c4bdd4eb6cc5187054e2cb7fb0bae3a75288364011c26565c34628d641f0248418f651fe549d56a25b0039bdd77cdb",
+        "dest-filename": "form-data-4.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+        "sha512": "d57d4d4ed889a61af29ffb8b433df086d63a8caddf4eaa04de884ab34b53f948ebd56e7da28a719a8121ecbbb9a7abc168f6e0a0cd1bcef7805b8422e51c960d",
+        "dest-filename": "fraction.js-5.3.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+        "sha512": "a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
+        "dest-filename": "fs-extra-10.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+        "sha512": "0935ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
+        "dest-filename": "fs-extra-11.3.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+        "sha512": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+        "dest-filename": "fs-extra-7.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+        "sha512": "ca1950800ea69ce25428eb11505b2025d402be42a1733f2d9591b91c141f45e619cb8e8ec0b718f9989ad26b5d1ec3a8f72fe13fe0b130dd1353d431a0eb46e2",
+        "dest-filename": "fs-extra-8.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+        "sha512": "85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
+        "dest-filename": "fs-extra-9.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+        "sha512": "5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f",
+        "dest-filename": "fs-minipass-3.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        "sha512": "38ed291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+        "dest-filename": "fs.realpath-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+        "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+        "dest-filename": "fsevents-2.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+        "sha512": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+        "dest-filename": "function-bind-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+        "sha512": "7b98b0ca874e1e16ccaffc8dadcedf0d81b8aa56c8bc8e606a3cb33e76f94c2c32863029ce7421d41305a2ef5bdf449ebd8e3780224a5f27280818cc6ecb96d1",
+        "dest-filename": "function.prototype.name-1.1.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+        "sha512": "c5c901517c9322a4fdeedab6c7600c6fe835eb76f9245cac624d31e2ac4d1706df42498d6688911dbeac3f323dfd0577dd67aebd5601508883e0dccd232a9a45",
+        "dest-filename": "functions-have-names-1.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+        "sha512": "485745988262fb26c2d2f8e51cdd191951877379601340f13c04f47638d583e9233a74aa725aa68f4290ef291338b3fa631a2a3afb8038319d707267fb8deade",
+        "dest-filename": "generator-function-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+        "sha512": "de137b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce",
+        "dest-filename": "gensync-1.0.0-beta.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+        "sha512": "0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+        "dest-filename": "get-caller-file-2.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+        "sha512": "090f9b10ef93bdafea966c36e1d09e8ee94ae6933356750e14e8a356881ddca42cd3b1e7448829f131a2a6f082453d3ac5e6046e96e0c1a0b18251728ae21c98",
+        "dest-filename": "get-east-asian-width-1.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+        "sha512": "f5f4a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+        "dest-filename": "get-intrinsic-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+        "sha512": "b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+        "dest-filename": "get-proto-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+        "sha512": "9c117e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
+        "dest-filename": "get-stream-5.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+        "sha512": "b6ce968beda3de3423aa2ef4c3902537c0c59e44b00be32a9b113374400b076a976585775ff6f50937e03cb18934c7805b174f7d4f053b59acdcd51f68708f62",
+        "dest-filename": "get-stream-6.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+        "sha512": "55a509b2905f7e7fcb302255a0cbd201d9ac709c92d5aba3e59ba59e7e54a18718e77d545a67708515a47062a7194f779b91d25cff4b3f6bac3abcab06d428c0",
+        "dest-filename": "get-stream-8.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+        "sha512": "c3d50ca96c09c4734ebe8373489da83c5e70bd872f3fb8d4bd8ce1a7aef21214e2d7b6430410b5cfda53746bb38c3f84148a8b4984707998ea7e23f3434e846e",
+        "dest-filename": "get-symbol-description-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+        "sha512": "c936fef035f30d113382f62687ab3dbc7b125421de0b41b73c8e5b1173411ed9ac84f9cef92e4eeea80b10e9f423942f332ea4a5937c2b534a1b28a52dbf77c0",
+        "dest-filename": "get-tsconfig-4.14.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+        "sha512": "00e22049009ea62258c0fdc04671b1fb95674eed870587736c63f8e5e2f0d6faf7cc1def64b7b279dd6c0bd8676dc39cf7f4ab33233944f42b906cf8692f59a3",
+        "dest-filename": "glob-parent-5.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+        "sha512": "5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+        "dest-filename": "glob-parent-6.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+        "sha512": "0df5cdf037e127b347dce7bb7059aedcd0aed7029b911789f13a2bcd20056d22ab94d69048a7c8cea62a558f3395bb3634b05b5a9462539d865f63db68154d92",
+        "dest-filename": "glob-10.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+        "sha512": "5a3972ae89669bcb83a66fe8806c976576f567e09ad81f0d6c9c2a0558346b12bd19b05ea12ef2195eaf8d79d87469ba5f9de27a112ec716f288aa7c42637857",
+        "dest-filename": "glob-13.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+        "sha512": "9c5474ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+        "dest-filename": "glob-7.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+        "sha512": "7b52e5783ca4533d88bbe31361d912b2e597f25bc08c072cd1779fd25348bb44b6c0e033b93c4226d71df52ddc8a3970605d7c12c537af36fc8cf5686f10e1f5",
+        "dest-filename": "glob-9.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+        "sha512": "3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
+        "dest-filename": "global-agent-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+        "sha512": "a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+        "dest-filename": "globals-14.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+        "sha512": "ec00b24f7c26ca9dc8eb54b87c6ebcd8bd150364460fda2d92a189230354305d52594a266c8224f9a7f5ba7b83620326d3cd9a1d8c03fa6cc9beff48bbc76c82",
+        "dest-filename": "globals-15.15.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+        "sha512": "0e92ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+        "dest-filename": "globalthis-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+        "sha512": "65429187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+        "dest-filename": "gopd-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/got-fetch/-/got-fetch-5.1.10.tgz",
+        "sha512": "1b08ff03686d8ef2c4718d3b3ca0c8b6fd1608f12cddd576bd6799fbd4d50522924ee584678a1768c0f46403ac6a3c31da8ada85058de0723431f47259266c6e",
+        "dest-filename": "got-fetch-5.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+        "sha512": "ead7d9f756ceafb6ce5e72bb3d10c21812dad47e14d3cd181cd6804362ac30694b13345b938e27b1917613521e45cdefb491cf55b2826207456da18eda58ddf2",
+        "dest-filename": "got-11.8.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+        "sha512": "9938416e5be5005d5de0ee68ab2bcdf99c4b018c0824aedba4cc6062a3c3f68916d02dea9b91459fb93cd7542b72e101c1aa204779e0385a027ecea646feed79",
+        "dest-filename": "got-12.6.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+        "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest-filename": "graceful-fs-4.2.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+        "sha512": "477a5ba64708aafd8f9b7754c208dc943455996a53256d8370ccdc221117131d6887f08430e6cc9b728b99124e76f84cee8e2e4019f0afca7344adac25622a7e",
+        "dest-filename": "has-bigints-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+        "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "dest-filename": "has-flag-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+        "sha512": "e7924d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+        "dest-filename": "has-property-descriptors-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+        "sha512": "2882fb7903df1d0442f3e5e5b9a230ec11d4c30a8bd7d6d09f887336076bfb5c17a14d0a2a3eabb9fbb8ee5858eca6c94760ba4faf8f7f237411aef09124bea9",
+        "dest-filename": "has-proto-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+        "sha512": "d5c0cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+        "dest-filename": "has-symbols-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+        "sha512": "36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+        "dest-filename": "has-tostringtag-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+        "sha512": "d21254f5208fbe633320175916a34f5d66ba76a87b59d1f470823dcbe0b24bcac6de72f8f01725adaf4798a8555541f23d6347e58ef10f0001edb7e04a391431",
+        "dest-filename": "hasown-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+        "sha512": "ce5eacf0bc0dca8d4ff6ec3e5c91af66d74517519d0243a0f2e8cec3ee0fc9befaf3be1f2e9b38b9e1d70e15d6764e981d0e8e814b629e5886ed1b18bc26db06",
+        "dest-filename": "hast-util-to-jsx-runtime-2.3.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+        "sha512": "f3c254374ea2a4bc2c9eff9d567f8e2183af02ebc1332fd0a22e8eee6407c5d3d7a63cbe09deb14645b0bb1ec328efb8b1820bb4b05120a82c7694b681073bab",
+        "dest-filename": "hast-util-whitespace-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+        "sha512": "ef18289945fa00399c6331629341f303187fef7625291f5b985cdfe75099c11f9be98b735369b4bb8f61402a95e92be5a88aac6b1a2f7f076f6e7b30ddbff3a6",
+        "dest-filename": "help-me-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+        "sha512": "d3052809c2e9fb912fe690d6d8eae21c2d8c2426f02f0b91c7e800a8c4ce9062892620422e3b6bbf2e0f5941a7e8c21579f79c469ce8399fd457a88674eafe0b",
+        "dest-filename": "hermes-estree-0.25.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+        "sha512": "ea9123aae1f7aea688e9c6005d83dccfd312e2b63a4789e0460ae07c3b21469b54648737970d0c0882481838fdfbe99fc923ae3d31c1e27ad25bdf410af38f20",
+        "dest-filename": "hermes-parser-0.25.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+        "sha512": "b7371415aba2b1628d1da4643785a397f640d3b8043408c597727f738f34769ae4193839110b2d81a345a817d4a82ab9e2465120472b793b00805fe6daab83ec",
+        "dest-filename": "highlight.js-10.7.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+        "sha512": "fe01a2bf18bc24f296366fd6d234a6cdc30fa5fa4f2dcddd63fe86c615f6850f621a3dda0df925578113ecd8caa528a72e9279bda7daf62886204660d7449f07",
+        "dest-filename": "hoist-non-react-statics-3.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+        "sha512": "9320ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
+        "dest-filename": "hosted-git-info-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+        "sha512": "a25e943f2056aacacee8427248fcf63bb652afce7a583ac4ccce7332aa7e14924b18c5b7e5c2d89a6667974bf3b40671454a0d6491530a885f8ee209f08e1005",
+        "dest-filename": "html-url-attributes-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+        "sha512": "753c5cbcf5ea3ef5c1429ab9754afa9843095f8a08105bfa6f0a26dc50f02910ecb888e324600daa106ea009fd73545024874029abf7dc40fae44db2b3ef3b41",
+        "dest-filename": "http-cache-semantics-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+        "sha512": "4f58240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+        "dest-filename": "http-proxy-agent-7.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+        "sha512": "102daeb53a1697844a7ece73777e8cc6aee7cc71c1ba89996e8234c982fa6344660604fb4a092ae2b4347b315362822c4aced39bd4897bea3615c020e8606118",
+        "dest-filename": "http2-client-1.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+        "sha512": "57edb7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
+        "dest-filename": "http2-wrapper-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+        "sha512": "5799d5c353c03a07c8dcb99e6a3d84c667a0edf7a78e1454833d653d27b3cb50ae84f61b810b5b423e2365f10010c95a2febeea6cbe18ea0b28f3a1bd32c6c99",
+        "dest-filename": "http2-wrapper-2.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+        "sha512": "7457008e94d0160a0b3330b657053e0bf09b4bbb912f49569b10c84e6aa6ec2fbb17439d9a3eacf65e9a95973a0042d786b9e080cd827964971c639d5f662dc0",
+        "dest-filename": "https-proxy-agent-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+        "sha512": "bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+        "dest-filename": "https-proxy-agent-7.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+        "sha512": "48442eeef97c2a334bd9ea0604b177fb0023a6c35f03d5cc9570188ffdc475a35f025c4ab610f5c631107c6394865942186255358df86d1afa94f20d84d8f267",
+        "dest-filename": "human-signals-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+        "sha512": "0177196fabf3ceb140504eb51e73789a92ea77f7122303508ed3564747ae3e6eb2d22ab1dc6e203976880ddb5d0f06668707bcd8b03afb38a7996e1405655e3d",
+        "dest-filename": "human-signals-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+        "sha512": "e60b39cad68d8c1ae1e4ec37cebbdd51463ed15c48b9654be22f62aede9fae257e06a7427e6575d4241358c8816161db5e1728f89d641df4ce52478f8420ef30",
+        "dest-filename": "husky-9.1.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+        "sha512": "5830bfba2d95551af3de33958be5ed8ea9038e25634ed15a006896dfb93a6fea21c90e7060338692f0996bcf87d27c77832befd3e0524fdc6e3a0232190d3483",
+        "dest-filename": "hyphenate-style-name-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+        "sha512": "4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
+        "dest-filename": "iconv-corefoundation-1.1.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+        "sha512": "e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+        "dest-filename": "iconv-lite-0.6.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+        "sha512": "75ccaa843bd7d42e3a95765c56a0a92be16d31141574830debf0dfe63b36ce8b94b2a1bb23ab05c62b480beeca60adbd29d5ce2c776ef732f8b059e85509ea68",
+        "dest-filename": "ieee754-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+        "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
+        "dest-filename": "ignore-5.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+        "sha512": "1ece7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a",
+        "dest-filename": "ignore-7.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+        "sha512": "b7bc5c9b6b22c3e86550cebc23e50438afb3f3847398de7d6acf4367b3f5974f7de03294595ed45c1310655c5aa0c49143e3c165b1c23a806dedadb0c4e32df8",
+        "dest-filename": "immutable-5.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+        "sha512": "4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+        "dest-filename": "import-fresh-3.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+        "dest-filename": "imurmurhash-0.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "sha512": "93dd88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+        "dest-filename": "inflight-1.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+        "sha512": "93fbc6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+        "dest-filename": "inherits-2.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+        "sha512": "35bd9cb4ec8d47c0ea4284743b0446f79b8d5880b40b594281fe4d6b3e47e898bbd8a67c39c1592f3d8fe6c360c25ca827c6227f5d6832e62ce690506bce9cb0",
+        "dest-filename": "inline-style-parser-0.2.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+        "sha512": "e2077b56958d40d07850a28214555ca75015bfe14c3a0b3d34ace31cabac73c8d332177978bd4da90a8ea44d0accc76cf34e3fc87960969deec6096e3aa00f2f",
+        "dest-filename": "internal-slot-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-2.0.1.tgz",
+        "sha512": "6acb714cbcc87573de3742bd46e9a2e8b7cca66debbcd3b488913e87f93c2abfe2b3ec0f6d17b88a4c838e52ebe954e1fe611f36ff118cdfa0bb72b00e2ba1aa",
+        "dest-filename": "intl-pluralrules-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+        "sha512": "5d70031f15e6bd3f7e091c615e0e7a2c9a2f13e6e65a711607bf0b07cdd5653a6b29399a0b941faee5e8731cd36762a5d033702ae05d9488632fc2de63c49ff1",
+        "dest-filename": "ip-address-10.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ip-num/-/ip-num-1.5.2.tgz",
+        "sha512": "094c47109b8993be0621003be4b0fd4439292bfdcd26ff32467b1e3a1efd0254661704f51e060f2833a256477441547930dc0c8fd1273a74b5c899fd09a60d64",
+        "dest-filename": "ip-num-1.5.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+        "sha512": "156cb263ad0c79337279246990cd88af2d06f61a6befff640f8d260ff706404ba295c6584b8a24cfc48dd90eab2c227c81b0ade9f37eac2fbab4c192f7d2dac5",
+        "dest-filename": "is-alphabetical-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+        "sha512": "8666d8857ffd314305e6e87bb4e5f22bf9f466f5a969de5c681035ec6b02eafcae0aa696962446e4ad6a4bd8a799484431a381216effc210274b0bde5bf2ed67",
+        "dest-filename": "is-alphanumerical-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+        "sha512": "edb55b8b486e8ffc2b2003b36fc5356acce0f64762dca37f0b2535f424c8eed028658119a0bf720835e96d737eb8fb2e5a73f4d9ccae8358257aaabe4d4f9808",
+        "dest-filename": "is-arguments-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+        "sha512": "0c37c03548a21b6c02d6a6b03faeaa953ba025e2f91f2ccca5fafc94b2be8cc422ac6ccda1dd01d7670507ff6af37f11bb6eec0707f0efcfeb76853b444473e8",
+        "dest-filename": "is-array-buffer-3.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+        "sha512": "f5d80cfdc6419cdbe3cda3181d5a31c5f3e3d905eddb612fed2bae3ebb3ec5abf4ba4181d12e9de3275974488ce3c90bc7990357e4013eba559c5c9e7cbf2491",
+        "dest-filename": "is-async-function-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+        "sha512": "9f8653dfbc06efc8b3d37c4f44a26b1d37596dedc889ccae704b5d46c579ca09707371b251f6c07e949e0f4149e3535b50d4ade706e1a9fa757d2f81827bc315",
+        "dest-filename": "is-bigint-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+        "sha512": "64c11161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f",
+        "dest-filename": "is-binary-path-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+        "sha512": "c1ae7aa36fc4949318aa30a31a45eb8bb8ade456de6d6e6eb0bc3f9cf98232ce43799edece24986614a63d19f4b71a9e5b82e702641053b160a8ba6c10528ce0",
+        "dest-filename": "is-boolean-object-1.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+        "sha512": "80d0866e79e79c501418a799f4f75bc9e19826a7b0a6673668a1d410c3b99d03d653d94e9afee3726408bfea870fc7d75ba5bba9fb82c17e2b63d2cd4635eb91",
+        "dest-filename": "is-bun-module-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+        "sha512": "d410b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c",
+        "dest-filename": "is-callable-1.2.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+        "sha512": "51fa1e300e9f209f304d81445237a59da188ebbbfaf8deea5c912f42e2066bdf65e31b02aee498395490d2e3c0367e1d0339bc96460f68a2ebae28cbabbc76df",
+        "dest-filename": "is-core-module-2.16.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+        "sha512": "44ab5617ca46992f3b8b60fa82a42efe5ec461195575fcde98224dfcfdd43acfffc75404ee67e1bf31c802905345fedac6f4fa0cc1b04b00576024f49df07dc7",
+        "dest-filename": "is-data-view-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+        "sha512": "3f0c2111a90754a4dd44d54ec3efc6ca1d3e33394297847aa8abe486ebcbb4f320808d56007b7db0ec19c502d21a951a0e7addc83b289a846036709f28d4975e",
+        "dest-filename": "is-date-object-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+        "sha512": "00007d862a2642ce435d6711075aeab31194b2d6d1ae814e3cf540a26364ff75c74792721190a13b24d67b6a1ac8a9ec4acaff91c1aa17ecfacae1fa1c7a4dd0",
+        "dest-filename": "is-decimal-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+        "sha512": "17e8b604ab05ac7eba89a505734c280fcb0bcbc81eb64c13c2d3818efb39e82c780a024378a41ea9fcfcc0062249bf093a9ad68471f9a7becf6e6602bef52e5d",
+        "dest-filename": "is-docker-2.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+        "sha512": "7a58dc8040e5127b3fec05c5a2c0792bfda708ce0fec540f90673f0d62f2e6b985116bd96b21ab8a4d5df7f4086399c9e1ff58b15bc1900ea42691e7f6b21275",
+        "dest-filename": "is-docker-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+        "sha512": "49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
+        "dest-filename": "is-extglob-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+        "sha512": "d690ba37ca9625b5a83ed12381c2f6c7285038fe3dd44423794a37a9329c995f184830c9ace7a97c6f29702ee1fd0827407612bf4989dd9fd95b199ab55af2b2",
+        "dest-filename": "is-finalizationregistry-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+        "sha512": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+        "dest-filename": "is-fullwidth-code-point-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+        "sha512": "3b82f4f78376fdd67bc6a55dad7861f6bd4a3833c9a459acf01e6c19d24b3f2ebae0082f5ecade654c82410348b59443958ba0e314ad2e3369feccf71ef068c1",
+        "dest-filename": "is-fullwidth-code-point-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+        "sha512": "e571d8692ca2a800dbe119d9d4175a77a70fa7c4e88ac7b84f312370e6031d991309b2a089497b593502a4d587bb1983b7dd709ec64173dc629cdce8a6fdc931",
+        "dest-filename": "is-fullwidth-code-point-5.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+        "sha512": "ba9aadd5290690e0d6f6db06346e66b574d7b440a2cf0b52da4035eb533e8093dcd7175bfc0c7adbd69fe98ad3c1c39e4076dec2b3cd944e43c7b933bd74e2cc",
+        "dest-filename": "is-generator-function-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+        "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+        "dest-filename": "is-glob-4.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+        "sha512": "0e0650a76e3573ca0ee9c03549b4c45a25dea31578daf95c271807f81de18b5022aaa2abb9947764617c227ddf8f8fbfcbfeeb1ef94e64b66d809ff8b6d60666",
+        "dest-filename": "is-hexadecimal-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+        "sha512": "8d86ba43dac7f74911d6f281e8d33baaa7759a07b7171e03870e535652b531406a8443ae09a82b10731ebcdb8271b1029976744e15e4466f989abe751f010f03",
+        "dest-filename": "is-in-ssh-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+        "sha512": "28860b08226085f1d9c6a8d8044eeb132d0e06e4dde710874bbb47560bc22e4c7b4ad2286b1c0d5b784200b80452315f79193e306fd0c66a7fbed113105ded44",
+        "dest-filename": "is-inside-container-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+        "sha512": "d87bc810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb",
+        "dest-filename": "is-interactive-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+        "sha512": "d5079dd3f1ebda6f98ab19ccd3d0a303677f8ba61935f17a476a1100e8f7e9e51d4baa8857f86e3c935212929bba97b016cf99b09971b238cf6dcd3f69f5ba2f",
+        "dest-filename": "is-map-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+        "sha512": "e4aa08bb6360a727a4ef98d7a1d16f9da7c1e83260af7bbcbae2b42c46498eb535f43acc0f7115111691f2c8f3f0208682966fc4f97d4ae13518c54f147c759b",
+        "dest-filename": "is-negative-zero-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+        "sha512": "95985c96e984d46e95603f151dedf9c0568889ff824f2e522488b9fb7cb8a6c0e05aee303c3a01845f0dc543a29c473ba478224ec4fa31a05bf76aca8610fe5f",
+        "dest-filename": "is-number-object-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+        "sha512": "e350a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e",
+        "dest-filename": "is-number-7.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+        "sha512": "f8f822faf32e50d909c84c62301b792251683322a7af9ce127852ca73e7c58e841179428219905c8d1c86c102d1f0cd502093946d9dd54db0344deb5fe6983aa",
+        "dest-filename": "is-plain-obj-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+        "sha512": "32362c2873b93bb982b26446c5670b5a1785a8df4327fd939a782f8ca5e285ee9e7d588fa9cdbbe3e171ff87d88ffaf4dfe112bc17535cad15ead037ae07b3d6",
+        "dest-filename": "is-regex-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+        "sha512": "88f0237abaec7b6effca018bc70f84051f5a82ff58eae2de61524cbbe40d0a8a2e275ff5ae2d261ab716a5f0aa159bb3cf1dd68edc311b4f7c5fe9f83ae4643e",
+        "dest-filename": "is-set-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+        "sha512": "21259a73c76bbf86467f02a5e6c9691c6f4ec0f36dcb88ce58f448841a713a80fe86a2138b0ba2a4e4366cdb61033c00dc1e1f2233b83659fbe0dd12f5bcaaf0",
+        "dest-filename": "is-shared-array-buffer-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+        "sha512": "845a222624e5eb79e7fa4b2d1c606d7b05922a740ba726f5e7928785e035977f6ebed3bd9d6228a75a77b9da8f71477fc5b17554b30ee27ece23aa7b45b9e00e",
+        "dest-filename": "is-stream-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+        "sha512": "2e7411e1b67d2000c345292fa6a306bedfed10959c9739253604b0e3c57910068078377aa86bcdf1e8ba939a74b6fc52475ef55661b21ee4e200e7f101bafc90",
+        "dest-filename": "is-stream-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+        "sha512": "06d11e4aca1a4239523c17a631022b635318d2e33abe74b58397e6b9f60eb67c4b19464cdb5efc3ca6e1b24ec57efe7c217f99b5cbe81b071c62c8743e096400",
+        "dest-filename": "is-string-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+        "sha512": "f601b1e864ed09033bdc18261d05df0e62ed7e38d35034b2a314c26e9e56b688b10217e0b038ab58871543f207a6f2395607798bf27917b07d70dfd69556c2ff",
+        "dest-filename": "is-symbol-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+        "sha512": "a7711cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381",
+        "dest-filename": "is-typed-array-1.1.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+        "sha512": "927c46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f",
+        "dest-filename": "is-unicode-supported-0.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+        "sha512": "2b9a5760e9bdc2a6354608e92f7613905dfdb678b55da8d42246b04cb528f446445541606b981240917c9cd4bb670250d36cbed5808d61c321f8721fd59a84fb",
+        "dest-filename": "is-weakmap-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+        "sha512": "ea2f661964a5ab334c12aa42a7ddcac114b5b943a8764d8e27a6feb2aed93c34b2d96b88e4d148c69ff6e784f2b51f1fb5e7dec645a7e713621d43693ce7d27b",
+        "dest-filename": "is-weakref-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+        "sha512": "99f7306fa23343238a4ecf3809032b3b05b881071a4ce016274cf32429765923c3ad693f3b30da2265851f77635e16f6e20e1eb9d65f2d1a3302f3c6c3877d85",
+        "dest-filename": "is-weakset-2.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+        "sha512": "7cacc0adad2b18951407018180d90766e4e865c9fe4ed5c7a5e0a09a430930c631d6c40361a092ca32414826b69c7d431a6eecde7d68067a21a154c168decbc3",
+        "dest-filename": "is-wsl-2.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+        "sha512": "7baaef7540a240202eba666c971449591fc3a2ae15a4f47cda4a9c96f712d1e7e0b78df44a5188934e6f742379f3e56bce0b4871f34e0e3a335627a5c9c0f84b",
+        "dest-filename": "is-wsl-3.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+        "sha512": "c478e10ebddc3412b40737542523d7667b50531fe6c0c4b9470e00ee53c9f745c600ee8848ffde3c336ea34be1a8e654f940f9268a1dc02000a1941ddc57802b",
+        "dest-filename": "isarray-2.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+        "sha512": "887aea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb",
+        "dest-filename": "isbinaryfile-4.0.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+        "sha512": "827583d78261dc5cd2dc23e117403134e27c0b1a9e6e53d3003cc8dfcaf4c2df19c9097979da72ef99b2b74f041b6a0abe9ca2a92aacc7e5a4cfdbed91b4ea61",
+        "dest-filename": "isbinaryfile-5.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+        "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+        "dest-filename": "isexe-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+        "sha512": "e81ded2ed16ab504b87a46abbcb54c67e5fe565bd07a46dee2d69491ffeb8553b777f874336adf0119bfa572dc3c4b238ccb0582b1604ab85023171256b073f3",
+        "dest-filename": "isexe-3.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+        "sha512": "1f476442809addbd9511e29004ec45a61f8901b72b41d13b282d1492ac292e6bf6102e0fe354173feaeaa3dc18a1d002886e7f58ce6cf680c0a5353cbadc23f6",
+        "dest-filename": "iterator.prototype-1.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+        "sha512": "386959429cf6c9f6a103f45dd58f0277d48812caaf5e42d5a12c3f720c219e114c0dbb1015e658a0927b6c86414bd05c6a6516f7a6acabf9e93d6ba033e45007",
+        "dest-filename": "jackspeak-3.4.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+        "sha512": "c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c",
+        "dest-filename": "jake-10.9.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+        "sha512": "fe298a346e046d636b563a0d0bfd47e7ff46172fadaa31811c2692b0df8fd919cfaa3b0b9afe940f7123f8a8fc9c159a440c3293b90ae5951cf8e11ab674d1dc",
+        "dest-filename": "jiti-1.21.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+        "sha512": "7a48a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85",
+        "dest-filename": "jiti-2.6.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jotai/-/jotai-2.19.1.tgz",
+        "sha512": "b2a9bd955662a811d91fc692464df60d28990c7637c94225ba55d89fd1908fbfcbbe851d61748cb62ed93c91a8fbace3cca16de5adb993f23a8810a2e373c973",
+        "dest-filename": "jotai-2.19.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+        "sha512": "df8c01fd8ecc5bb6f38ca46350a4dae3a23667b795eb646486f6be2a4a295bb42fbff392581aaf91263bbeeb0e3eb36e65c506ded029bdd560341f0f3a3dd23f",
+        "dest-filename": "joycon-3.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+        "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+        "dest-filename": "js-tokens-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+        "sha512": "a90293e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+        "dest-filename": "js-yaml-4.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+        "sha512": "fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868",
+        "dest-filename": "jsesc-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+        "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+        "dest-filename": "json-buffer-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+        "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+        "dest-filename": "json-schema-traverse-0.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+        "sha512": "34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+        "dest-filename": "json-schema-traverse-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+        "sha512": "05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f",
+        "dest-filename": "json-stable-stringify-without-jsonify-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "sha512": "642960e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44",
+        "dest-filename": "json-stringify-safe-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+        "sha512": "83531630b062cfc14a8b57b8c3453254bdf0fa225c7960050406819e718a3a935ae5ff132e4b646eb7b5facea8202c9d5809be1d15064e623efffc6fda1bd760",
+        "dest-filename": "json5-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+        "sha512": "5e63967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+        "dest-filename": "json5-2.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+        "sha512": "9ba175477cfc8e395fda29901d2d907b3e6c8ca590cdbbae86e27f14a605459bcf1373ee1dc48c559cdfb0b84654e91f776d286cbe5258405ec394a196ab8dc6",
+        "dest-filename": "jsonfile-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+        "sha512": "146b8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502",
+        "dest-filename": "jsonfile-6.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+        "sha512": "659a30f47048e4ee843e04892d46fc9f634a8265564f00af1c6c05b8994c8ef2c5aa5186ea98e2acf86d76cb1e68b6634a26c3f1e7a0ce6629519c282258f671",
+        "dest-filename": "jsx-ast-utils-3.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+        "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+        "dest-filename": "keyv-4.5.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+        "sha512": "793233955392511f89c5d0c57a911870132d67d42a75e7feae7cd675166e31b3b2c2ee6d3b6c3637baea8e800d67993dbf2c212fa06bd55463508813431e04f3",
+        "dest-filename": "kleur-3.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+        "sha512": "d0aeb92de6bcf35a47a2da0611ae600e5331b77a5cb4b8b64699416fb133878ad174b10eb608bb9f81302bd95a9a750290a06a69e29155e6d3aba040c529295d",
+        "dest-filename": "language-subtag-registry-0.3.23.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+        "sha512": "31b8cde34f1f12775f8905db150d6f9ddfb53682c3b27416e35e35d284015e2c970cc607e73e74e63b966b82941352eac510bb0e03a06436ca2f11c8c26dbb84",
+        "dest-filename": "language-tags-1.0.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+        "sha512": "d3f06718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9",
+        "dest-filename": "lazy-val-1.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+        "sha512": "f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
+        "dest-filename": "levn-0.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+        "sha512": "fef945280a07e4282ddc87be24b8516f03ac09078f001894ded2757a01afc90fb7dd1fef730336665d9047f2f38ec05e22d3edde84955daa67fa6e27403be9cf",
+        "dest-filename": "lilconfig-3.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+        "sha512": "ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406",
+        "dest-filename": "lines-and-columns-1.2.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+        "sha512": "61448e2eaf55791340a3f0936959a1183286f8b06d03c285d57e0ae7eca4312c16493d6f0f125107692fd823a02dbd5fbe90a8f80ff2f40d06d339cd566771e3",
+        "dest-filename": "lint-staged-15.5.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+        "sha512": "2d6cd7d8ab2a701d70a90e001e061be11b035dab908aa8632e4fba8636da7871b8ce98e354007ac02fe0cfa5f497e0eed5c377a54079665aef4db84648d9d441",
+        "dest-filename": "listr2-8.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+        "sha512": "ec03bbe3cc169c884da80b9ab72d995879101d148d7cf548b0f21fc043963b6d8099aa15ad66af94e70c4799f34cb358be9dfa5f6db4fe669a46cade7351bae4",
+        "dest-filename": "locate-path-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+        "sha512": "88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+        "dest-filename": "locate-path-6.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+        "sha512": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
+        "dest-filename": "lodash.merge-4.6.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+        "sha512": "74c22789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1",
+        "dest-filename": "lodash-4.18.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+        "sha512": "f173efa4003cbb285fb5ebbca48bd0c69259ed2618769522bd9a46cbab05b01b8a458ffbad019abde75e07c68af99932ababa930554bffd016eaf398cdf4722e",
+        "dest-filename": "log-symbols-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+        "sha512": "f627bc22d3d1ead8d8e6e60987c2bf66bbff44c67954e94e5afb597441d849314a65f2013d06bdb4e0047805a177e02722778b276db0e5f8ce62da2eb695aae7",
+        "dest-filename": "log-update-6.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+        "sha512": "f518bea3425881e8536950410e832a225f065ed6d683bd753b7b2b7ed707859d1daa7113a8b6a820ad31d7b7d4c3dac54a52bfd0d96c29ed00861ca5e695c4da",
+        "dest-filename": "longest-streak-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+        "sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+        "dest-filename": "loose-envify-1.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+        "sha512": "b6a357ad2efca0c384ef734cc4ae0430b42c428c167fc8caa281fd83bc4f6af453ef4e91e9b91027a0d8d937bb42e91a66cba5c5adf4c10edb934a66e1788798",
+        "dest-filename": "lowercase-keys-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+        "sha512": "a33082ea0750fa0957390b2f78a0f462c0f2f034901630d3cf8cf2cc41cd579f893f90fad8b99f0d9ea8d5cc9c171f68b86f78d0ce5d13c0bc0937b0763d9859",
+        "dest-filename": "lowercase-keys-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+        "sha512": "24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
+        "dest-filename": "lru-cache-10.4.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+        "sha512": "371545c0b027addf62eca501c42e03ad4866823cceb3ed509b9d03de8175fe82feaf5369678800ef1bc6d3fcc9f1ebd1ef320a9f8bcb7fba9335db9616d0ab47",
+        "dest-filename": "lru-cache-11.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+        "sha512": "2a9340450037230bfe8d3034bad51555bae1f8996baf516fd1ee7a186cc014e5cdedd93f16f89a0d6f0b1e62b9d8395c1f858fda7ea023cbcdd5a7ac045828f7",
+        "dest-filename": "lru-cache-5.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+        "sha512": "268e9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
+        "dest-filename": "lru-cache-6.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+        "sha512": "69f3b69a7c56ec60d35cc9b9fc0a0dd56b8e71da0a86d8178c8bc79a86ea4c3d60acda6584676fdcf14eca30959ab9ce641213fe00ff9280caa581bed26bc772",
+        "dest-filename": "magic-bytes.js-1.13.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+        "sha512": "bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
+        "dest-filename": "magic-string-0.30.21.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+        "sha512": "2124137b9e53d9aa3b5ed9404adb9deaac183d98c4e062b54bf05e54fbace23aeae89b8e9d0d3460a402e7cd515a1475db65bb9ac655dbadcacd578ba2a89dc9",
+        "dest-filename": "magic-string-0.30.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+        "sha512": "b3c52194d7bbbcf2a8990842d6a15e94ca24aff49cdc080d6eca379fbe2654f0392d3670901f4d9577f85cf6a62f1244f21d2087bdeb33de31bf0453d825489f",
+        "dest-filename": "make-error-1.3.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+        "sha512": "40c8c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5",
+        "dest-filename": "make-fetch-happen-14.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+        "sha512": "c22633e3e26b2f26ff0ea5b6864149c4fed577b26e4c39bbedfbdb33c55f11076648ca9c22659e7916c7c198c18c81648bf55a30ad818458bba1451978ce5bab",
+        "dest-filename": "markdown-table-3.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+        "sha512": "3a478368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
+        "dest-filename": "matcher-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+        "sha512": "c2b669a13e747a160eb9d8438edfd8bd425ce9e53371d14f7666e2cdf82fb3008a3470f5fce04e1d82691e27be1d7a6ee9b4a410689e14c624e95baeb5a8917c",
+        "dest-filename": "matchmediaquery-0.4.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+        "sha512": "fc85ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+        "dest-filename": "math-intrinsics-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+        "sha512": "4e6775560fe6dd7cf8dda7de3710c885646d15980cd952f269fe2f493630b9d4f27ae4e77a82f7aad58c0398de2f2cff3b5bc3266995e10b92705080dad04fc2",
+        "dest-filename": "mdast-util-find-and-replace-3.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+        "sha512": "5b8980593bd294abdff0be89f9537dc8b4aa43d00e000bc7ba80c098f933e1d1dfe79de6e60563d9e8da747261a0999c9b11273afe8f6bc5c9869c44f7791bf1",
+        "dest-filename": "mdast-util-from-markdown-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+        "sha512": "e4754fd8c29a3fa2fe1ba61ac4f363b8bd013ebabda2b1b74ecad9f585db037bc3c3f002238304b27a03a67e99366ec69d982d01c38d2723e138ff2d34941abd",
+        "dest-filename": "mdast-util-gfm-autolink-literal-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+        "sha512": "b2aa435a5b079fb01cf4635940c794ccf41233347a5afd1629136f4118342aa1e1d367e94f3ebd41cd504ac78d5f6f5b873d51388c8dcb11317dac152939b519",
+        "dest-filename": "mdast-util-gfm-footnote-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+        "sha512": "98a29bf75e5317e382e69b63e5b27b58544f758b6e1efd324d1c4adad26f8be043a9b9221bb87bbbff5223cf6744061c99aa76c4740bf43f901bfeb04ab4ed5e",
+        "dest-filename": "mdast-util-gfm-strikethrough-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+        "sha512": "efc504bde6f3cffac92312ef13b66d0ddfef210d111effb7321e4347dea9edc4bb1ec0616082020c10aef1cb1335634eead0567ea5cf59e911ba3d8534e18e66",
+        "dest-filename": "mdast-util-gfm-table-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+        "sha512": "22bb6f36f8f10b5a34ead6810152739c49e4887c4b153ce0a2751dcbc873155783ba7d2e4e3c71ad119568d16a914d70251dd104f11fb31994ea30d63e87eb4d",
+        "dest-filename": "mdast-util-gfm-task-list-item-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+        "sha512": "d2e95f75038cdf2b07842275a74ea5d1bd152a5854d30b90b37b61c5941a8237233eb94546a636d79b991871c96a7f461005ddf4c6df3e3149cfea8c91547acd",
+        "dest-filename": "mdast-util-gfm-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+        "sha512": "27a7fef61529fa575366a2914a0ed5c3957a32a8c04dcfb713881fdc214d72e64d583f1777223acd0f06a87edff35ebd30ce8fee13014435469e7ee81c1f645d",
+        "dest-filename": "mdast-util-mdx-expression-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+        "sha512": "963ff3f2fd2be99b6c37f70634db5e9a699fa0b0056678cc6cdc8bcc169f8f38a438cfa096b8cd1cf95fea540339371c8fd9f96f43cf8a11016e19de3321acd5",
+        "dest-filename": "mdast-util-mdx-jsx-3.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+        "sha512": "11c98ea71b19f7a0af94fd3736086d1f512c2edaf49fd4e6e253d425405c715f51c143a77aa4b2720d7d9f91c6cc27fed742e8ccc45239bb55af779ed56a07b6",
+        "dest-filename": "mdast-util-mdxjs-esm-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+        "sha512": "4ea202c32bc9269070bc600c6638f82769f45fc416a76d5bf65d28ede5f2549db960d5986c90d52320f56d95c4e96b55e9198a2556264002966b4cd6380073db",
+        "dest-filename": "mdast-util-phrasing-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+        "sha512": "71cb6cab6c29e6f4ec2c871aca66e552b8a24dc65dd02c16b426cbbeb3b36020d9a16c8c355f2c67b92b8f4f454a7b22262dd656c1cb33893a0eaff268fc825c",
+        "dest-filename": "mdast-util-to-hast-13.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+        "sha512": "c63ebcc0c4ef19754e2a89e6a20e8bc3224aad85d93ef97069b6abc938cb87d2eebe8bc1fca007fa4be2f068e3fbbac98ec162db79e4531450bf52aa4aba0ca8",
+        "dest-filename": "mdast-util-to-markdown-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+        "sha512": "d07e38bc38a69f9d45d18c2fc522529b47820ce25346598dd11d72061e072e3f70895d439f44285c66ef1405a3da1488b554e50a6045d61a8a948c9405514b3e",
+        "dest-filename": "mdast-util-to-string-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+        "sha512": "69bbffa8e72e3df9375113df0f39995352ca9aec3c913fb49c81ef2ab2a016bc227e897f76859c740e19aac590f0436b14a91debb31fa68fcba2f6c852c6eddf",
+        "dest-filename": "merge-stream-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+        "sha512": "f2aed51203095b827cb5c7d53f2f20d3d35c43065d6f0144aa17bf5999282338e7ff74c60f0b4e098b571b10373bcb4fce97330820e0bfe3f63f9cb4d1924e3a",
+        "dest-filename": "merge2-1.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+        "sha512": "661a08a0bed3355e2ce41ebeaf1e660bffdfc3cfcf386c8dc52fc36720897a2675d9270b7d5c1113f19fb31c224e4318603e4398adbf2579c4557a8be2b17e4b",
+        "dest-filename": "meshoptimizer-0.18.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+        "sha512": "44306b1c4312c5514b83ac6f9d799bd40cabd96ccb0168de4804c0a31c0a60957de1378d6af82821d0346bdcadcc3495cc1cb660a14af9e9823ce1226cb782ae",
+        "dest-filename": "micromark-core-commonmark-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+        "sha512": "a0e83b927ce189c810dede100a309681399f361bd06c30e725e56ef6ff35afb365b4d0959a13f2d5f2515f6ee921269f7632fe495738777978f066faa5b472a7",
+        "dest-filename": "micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+        "sha512": "ff23e1c48d67b670cdb221edccb2989c4def7fd259e9c022b2a5436ae869e02107c656f8ba8393c4e089fbdb39d5b201f14d4dd4527545738a4c8943e41fe0ab",
+        "dest-filename": "micromark-extension-gfm-footnote-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+        "sha512": "003563a4e3a48f3d6186464b94189803d711d809dff05e07a9950ee9ee5e0dc3d07744f1c397f12f3cf19c491291f9c3d30ce24868afeec62193f92dbdb7f5bb",
+        "dest-filename": "micromark-extension-gfm-strikethrough-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+        "sha512": "b76394fdd5d78a8011ac2eb259f27886a07badcb75e1ef1fee6d1c6c8e615260f2c88970bf9bc4b68a29b47f083646cbcce6adccab956d098061c6d6a32cfa0e",
+        "dest-filename": "micromark-extension-gfm-table-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+        "sha512": "c479533a6b824a8b4803c4d6d660c833a5f63b54a25f93fd22e0eda86a2716110ad2a811238c9e0babccc44576760cabd93883fb63d0d74a3e70e85d5407307e",
+        "dest-filename": "micromark-extension-gfm-tagfilter-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+        "sha512": "a8805986ac6a23a7e32c36054c121ae1e8af0cc9cff8e66ab0dc26437c4d2c4e02c7073ecdf4047dbb3ab73028d878eaf9b87aab917e67cfdc92cacb15859043",
+        "dest-filename": "micromark-extension-gfm-task-list-item-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+        "sha512": "bec280ad0b22726eedd33d86ba09022ad65e86a526df5a1e18157f2954a8ad64b2f1994d02fef2b63161bdaaf2522094258aacf8da04e80161a50bc14cce90e3",
+        "dest-filename": "micromark-extension-gfm-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+        "sha512": "5deeab0dd2659266c5444c694ce9918fd37731a5a66c081da52ac142f085aa17b3527e001ea2476da1277db5586227b1552b3ffeda8e758fc3c618dd0a226720",
+        "dest-filename": "micromark-factory-destination-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+        "sha512": "54531e932404c6a216ef120285c5e7e28936f58137ae7bb2bde5b7c194165aa17836ff56939ae027df4accfbc78e498f5c5f7715721b069e98756dedef5ffb56",
+        "dest-filename": "micromark-factory-label-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+        "sha512": "cd19318ed071c4b77649cd1df9f6e712e9ec4e3e3a4965e05dc899987ab49036069dc93f6521a3f7fc142d357de6ea1e6222b98515cfda627df14a3872afcb42",
+        "dest-filename": "micromark-factory-space-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+        "sha512": "e5b67edc28e101df5e0a16131ec8f2e931b1a4e1522a028a24f271af6f778d36dfaf2d8a0e85a48416fa4dc3d5078366cda3e132cd45ae6f40647ece0f80a3cf",
+        "dest-filename": "micromark-factory-title-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+        "sha512": "39bd27b99dcf2adfe7d213911f2be80fdb9986bf996bcb05a0ff8e9cc72758ae659e04b300b81060a32bf512553962ea418bb29faba5a865925ddc1fe85f3495",
+        "dest-filename": "micromark-factory-whitespace-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+        "sha512": "c2ff2d7544c9ded8521451492ada5828e62218fdbebfde87be4e13bbc2a9080b1332ceb28be9d5986875b32bd20ac6b1cf8e49e896f0fbd0c3ea0f7bf8d57aed",
+        "dest-filename": "micromark-util-character-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+        "sha512": "41434510e3c42df9afbfee3188d836b1161e4bf3fce294d6d130a03f9cdcf45a577ad1d8d1a6fb4b12b201008d09cd5e2b4e39f6ea0b235cb9a0ee5573575b84",
+        "dest-filename": "micromark-util-chunked-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+        "sha512": "2b4907ccce9a7d6fcc6de59858b8e81d0bf5b2083643d11c707103cd293188ffc469a80dcc29bb4ff58c299deb8cc6ef229bc189983047774a33282d038986d5",
+        "dest-filename": "micromark-util-classify-character-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+        "sha512": "3a70271fc5239b2e7d25cc99c3c2526caf5c1a9755638e0d2a048cec4f4487b0e22d2d84f513507f474e35a183cc41bdca3125e6172a788b23e217d190b1ff06",
+        "dest-filename": "micromark-util-combine-extensions-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+        "sha512": "71c51b624e82c1576498240ccabeb8757cf8d847c71a43d09418f9a7b6151b3abc23b0ad8d7649aee6c061ecdfed1a7e6e33ec7a244ea9eec6e9fa0577e944bb",
+        "dest-filename": "micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+        "sha512": "9c357fefb163e9e1f5ca7c2c7184ceb1b2bbad1fff523d1b65707025945f68b109d6218147a9087cd9a536a6aa25feb8f443f417735635d7898b4dde96594d51",
+        "dest-filename": "micromark-util-decode-string-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+        "sha512": "737715c76cb82aa527c28a5c3bd6ff482768d8eebb2f0249fd4caa19f6e281a85f7a02fd9b2a041680d8660913edfdfa4f46cbaccf6165301a0321fe3c20178f",
+        "dest-filename": "micromark-util-encode-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+        "sha512": "d9c3448980e1096288f86b3d4f44e2cac935dfa4a7475de184ef325ba04637284e0b8a98167c05d6729f0f71c50085c0e5ce3946b206d6e6f5d46897798775c4",
+        "dest-filename": "micromark-util-html-tag-name-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+        "sha512": "b313ea9a8ef42f201126cd30d947250023d4504aa5b42909e8f84a74c203b89de049ffd0fbf1887b758a9742236ff1b21fd94ea5491100edb0a7419590bbd2f5",
+        "dest-filename": "micromark-util-normalize-identifier-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+        "sha512": "55d432c455854f6fc51898304272586ded638d0a0d4d2e118e09664a34d496950c6bde47b71f4d1de616e2b1832736e3bc2b25f5e2e3310c0678496caa6cdc1e",
+        "dest-filename": "micromark-util-resolve-all-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+        "sha512": "f4df48a2667f62e18665999079cd4c6e0c6d960a2e8314e8755c03cf3128b8f2a8dea156bf29851d67270e2dafcd5d5f7fa91ab3db9c5bea37cb324af5807501",
+        "dest-filename": "micromark-util-sanitize-uri-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+        "sha512": "5d02eee79da249cb6f9c47205f0ebe4b1ef919f9403cd103d6ac7b78127ec327416f62826d165ef8dc2f20410c33cdee9a5d7ed96497a4101ca7d2140a009858",
+        "dest-filename": "micromark-util-subtokenize-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+        "sha512": "bece6df00a5ab9df4ddbc9200ab45474479de1427ec1636f89c1cb3f109af4436562e018df5334113cb9cb5bc0df762834f0c54e08446e787a79f684f21e31d1",
+        "dest-filename": "micromark-util-symbol-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+        "sha512": "630d04092a49a15885d6a4d4e030ba370b42e1a586b75124cda401f0a3cfc82451f33f5359e5741db1051933be658d70076db39b19c9aa13f24e93950a97874c",
+        "dest-filename": "micromark-util-types-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+        "sha512": "ce97bdf10ea4bdabe90abd4d3d548231e6c229f0fb080d8da99fabca478d84e348241a5cd6d14ab7d86e70b1b085ade3353348f251e972d5895a88a6545e0f7c",
+        "dest-filename": "micromark-4.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+        "sha512": "3d7c1f06162ed210423f0f039f413e58361beda7f77522d558a8b71c6bfce08745e13c85a02d32b3115dd06a31c3b9d2bf84ff3f3109431b18b0488508aa3604",
+        "dest-filename": "micromatch-4.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+        "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+        "dest-filename": "mime-db-1.52.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+        "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+        "dest-filename": "mime-types-2.1.35.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+        "sha512": "5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
+        "dest-filename": "mime-2.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+        "sha512": "3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
+        "dest-filename": "mimic-fn-2.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+        "sha512": "bea882d3a0ae8414d47591fe45897cb05acbd3deaf038e4e9392123bab04fccaf58d16c61f80ac9e18bc7f7c0a565ef1f263b802eec8afd0f73b2bf555830527",
+        "dest-filename": "mimic-fn-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+        "sha512": "54fefd5d43f15760a28183f78d6c005054a4bb668aa811fbb9301aa4558206abadb1b983a3de8a639a3cba1e94fbf612227e4ec499d7a7bddb795929a8c20684",
+        "dest-filename": "mimic-function-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+        "sha512": "8f911cb67907eda99f57fab91e09a86a5d60d901c5251ada3ad9b1d09a48aa4c6106123f9494a5d67329438e6155aaf03444cea161229a7759e102b4447c6ec5",
+        "dest-filename": "mimic-response-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+        "sha512": "cf4c9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19",
+        "dest-filename": "mimic-response-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+        "sha512": "7b92121fdc4c614d03ceb4fe8e5f2adb37bd0fa79606da3e23c08da5ef9523e2b627f17f9373dd91d4ddcf8c2f1951f8353a68f8d4584d522e31010c31cb0baa",
+        "dest-filename": "mimic-response-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+        "sha512": "afd75e0def69e452543d9024dc0e7dc061fb222f58ae38d6c348e6c3f96249b1e5d821e2c978fa15c0d70eed8add38d5017aa225d6b0df1c7095966bf44ea71e",
+        "dest-filename": "mini-svg-data-uri-1.4.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+        "sha512": "3142e454b7ca1980c561e8cfd3b40ebab0cb2d0a5c8e4ec5c3eee35d2d91d9ccd1433479eb21d1bde5393432443af887fa111364a4a4224e5cf93db71a315432",
+        "dest-filename": "minimatch-10.2.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+        "sha512": "5608d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+        "dest-filename": "minimatch-3.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+        "sha512": "ee8d70100d91c8c3fb22eec635b6bdbdcd11596180089382641257d862568a9d22915fb070eb2056e63db84f023e2c908641854a586e4a464f6af37bbb573617",
+        "dest-filename": "minimatch-5.1.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+        "sha512": "57ed6e40d773c9bc5ad787bfa74d0766740d35c4e39d12630f183657cc2d92315cb6ae0cee15c5c2ce287a4c933f425e6deabb418b6917239e0408dcf3ccef62",
+        "dest-filename": "minimatch-8.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+        "sha512": "381c0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662",
+        "dest-filename": "minimatch-9.0.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+        "sha512": "db2c8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+        "dest-filename": "minimist-1.2.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+        "sha512": "0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b",
+        "dest-filename": "minipass-collect-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+        "sha512": "8fb535d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81",
+        "dest-filename": "minipass-fetch-4.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+        "sha512": "4dba93cfd714c16c874b60f2f3d3f7a1c006506c4a8e32ee47dcfcc385944c60158048f5effe27860a360eee7a8b4166dcf9b7d20e2203c2dca9cb5cefa8c2cc",
+        "dest-filename": "minipass-flush-1.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+        "sha512": "c6e22aedc20eb74f513d1275f60762e1bf9188dbc31587b9247fa080dbc1a86aa941772bbb73dc466399b8704a58ad53c5ff7e710f8731537877acf8e8b64fec",
+        "dest-filename": "minipass-pipeline-1.2.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+        "sha512": "31b9104360938813250360e6ff9718fbd49614437ca73cce5e2eab94ce57c6ad18a9b75ae59432f6c53be5aebbdc513d64ad19b1bafa63988feaef6792d7e0da",
+        "dest-filename": "minipass-sized-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+        "sha512": "0f188d89dc5210afad1c6eb3388925bcd3b09b786f0ab6d4addb7363be14e87293271bc80df3942f95b93f61a17770d392184a3d81aa78d508879a9c3386017f",
+        "dest-filename": "minipass-3.3.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+        "sha512": "7cdcee57289fa2548b14be0dce917ec04178aab82a69a297d216973d011d43b34a00df9679ca0a307574f5872e2ff0c7c6b52c61038adcc8ae0dfec8a763977d",
+        "dest-filename": "minipass-4.2.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+        "sha512": "b44047a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+        "dest-filename": "minipass-7.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+        "sha512": "299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397",
+        "dest-filename": "minizlib-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+        "sha512": "14ffa9f1107c396a45dd86410ab3f982d0039ad5c0a41e4030b9febddc80f8fcb10a3ac2b34d268f2528cecb0edf77300de4f7c0d19d2f127933ffd8aad1c027",
+        "dest-filename": "mkdirp-0.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+        "sha512": "e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+        "dest-filename": "ms-2.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+        "sha512": "cfcd4634eee79d830486b1a1f4b7b29a8138f98af45a7e4c70721930ae5c7d00a5f8d0d7d3cb0266051cf7fe8c1e78bd216b852e6d59dc74c25eedb3f5f37ad9",
+        "dest-filename": "mz-2.7.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+        "sha512": "37c4a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb",
+        "dest-filename": "nanoid-3.3.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+        "sha512": "3c72397f53b410fe7127d81098518c4ba21972b56f4e3a578f3ecd6b8d604c4ede13684ad75960d3808408260412375cd7b115e033be7e4184b6ded3a5369389",
+        "dest-filename": "napi-postinstall-0.3.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "sha512": "396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
+        "dest-filename": "natural-compare-1.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+        "sha512": "f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
+        "dest-filename": "negotiator-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
+        "sha512": "41fa795d92f57090ce69b393f07e609ea31398ce0d8ef6331e9e08fcab7f4a5efa39590e0411d11653eca46574858bcca2a42cca91634ff629eca9b46de5d6f6",
+        "dest-filename": "node-abi-4.28.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+        "sha512": "89b3cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce",
+        "dest-filename": "node-addon-api-1.7.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+        "sha512": "e66ddbb32ae3156135c5fee7cfb61774de2e76756d5caebf61f827e6a9da84be9b0a47f6c8ab789379ee4ca02d4f8af7206f09351da772c20c759b80cc98c741",
+        "dest-filename": "node-addon-api-7.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+        "sha512": "db13ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+        "dest-filename": "node-api-version-0.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+        "sha512": "a72152eb7a6d8adfcfe56a9492df9451f7bee287af1fe6c578888f3dd7dbd2915e604bbfd442e726ee65fb911c4ca60be4cef36806bb4bc75dcb0817ca9a8a0b",
+        "dest-filename": "node-exports-info-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+        "sha512": "a1f456f7801bd13e003a1e4593cb7487c3815ab9a36f4492076d318751fc6273d5f4427e7f900ca18494436ce027822ad8700ad08da5e7f35eaaef18cc54b71e",
+        "dest-filename": "node-fetch-h2-2.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+        "sha512": "7381517d49bf75b71667b53ed56ab40300b214bfb79edd9b130d39c1fc52cfe0d6a56b22b609928189b2d9d41d5b2282d7af7810b3ea32cfd8cd448da332edf0",
+        "dest-filename": "node-fetch-2.7.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
+        "sha512": "adaecabe58719f957d4a5caeb34ca031ada1f94a84c4fa942247e4ecf73c4132d3f79e892d2cb9d6e585c07b48632d2f23c701e010e173f4b4dfef3cd0ccbf2d",
+        "dest-filename": "node-gyp-11.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+        "sha512": "494d3465aadec4d944e118dd9bcdef825b7963dca243e5c8d57a5f95695beeaed44cdd49508b66ebdc4c7a24024f1b537e7cedfbcdd3f02c7ebc8d840fef950c",
+        "dest-filename": "node-readfiles-0.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+        "sha512": "d61e60299085fa93bfa3722ab79269ef073dac7dde249d3e9e1fc2228891c2347175efe1007c8b3d760de15dc2a8a01b8993d2789152587989b1b92272d6b412",
+        "dest-filename": "node-releases-2.0.37.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+        "sha512": "89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec",
+        "dest-filename": "nopt-8.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+        "sha512": "e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c",
+        "dest-filename": "normalize-path-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+        "sha512": "0e52fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
+        "dest-filename": "normalize-url-6.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+        "sha512": "2587340cf969196078d241f9834ee0193ad8b8ca95eb9de4dee04a63ab884cf59db37334a2fdc66961a9f656c4dc1ce7831f3e5e47f382f0126fdbe4f490c55d",
+        "dest-filename": "normalize-url-8.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+        "sha512": "4b8f16cd95bbefbce1348ae7ee0c4e94848d02a8bd642fee4059d175b7881e1661080e94aa990e4fc4f51bb06f7dd80fe04afc805e2c51b692d22ed0bc87c25b",
+        "dest-filename": "npm-run-path-4.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+        "sha512": "a69c13b62259ab43bf6a2d33ef27ee76d069588a3133cc84ea71e2d57e3b785476116391a9f6eee829cf94db2378debcdde4f4a86e87fcfc9ff5f09cbe39e79d",
+        "dest-filename": "npm-run-path-5.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+        "sha512": "a494d2dbe4f4a062308231a9c3bb08454f1140c714a0a0835852dd06a281d813661a96c1307dac76a01a397520f0ece89d91d4d0beef7c9bb59891448980d639",
+        "dest-filename": "oas-kit-common-1.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+        "sha512": "2841a33c35685392bab30828f6125503fa981a5c1f6c5c7e2a0d9007f91deebcd5e4df0de4c83a3e5b2808ca21567426a3ea7325aa7f17ad74a93a1d2b379c19",
+        "dest-filename": "oas-linter-3.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+        "sha512": "631e4f590359a267c484f3cea6115b64a8bd5bddc2a1c423d7c3650f63dae06599cdd669489bd8c288aebab448ee6dd2a5c0a1ae73b4f2192e4032f7146b1515",
+        "dest-filename": "oas-resolver-2.5.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+        "sha512": "db2b9c7a7ab56bd60f99e344c6851af50c2bb7d445923a9a3000355fe53bb1b6f402a05e4c874c1e4cbd49043a88df786cee4d5b45b84d16177ab1be05d02f01",
+        "dest-filename": "oas-schema-walker-1.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+        "sha512": "72edb4fc71393791caa95ca0b3776df7879825f062d13b19bcf5570e16d74078848adc8337e45139395e79fa0a44a289f5d1401762419031e0bd68f4b232869b",
+        "dest-filename": "oas-validator-5.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
+        "dest-filename": "object-assign-4.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+        "sha512": "4529fd17af0f8c7f47aad96db129ea602d575e859ef418eee7edb5dd1f7c70d1adb5a83dabdc80393cdd6ecaaf21aeda366e567df059169598af6696ae495603",
+        "dest-filename": "object-hash-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+        "sha512": "5baee22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
+        "dest-filename": "object-inspect-1.13.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+        "sha512": "17c719f8a7c69521a2d3d9494fbfcd77a28967dca0b6f602d3f51860b23d9e640a2cc9f276907dcaf6eff4ad6e4a412eec553dbd83e65702e0df6f2d5fea2ddd",
+        "dest-filename": "object-is-1.1.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+        "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+        "dest-filename": "object-keys-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+        "sha512": "9cadbc58ea3e4088c190376e4c8344e09905fd42492b27f6109c6f24a7db943a7283443ea643873532f4430cba34fe85844fc49f357bdc1c71a9c25a5d8f5a9f",
+        "dest-filename": "object.assign-4.1.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+        "sha512": "f2efe17d7151043d4ed213d48e2a0b8685851d19adead280e3fbd93f272406bd7c975284f6e1eb15a15a522f0c0d14e98b8b9a936828c8f4d23492d75f69361f",
+        "dest-filename": "object.entries-1.1.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+        "sha512": "93a136d45cf24ac48ae5adb529100305dfcd1a77917a014ee692c77dd40ba510c44d4349b9e2d7b37582cf2437b454436206eadca1c65df4db8b66ecf1643aad",
+        "dest-filename": "object.fromentries-2.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+        "sha512": "f8b872dd3413bb35c8e617af87cb011aa6e6bab1db6c88c08b46784bade7b6154b98bc5f6e3e13e786b809f66b5c8aedf623f899500f60ca3fbfdf6d6a3df08d",
+        "dest-filename": "object.groupby-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+        "sha512": "8176a1e9a66b714c635a0db3476330a2e3f6787942073755e29ca0b9d7a168a5d2196e2fd80b114142be970c178628ba28565cba7127992528629e425e26f1b4",
+        "dest-filename": "object.values-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+        "sha512": "7892436248491456c1040c5e87cc56fb0787964236f27d9975057f27f0cd7d67d22a51847f6c5c7c06d94efdeb8845c70212fd495393b36a519978924dfefcc6",
+        "dest-filename": "objectorarray-1.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+        "sha512": "d1e24963a8572c67f5b9d1f07cd7ed06a1fe83bdc4538079d389d978aa73d6c61129a7c0821c31109ba70763bbac36642f83c67ec3159d35d9d848e26dba9cb0",
+        "dest-filename": "on-exit-leak-free-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "sha512": "94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+        "dest-filename": "once-1.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+        "sha512": "91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
+        "dest-filename": "onetime-5.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+        "sha512": "d45951fa08d72bb5fe02c007b28df9327c8de4aa86c09462ff7d5fb7ac74335f7886ded2fab580bddecf1ecb3dc5228ccc4d1ab2fd69c881da258abe05b69c01",
+        "dest-filename": "onetime-6.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+        "sha512": "55726373cec549c17cf2e69f4b726594382f026f9cfd295fcf4ea5a2b8f6b80637e2b954bb436dfaff30ade88899cae00238c81e9d6b5e94c394b386c36f56c1",
+        "dest-filename": "onetime-7.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+        "sha512": "b26b16bf62f31633f4df19af168277df5b2cea1fa38b17c0e14515fc1b22caebb86093df37e1484063888afe30f7ff8ca0791f909db650869059154545f1fa57",
+        "dest-filename": "open-11.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+        "sha512": "ef1f353422fbd7da0d6ecabfde687e855ac05a616e11852aaeafc8c37914cc7f117b2a53f5043404ba094bbfc6f64e8df355e35b8a875ad8d6c1effd78bcb511",
+        "dest-filename": "open-8.4.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+        "sha512": "4f185804ca2ac7d7eb5f23a09d11ee7e341f3d7a264c81d82a148a27a8c77e3d77912f0e10886f984f024ee4322ad8e35adb408d7e433f1335be66a5129a3c43",
+        "dest-filename": "openapi3-ts-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+        "sha512": "e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6",
+        "dest-filename": "optionator-0.9.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+        "sha512": "e5be98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9",
+        "dest-filename": "ora-5.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+        "sha512": "a853b22b93e389665df9040887ed6385d6fd2e9c53174aacecf9bca39407619d0cdef2aa4aacec65a101ea85a5c59faadac241308fcab607763796704284477e",
+        "dest-filename": "own-keys-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+        "sha512": "0593abde74501ce9ed5234eb1fcf8b879e2c98a1e81f2babf167b557c0d2315ae5e40da66a538ec2e2519ca4438d29e4a1e061e1ab7a0701276f923b265df5c2",
+        "dest-filename": "p-cancelable-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+        "sha512": "9a55604773c6bb3968d0c993764e1c5ea5d69704032e738d4c083ab26eb65e430912247137718bdd27df918beac289db90905cac8ed4befe5987dca3be7da253",
+        "dest-filename": "p-cancelable-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+        "sha512": "ffff3c985592271f25c42cf07400014c92f6332581d76f9e218ecc0cbd92a8b98091e294f6ac51bd6b92c938e6dc5526a4110cb857dc90022a11a546503c5beb",
+        "dest-filename": "p-limit-2.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+        "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+        "dest-filename": "p-limit-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+        "sha512": "c7ed76c3f4e8fb81857e0261044a620dc2e8cd12467a063e122effcf4b522e4326c4664dc9b54c49f5a3f5a267f19e4573b74150d24e39580fbf61fb230ba549",
+        "dest-filename": "p-locate-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+        "sha512": "2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+        "dest-filename": "p-locate-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+        "sha512": "b64010130f32b0cce6921830f24fb553f88f856361ca42a74a4e11779ccba0f242b8968644fa3a629a2cad981ac472b30c774359666f13f4a4ee1b0bd97fc2a5",
+        "dest-filename": "p-map-7.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+        "sha512": "4789cf0154c053407d0f7e7f1a4dee25fffb5d86d0732a2148a76f03121148d821165e1eef5855a069c1350cfd716697c4ed88d742930bede331dbefa0ac3a75",
+        "dest-filename": "p-try-2.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+        "sha512": "5046484b7fdbcb8382f2f2f73f67535d1113a5e6cb236362239bc8ae3683ff952dae4157fed35bc234d2440182ffeec2028da921c05a4605a670104772c68223",
+        "dest-filename": "package-json-from-dist-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+        "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+        "dest-filename": "parent-module-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+        "sha512": "186d804185a82e02fcefb81020a7913c63b5c45f7e786d6e8c86f9b284b980fbcb435cb6a3c14bf74c3641635d7fd237eb5329a7bef6e9cfa58f7534a8ad6e1b",
+        "dest-filename": "parse-entities-4.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+        "sha512": "a8fb96bdb2e0bc31a294a73906889c468be54f832d613e897c9c8138c0ec2a8893f868ae3f9ab2acf0a747d1dc3c40882499998798d19ddc8d4e19e185bfef94",
+        "dest-filename": "parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+        "sha512": "ba0ab80c52343ed6fe5968c074e2b5ebebbf9c77e222b704fac87c91931a3345a595028b23dace52ae9cd9bedcc0f9177737d0112aafa2a2baba0ed4fd8cb3ba",
+        "dest-filename": "parse5-5.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+        "sha512": "39f9ff0931734464d3c70a4d12cf4f3fdde05d2847713ab6e799f345848a7bc024569658eded5fa664df3b2a08be33f91c6ed9d9933b552f4f3e14065b6a4ea7",
+        "dest-filename": "parse5-6.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+        "sha512": "6e90bb198c220d8438c182def8503c96146385008c7101ae4a0186a83920fd07ab456c3d0a61914f4892395452649dbd34c2d9808cea6a58c9eb7a1a2f834825",
+        "dest-filename": "path-exists-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+        "sha512": "6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
+        "dest-filename": "path-exists-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "sha512": "0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+        "dest-filename": "path-is-absolute-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+        "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+        "dest-filename": "path-key-3.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+        "sha512": "85a444ca9abbc6433b12b7e0232034cfe063e0018a94c49d9501368ef268ea1b960f511d90a615f86fd3e27ab4604176be04d3f24a8c14aa35b879fde74af849",
+        "dest-filename": "path-key-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+        "sha512": "2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3",
+        "dest-filename": "path-parse-1.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+        "sha512": "5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c",
+        "dest-filename": "path-scurry-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+        "sha512": "dcefe2555b0900fb0e9e9c1621e0fe77acffecf9aa029c9078f52d0a77636ad8fff48e4bca51efb79aa5b856814f7239877af57a37d1d39e9cf850aff8d9cd5e",
+        "dest-filename": "path-scurry-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+        "sha512": "791581e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67",
+        "dest-filename": "pe-library-0.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+        "sha512": "a88e7ea053441a2dcbe470310f03762c0e0683b8ab17bd19b36e5e7618e577d41e98e829d026ef32d6c570cbc5b44a353a2b723eb702ce440507c24ffe1c60a3",
+        "dest-filename": "pegjs-0.10.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+        "sha512": "1776acbf8d94b97721773b7ec57a9f5b538695505efa6c5ada6a88d29839c801d93ef16663763a76b49ffc643503ce9681610df4ace1fd6ae029aea219c1d72e",
+        "dest-filename": "pend-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+        "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+        "dest-filename": "picocolors-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+        "sha512": "57bfaf404274e99f9ce6d4b27bc4be9c751f239d71a172178c743df5c42d294910aaa3b590efca08951f657b81e3b87f60194385a8761f785d5065e7f227b4a0",
+        "dest-filename": "picomatch-2.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+        "sha512": "40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+        "dest-filename": "picomatch-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+        "sha512": "786d9d593570e5bcea191ced9c7131733371b79546b04e8ec137821b77dd51ff4a06c6733b7479388208cd647e89903436d67e44355d6a813674ad5c9fa8c7e2",
+        "dest-filename": "pidtree-0.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "sha512": "b9d82c018f9f4e7befee423b69ac5bab058d6f4007881d2a04ef3d3d928f9284e618e81d6eb1c3283fb40765f8b937c9fc54f5474f6bf604ec8d48cd268b6ea2",
+        "dest-filename": "pify-2.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+        "sha512": "c257d473353e9fb1f2fc76b98fd6bf819372ed67b9f9c5e9f182fe5fe3c6f12d0a5f1c3b9ff257037738e98d334339c827cdd44498b0cbb2e1e7a58ba2436ec6",
+        "dest-filename": "pino-abstract-transport-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+        "sha512": "b6d5d19243b3e96582f7929e63dfb1c562fa02d226c1bc8c1eb2f5992c2ac16f6efaf2e9fd620496f1ef0920e0d313bf0f3ae0833d73bf7acde68bd3455a302a",
+        "dest-filename": "pino-pretty-13.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pino-roll/-/pino-roll-4.0.0.tgz",
+        "sha512": "6b1235690688c57770d45e0e145962d440f122b7583462e8c24c3f668668817f280922c7520873c15557512f14fb10ff49abf06b9217a625e6b1218a157ffb4a",
+        "dest-filename": "pino-roll-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+        "sha512": "06774f1faeff271184c518225f5757d30d45bd9724e566b869a97dd7df12ad18598c7dc6c4a4142880676094dd8f61c3377510012d3a1e57dc49b423d8e1e66b",
+        "dest-filename": "pino-std-serializers-7.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+        "sha512": "af7e321ff1a54292996d4d41bc516a3a3848491a3530dc75b5662c62f9a3e8a2111d23cc4f6fb21ce11bd521ba34cbd1a07445d1ad3b9023a8c7ff726a4975be",
+        "dest-filename": "pino-10.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+        "sha512": "4dfc92aecff99e6f1f4090dc043b949e0dd53942ac77b4beceabdb3938865c77f15f8c0adf56ab77e86836ebe489c33fd981739690e000139ebca4ac0781bf14",
+        "dest-filename": "pirates-4.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+        "sha512": "9c3cb04e1164d62e0140ae2dc0f43a4c0e114fc6c363deb27ae0950562f778f0110a210a0d14ab3466c5220509a4ba7e5de211eb9bfcadaed6b89385501b6430",
+        "dest-filename": "pkg-up-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+        "sha512": "bb2b2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
+        "dest-filename": "plist-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+        "sha512": "35cdc84f9c87cdf9537db8e0a967023e9a3b0da2b2e059e907497fcc2016d1373b8f1022baa4b11dab27b41dc3efcf3b2d2ac0f7790327d217a2fc49631c8b08",
+        "dest-filename": "pluralize-8.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+        "sha512": "ffee55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6",
+        "dest-filename": "possible-typed-array-names-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+        "sha512": "869afe274e41d855585005c778ad58c88dbaec9fdd0c384c53a07a722be6f21498d636099c15f1cca0ca0ecc33266b4b1ebcab8e19c38eaaa9ff8f6df0500b7b",
+        "dest-filename": "postcss-import-15.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+        "sha512": "a0800e4ea808a3bab610ec1b85bf146a561e3ccbd8a0879163660a9ed7691505cda2c4aedef2eb9e21a0987f4e2acfea0247e88f9a01de57bfee620d5b52c27f",
+        "dest-filename": "postcss-js-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+        "sha512": "a0fb53338a1eacbf945e6c7ef77cad65537cd91ae563fc0f515f08783c45af32235ce2c5d6937e12628f2dbb9bbca1d3d870b6d315ec0801f667e08a57a3b3fe",
+        "dest-filename": "postcss-load-config-6.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+        "sha512": "1d06eddbc2ae942e402731be719b63f64bca07ddc214274bbe88355852dfd43fb198cbcf1a506cb64a531197cae7e00df617c9a1cc81142362ab24b8f1ba60cd",
+        "dest-filename": "postcss-nested-6.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+        "sha512": "210ed365da1aa9b4fe2c2a52860e3a8e7655961583db0ea241801c6177c701167b5f5b7f50686171e403b395f4706a8abd894734ebafece6b5c666f4a10b80df",
+        "dest-filename": "postcss-selector-parser-6.0.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+        "sha512": "43ca907cf899f931ceff766b3ab3b470924a7e96026a0b4c5245db9c47e68148f05e0eb3fd605e3b24bd00f0413c24d288357eb384b0406bbcc85b2231122e76",
+        "dest-filename": "postcss-selector-parser-6.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+        "sha512": "d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779",
+        "dest-filename": "postcss-value-parser-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+        "sha512": "a4c307c4139928553a1e0019e1ec869f05c5fc4bcf186a94af4327679fbdf78f39c305b8d645bdd40e0b386c521e182e8199920a12f902512535dc253607272d",
+        "dest-filename": "postcss-8.5.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+        "sha512": "6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+        "dest-filename": "postject-1.0.0-alpha.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+        "sha512": "74cd2356e5c93ec0cde83bd1a5e6b8f38b4251a3225d68ee0a7fbe1c64ea516cc60e3bf9b5990466574027f50c96a458185ac3fdeb41ca8e3fc4eb82fec9d7d8",
+        "dest-filename": "powershell-utils-0.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+        "sha512": "be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
+        "dest-filename": "prelude-ls-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+        "sha512": "ee280f4cce777061cc5bcc56b954f2762d8a3b6df754589337217984b26aa629477e69fc0bc80f7fe3d2edd513eb861c5c56e23066714bda424b12ff0f19bf27",
+        "dest-filename": "prettier-3.8.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+        "sha512": "033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d",
+        "dest-filename": "proc-log-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+        "sha512": "6b7f6df40a47371d8be3e1c19d02aac711cdb35afb285f889ed77c43f8356d487aab4588a7dbe83d727fc748fe64be39285d6925df7eab68cb21131fbc4b2190",
+        "dest-filename": "process-warning-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+        "sha512": "ecf887b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
+        "dest-filename": "progress-2.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+        "sha512": "cbe58a165051f011979ec3652071463d99b20dfdc314ca0b85a7e5027c99815eab1bac6ef89c1eb13a3643d47a5f0626b66c001429009377b7e6311da1e87fde",
+        "dest-filename": "promise-retry-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+        "sha512": "37136ffe42e0b8203ba778c4f282f668406cac95a001a901a609a02ba9693d657e5ae3a663aaf6ff36c05673fe4fc6d0940d27cc75d2252256d07abbca5683d9",
+        "dest-filename": "prompts-2.4.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+        "sha512": "a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972",
+        "dest-filename": "prop-types-15.8.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+        "sha512": "4e334f6e537807001631753cb3d004cf82664319c3d4d34bedb34e63f00a533c9a99cdfbf4558049485cfcad692f69e855bf9799928b2faf1c8f32ec88e00c68",
+        "dest-filename": "proper-lockfile-4.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+        "sha512": "495b66c61444fc21a49f77996354faa42f0d967e85aff96ed66292811b9dd1e0bbdf086319fa00a206e7efc2e40fc6852f4cf3ddb0057ab2929ce97b36512b04",
+        "dest-filename": "property-expr-2.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+        "sha512": "4f0119f97fb20899987cbed33d439cbc167841fa13e587a742226e5ffff4b61e770c4eb0d31c4b12d7cade2cabc9015d757baf908939d44120ac943458990e99",
+        "dest-filename": "property-information-7.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+        "sha512": "0fece439109b03d7f5b5d5912b445a091dc63efe7470cc5caf3e17f24e4b4d2503d43930e3b98a24465036e9c8b514e45b082d6944a8d515454481bd65788562",
+        "dest-filename": "proxy-from-env-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+        "sha512": "552eec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
+        "dest-filename": "pump-3.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+        "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+        "dest-filename": "punycode-2.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+        "sha512": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
+        "dest-filename": "queue-microtask-1.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+        "sha512": "b580b5435860c91b87825a15fd85ecdb0d79ba73d587ca9fbbfa824df85361a99ac3b7f286e98a6b6c86a5d4a8f3bbd8df6ac87258fee1f59841750cb3d107be",
+        "dest-filename": "quick-format-unescaped-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+        "sha512": "5aec802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848",
+        "dest-filename": "quick-lru-5.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+        "sha512": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+        "dest-filename": "react-dom-18.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.1.2.tgz",
+        "sha512": "1900f167925df80abfa94c5b0a6d54b7398bfecfbe57bcca804f32324b498824170821599cc661f6783eebf35ee8f8cd4971f42fd0a378e11111f467aba0ee6a",
+        "dest-filename": "react-error-boundary-4.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+        "sha512": "9ec3be292360a3549b26a24461113d111ce8ed8b586e8bbf3aa8d240ac55ee370aa31efebac8945593800be5e70ce0015e08104e7a346350a9567b9611cd5ba1",
+        "dest-filename": "react-fast-compare-3.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+        "sha512": "e2e333118f67943960c6beb534bdd76ca472d611245e628d5e18db008395c39bdc16bb1d61b1f6144c1c3725af5a29e5d74de75e0cd83659ecf5c6bef241625b",
+        "dest-filename": "react-helmet-6.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
+        "sha512": "461c01a32db281e5598def82f9bc09f20d0d8d3741983949bc05074f14634e649428f62c29f3298644b6b2010ca2db18d376cfdf9f3211896751e672fff0fd22",
+        "dest-filename": "react-hook-form-7.72.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+        "sha512": "db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d",
+        "dest-filename": "react-is-16.13.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+        "sha512": "7c10126c0e8b9ce53d74e536796eda43cc666014975085abf94985f5bd5e7d905acc634efab7174ff89c74a9d89b6a53c1c472955518c16ec7d4f1df2de915cc",
+        "dest-filename": "react-lifecycles-compat-3.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+        "sha512": "c5a8a3b890749331a251d1bb9dcd8c38c0d40c158fc8602366d52ba30f57c547ae6bc22a78ff959487c06776e986970b4e74995f3eb3f637150bf4c2c1b7e077",
+        "dest-filename": "react-markdown-9.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+        "sha512": "c82611241e5891e4034254edd7b586020149ee3af64187166b5487a99dcf96e0e69ca27fefeb5553e13ab8ac99d2738369e123fb10a92b82dc4a72972cc0b437",
+        "dest-filename": "react-modal-3.16.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+        "sha512": "cfa17b2bd6d5f3911fb1e442a766f3ae9c90d06930d6e2e809e97d5c15563e0fd38d18fde12909cd44c67ce6b86ecee226f056b501b45aaef09c8d2ccb0dc405",
+        "dest-filename": "react-refresh-0.17.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.1.tgz",
+        "sha512": "38ce7f711bdbb545845fc95ef11093f2c700f32d8e3ed6f443f215884c8210ce4504df2546b9143999eef3b23cf00ea78f10e576fc46fab2c1c56880eff50cf6",
+        "dest-filename": "react-responsive-10.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+        "sha512": "a713dcbf501ccc3e2fb28ec6e19dd329cbe5c4aee0ed336ddff14d18c85fab29eda1cbd82a3f8609ab5f8a01838db2e8cc2e1b6a0b89d117828a0a032576f46a",
+        "dest-filename": "react-router-dom-6.30.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+        "sha512": "5d19e56ca3139a4b4192308b13cfd77191659c7bebd8bb5daf57895f889d2f9e7ff416ce473c9911a2240450e1146084581048b6c56b0f1c31de09e2b0c8ad77",
+        "dest-filename": "react-router-6.30.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+        "sha512": "3d58ce72f54ec8820bad8a32184a43377be660d2ddcb509a8d214db784c3b15402e4aa538a30ef595a11fbfed1cf6c53f7bf03f3f66d15c797c73b0fc19103bf",
+        "dest-filename": "react-side-effect-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+        "sha512": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+        "dest-filename": "react-18.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+        "sha512": "04d83d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
+        "dest-filename": "read-binary-file-arch-1.0.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+        "sha512": "3b076ffc5b7b2233a09bf8b4c6f3436752eb4403517dec386f6a6b1773963102f12dfbb76d2f055610acad208c2b8951e7a63dc9af804e1a13a43093c429a944",
+        "dest-filename": "read-cache-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+        "sha512": "f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0",
+        "dest-filename": "readable-stream-3.6.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+        "sha512": "84e4b4f3da27f1176ea9d6e1bd0e59dfb0341128ecab3eaa9d171f7ec314df8f7916e4dda929beedb849dbd26f20eb010c41276a7e433eef6ddd3a3d55194ccc",
+        "dest-filename": "readdirp-3.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+        "sha512": "18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2",
+        "dest-filename": "readdirp-4.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+        "sha512": "e7b7ebac633f3824cba8b3808749a1540f5504c1ddfbd53b65bd931cc19d054a1954eb466c9ce3c6c6060c9dc0f4061808fe219facb54d56da39fcd6b66e4616",
+        "dest-filename": "real-require-0.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+        "sha512": "d34a3823e0d5ade7e1bfe9d7d2e9728b76e248708f0defb22efe68fe9e9dfd45658ab8a307c135e85b5fc12022e20ded72aad0e25440a904a81446497a160473",
+        "dest-filename": "reflect.getprototypeof-1.0.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+        "sha512": "39579d7bf350135df1050fa86f908a7792b2789614d982276f56e65789d1a0e7eab993e4024c6e39789c49ed4fbea22e659e240f5dec3ca05b47b5050e6962eb",
+        "dest-filename": "reftools-1.1.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+        "sha512": "758aa035265b0f091a27671e45df688c21a306afa63a6f4b9ad5e7027106c8784dff947b8835b64d1c3787ea3f8c2171bacdcfd8b7d62088b0a3002300d9bb20",
+        "dest-filename": "regexp.prototype.flags-1.5.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+        "sha512": "d6aba87d9d9143d11675e377e12efdf8a131575efae3ec02506a29e423cbd5619d0f4a1c3e9bbdd65ccf19bc163040a9129778da4246430cd17f2a2ff63e3236",
+        "dest-filename": "remark-gfm-4.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+        "sha512": "142c6528b3469274b96daff5966a588a3314cd7d9eb315b9c50aa35b1c3678715f4b631275a1d520d166863a3ea8dd5685984d8a6ab475901337da47d080eba4",
+        "dest-filename": "remark-parse-11.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+        "sha512": "0e1ee5e7b89a9da128229cdba743c2f542807424959250fc139469c3b1137db4e5dc5a9c38e82ae6ad8b54386018291a06fee9db82578a43ddbe18661ef28cb3",
+        "dest-filename": "remark-rehype-11.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+        "sha512": "d4e4a62ddddac01fedf2a76810e31acd990db1f553798e1f4ec83371015d5cdabc4e84cde191b0acc9e575ae0aeac99314a0fe19157a3b8f22e99e222a03cfa7",
+        "dest-filename": "remark-stringify-11.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+        "sha512": "7c6c4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+        "dest-filename": "require-directory-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+        "sha512": "5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+        "dest-filename": "require-from-string-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+        "sha512": "bc78dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410",
+        "dest-filename": "resedit-1.7.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+        "sha512": "69bf44991f3417fcd04cc35e9de52be1cbfe8d2c0f260225bc4995c0b7abc2b5956e92e506e96cf571f321e4c5cb871e814d8d1c1a77bdad0b28ecd4e6a14461",
+        "dest-filename": "reselect-4.1.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+        "sha512": "d1ad45e25ef7fd915939a9099d0dc5be4276fa0493416cffaf6284e4e7436344f13e6e61e0692a91659f338ed3ec7b1b9ceb5c255105e1ea42572eaeed0dcafa",
+        "dest-filename": "resolve-alpn-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+        "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+        "dest-filename": "resolve-from-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+        "sha512": "b1e4b64e3dba4c154e0b6348736ace7b6cb664eede7f1213b4b65c1923a71c734e43b0a489405fc34230d9c93ac642213f02e128d2d2f013be844a6781096acf",
+        "dest-filename": "resolve-pkg-maps-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+        "sha512": "4f2789d7389fe7704f7c7a28b411b03d1613d5152dea8196b1a42bf14c995bf7809bd6caa228edbebb920c49991e6f760b04bd9e3eff7d6b6da8f0a0cdea7c08",
+        "dest-filename": "resolve-1.22.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+        "sha512": "dc999597984c1ad27790c981df38b70cbdb929f902132cb74f0ec69b0ef3e70f0cf56970a0f16722fc02873bb5f9c17789a2b7b29d7c8613f3f0035e8a67497c",
+        "dest-filename": "resolve-2.0.0-next.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+        "sha512": "e20974df09f7863d473f7cb381d23b777942905f79176d4fcf804f1af2878a7c90cc02d1e426a9c02f32222d11879f0310c43f4a0b82d37c058f693433f98787",
+        "dest-filename": "responselike-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+        "sha512": "e34c87c5b35c976fabcd7bd9b9592b62885ab61b122653135caaf21b9cbcb9c887bf5fb10cb1d0a608c6eb82543bd9eb12ada318b1fa219f01719cb0df0af07a",
+        "dest-filename": "responselike-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+        "sha512": "97eb1279fcc7a63e6a8a6845484e5af27b9f65800cdec05254c00fb589260bee041f66a7486684317483d22cd141bbbd9dfc90f72e49ad59a9ec4f2866b523bc",
+        "dest-filename": "restore-cursor-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+        "sha512": "a0c03675caf0eaed187f12505e6df8d9b14a5ff138b06f6b6d3ccef69b54711fdef00df7707baf4ad8983b01fb7ecce4665675cffb5af400283e4d85e2a20e1c",
+        "dest-filename": "restore-cursor-5.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+        "sha512": "f4b9224f08d487aad3e79e43b44f6b4d7f81281c8f7eb333100b67944b5d130af73647dfc228a1a9ed9b5800e0f8e4118edf6097a20276607f6450c2180b52a3",
+        "dest-filename": "retry-0.12.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+        "sha512": "83a4147dfd38a19a47b34786e69f37ac52e11de574d2e83f61ff6764ce9f2de52b3e0b814e44d039da40596b29321e794d97d54033da37735025f6d5440c5d23",
+        "dest-filename": "reusify-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+        "sha512": "ab56f737942445459497b8b2ca569a8f790ea484f43768bd32a2044173fbdc656c37d730ddf771f17eb77049968491a2d8f3c2176dc88e9ee4b66777f6b6b020",
+        "dest-filename": "rfdc-1.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+        "sha512": "9b0a9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+        "dest-filename": "rimraf-2.6.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+        "sha512": "08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
+        "dest-filename": "roarr-2.15.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+        "sha512": "5650d79de4c368ab07230f32cc90055adaf382ea09fcb9d0fa5329a157d82778c91782217b9a182c0a8b92520aff7e6581463ed721330a41f26758f8039c397c",
+        "dest-filename": "rollup-plugin-visualizer-5.14.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+        "sha512": "566b41dab154fc6ae8678a0bf3e66a5e0480dfc3ba191f0a488bd698416feb7a50d06e8a6811fdb34ecf3bc5d35cfe2f23edd4254132a4e7e39067e6481051d3",
+        "dest-filename": "rollup-4.60.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+        "sha512": "0cf7b9a5515a02c8a749a57a42343a81d89e7560dc4426d4ba241f41adb099657bfb10bd6c6ba5188f3e4dd466a059003da05793c0ab01b9e56362129e2278ed",
+        "dest-filename": "run-applescript-7.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+        "sha512": "e65e15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004",
+        "dest-filename": "run-parallel-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+        "sha512": "014466e5fd236043b27418fb550955bc3ae378582d8437441791f574ffba98da685ce328d6ab90a89e30bc90f2459f7ea4ede4196a0e766574f1c4afd9a255e9",
+        "dest-filename": "safe-array-concat-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+        "sha512": "ae9dd2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d",
+        "dest-filename": "safe-buffer-5.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+        "sha512": "88a13dc3f67bc42cd430866a741b29ea9110bf0b8479b1f8bdda637035a7cb3688eb297a3bd147bd5a6619e96f10736ca18eb019b964c51e99b72fe1d345a248",
+        "dest-filename": "safe-push-apply-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+        "sha512": "c7ff82cf862b8a643141c7097f998a11b21ad4dcde091348e44725fde92695869a9a974d2cf6a557221c09934d1f732f9aa06e815e53318657bf4963b255256b",
+        "dest-filename": "safe-regex-test-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+        "sha512": "6f7ae9a532a6f53f8fb1508110e511e3a19623b7dd3acd3454a675fbd7351160da0ccbe341cead530b85c88a6b806813716a151d22ab53c1f7d591c0d9ed111c",
+        "dest-filename": "safe-stable-stringify-2.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+        "sha512": "619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
+        "dest-filename": "safer-buffer-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+        "sha512": "f59c88d3c3ecbdd425dabfdb0481ae6e955d477451f6c63a44389614fade036d42fc41654219a0a36d1466536364c31936e6eeb0b840428ce403439de49db512",
+        "dest-filename": "sanitize-filename-1.6.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+        "sha512": "9205b5dcce780d407b22c2113392ef264365a47f9684ca68a1471a5861404641754dcf36bfd9885a409b0987fe301be92140527923938a5a598c43ebd95604e9",
+        "dest-filename": "sass-1.99.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+        "sha512": "e91dc9e4ce0071bb4b51d66646fd92ca079568cec886b2d7bbd0669ce1a698009a93c7e252d3ac60d5944b8b8aeeea5b9872016cb05e15e23fff8efb04a2c1cc",
+        "dest-filename": "sax-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+        "sha512": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+        "dest-filename": "scheduler-0.23.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+        "sha512": "9782a761f132a982710f094d57245f3b61383531df30a016754b80f09d32bded83cff13f3dd05ea58d3746fc89a6cb08a51170268083e79c00fa6103b3a07258",
+        "dest-filename": "secure-json-parse-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+        "sha512": "60cdff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3",
+        "dest-filename": "semver-compare-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+        "sha512": "701ce79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+        "dest-filename": "semver-5.7.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+        "sha512": "051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+        "dest-filename": "semver-6.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+        "sha512": "bc5282d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+        "dest-filename": "semver-7.7.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+        "sha512": "f08f138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
+        "dest-filename": "serialize-error-7.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+        "sha512": "a6045ce21278fec363582492f409a74b8d31ddb34c0d39271e02f951a3014ccc899d4f741205a1d51cfe302f5e16ee01b8dfd4c198ca42e63fd6fdeb33b1cc7e",
+        "dest-filename": "set-function-length-1.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+        "sha512": "ecf185966b70b040036f4598caf08c6b5b7eca47ba75a206e168ab69fbabe6471ff8c8549cf9acd54791d02290753643f35c844b03076ed9fe4d1f9d32f89a91",
+        "dest-filename": "set-function-name-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+        "sha512": "44945dbc2a3a2009cf76cbcfffb9ba6ec42a3679f5142057e5936d14bf7c326145ff8c402094c883561b1d6e430b65b948a65a9eb0ba8b81ec26a95a8f0fdd67",
+        "dest-filename": "set-proto-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+        "sha512": "a5f54ec3c419217a4c6e1056bf30484a272f4e84e233958117511e0146430d26f90eddbdca5e0061bcb2c1b245484b1150cafb8096b1a8276be0bded41ff7056",
+        "dest-filename": "shallow-equal-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+        "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+        "dest-filename": "shebang-command-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+        "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+        "dest-filename": "shebang-regex-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+        "sha512": "64fdfa4ccacaf5eb84b9641806283d5b9e563c2eeea37eeacc01266e31f3e207f2b97ac452017c714bd054efb0f9ddce31f3ef491409db69529bc310278dcb4c",
+        "dest-filename": "should-equal-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+        "sha512": "859e7c69db6e94093480ab6e6bb4317af8146974d35f1222f2de352f7ce8f401ef8d73b5ffbb1d2c40ae1de20dd9246d617a4d92686850fda975e5a0ae2710f9",
+        "dest-filename": "should-format-3.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+        "sha512": "240e217682e737e91e6c4a7656cf1e05ef60eeecb4cdb468f9131c53412c372f91fa4d38f4a8be379b53e496a0b2dda0ec40236be7ae16ea171426bcbc89257c",
+        "dest-filename": "should-type-adaptors-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+        "sha512": "31d02c4eede7db9c836c87b535e37af46e27ea6527246b52247ca05f7fa837465b3b70d38804e77fb5e76097464f8d89097bab4dbd49234a8e051eb9b21be13d",
+        "dest-filename": "should-type-1.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+        "sha512": "a1717cb5fc71e5c0e4f2bda462a964509cd9a4306a558fc82365a1bd4d27f58dd762f01846679a7f53efbc8bd380f9efe0a27e112e4cd0fc83ab9269f98832da",
+        "dest-filename": "should-util-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+        "sha512": "8202deb0bb6edb1a7e67123ecac25398d8e1d94d13b02fab43fa5f103f5b5196780ca79f3f6ec3fbb6095554ef2ac9a32e9222f6301aee2b700c69030e6b7519",
+        "dest-filename": "should-13.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+        "sha512": "9a39ffd1b8bfa145118dce5797b21a5a2fce24926e9aea0915025f0c3c8ee3afa1056b1f69533ae53047ab67a864187397d11c8713a28e991b442f12541414d3",
+        "dest-filename": "side-channel-list-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+        "sha512": "5428c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
+        "dest-filename": "side-channel-map-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+        "sha512": "58f4bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
+        "dest-filename": "side-channel-weakmap-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+        "sha512": "657f7d7bab51c1ea145ea47e541aec96175ae75361e4c4d0c28bb9b6750381bb723347418268440ed5863ffc5b2a7ea1a9f3d11ee8d4370cf97f2ff06db867a7",
+        "dest-filename": "side-channel-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+        "sha512": "c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+        "dest-filename": "signal-exit-3.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+        "sha512": "6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+        "dest-filename": "signal-exit-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+        "sha512": "6b607d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
+        "dest-filename": "simple-update-notifier-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+        "sha512": "6cb186951d50c417329e7d9de589835f83068e566fcb631104344d1cb27c548ea5ebef45522c9314d27422f78e48fd1b7178150cf45c7c6a80d298daa94a5f56",
+        "dest-filename": "sisteransi-1.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+        "sha512": "ddd3ac0075d7524413a4e61ca00c4b228acc4e9e20210af9216de255bec0ee5148a74547867ca79bd8b3c7a4ecb1dac87152044809558ed9ced8af1b83e0a87b",
+        "dest-filename": "slash-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+        "sha512": "a52cafedb4930bb8a0f437206f0f40b913546f993957aa03b9d8d9a0c052af5deaa4b046eed07ece00a40118eaef121481dcf93f541ef2efab486768b8e388c9",
+        "dest-filename": "slice-ansi-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+        "sha512": "142fa5822cd53df89ed24921a9449cc11bb53bf945e8d3a026694280afbf2d8c4309393cb067a561a1c384570337e4a7dc2bfedd549ae01c9ea3e20c0b3a4c81",
+        "dest-filename": "slice-ansi-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+        "sha512": "88e056160517edc688662baeb480b15605f549dc700151452b0b7512f31861e73f3563b999e389e8ae6e43186b6017502677b82b18aa65cf8aa6d14e585488f7",
+        "dest-filename": "slice-ansi-7.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+        "sha512": "f7884ad0787cacfa90976c577371ec681a0e5ca576d0c4e83e4717bf06c84962c4b3eeb8b01ab9905827da42431dbd4faf2f72acfd1dc6b088f5145c8bb4572a",
+        "dest-filename": "smart-buffer-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+        "sha512": "1de84212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327",
+        "dest-filename": "socks-proxy-agent-8.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+        "sha512": "1cba6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0",
+        "dest-filename": "socks-2.8.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+        "sha512": "c3a031b6e6d76b6c135c052c64c316111aec21101dacad1273e154cad5af60084124bcae238965acc202d43b65352748f7d108f3a299ba6d8c32adc4019945f5",
+        "dest-filename": "sonic-boom-4.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+        "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+        "dest-filename": "source-map-js-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+        "sha512": "b811d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
+        "dest-filename": "source-map-support-0.5.21.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+        "sha512": "52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+        "dest-filename": "source-map-0.6.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+        "sha512": "8b9bafb7c0b78a489678d65255935671f64f22d1503ac6135003a47143c677c0ea0f2d6e3948a48ede5d1beb91970caf475d3c15bf4339de06bd77d3d0ddbfb9",
+        "dest-filename": "source-map-0.7.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+        "sha512": "3c41a5030ac6f325c65d18d6df67c66e0eba24094e0306ce6eea95a09a6ffe6460a160d07e01f5c033efb735b25123405c119293c87be796036db704cb7487d9",
+        "dest-filename": "space-separated-tokens-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+        "sha512": "0b598364e5f4867bb47a9f5d7e6ba88b4dfe78e743a33db2bcaefd4716dcad5106d4d3b53e1df9c96d74d831d628de2993cd27c0281e326498e4bdb9544e03f4",
+        "dest-filename": "spdx-compare-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+        "sha512": "3e2538dabfb13b851b512d5bba8dcb3c992394eef8df45e7e5254085da73cec3c7b236d855f9679c57404e069b9cbb9d7be0aabb6e69e8dfa0da5c3f3c5b1ae3",
+        "dest-filename": "spdx-exceptions-2.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+        "sha512": "71ba87ba7b105a724d13a2a155232c31e1f91ff2fd129ca66f3a93437b8bc0d08b675438f35a166a87ea1fb9cee95d3bc655f063a3e141d43621e756c7f64ae1",
+        "dest-filename": "spdx-expression-parse-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+        "sha512": "0962dc0821fb54bbb5dd380e1feafca753bf667c21aaffdd6dbea5a96cbaec6fa94f590799e0fff95dfa0156ffbeaf10308430552849e92b25e453e1d1fb9277",
+        "dest-filename": "spdx-license-ids-3.0.23.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+        "sha512": "99c76940557b5030202e95c413f8ce32abcae0b0683b4b93420d2ebd751ec26105869899c79c894992131c1f30d596a129d85f66a3f918f10e28bc84ab9a7c5c",
+        "dest-filename": "spdx-ranges-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
+        "sha512": "370a2be96ea0cc5a7c5d7e2779a290ec2855e309a94a1dac4837a63054b31f1a53c38eb48f115878e9fe8eae326e7492c3fe6c737a6391af4c40fa2e92c40da7",
+        "dest-filename": "spdx-satisfies-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+        "sha512": "51c8dc24e5a49eb36417a3cb5fcdea70733a28781528d915eb663c6b9b980d5bfdc9d19057000730aa877498ded554d6a658c6d1662908386b09d00e607e135a",
+        "dest-filename": "split2-4.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+        "sha512": "3a8fb4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68",
+        "dest-filename": "sprintf-js-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+        "sha512": "4bb886368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01",
+        "dest-filename": "ssri-12.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+        "sha512": "f8bddc729ce26e8bc65c52be029fdff0b392d1a84cac74dfdf1bbb98c2d2a44194d043bdb9c6b2b12ca52a8f5e44314d856bdeff2dbbe623e6219e33dfd6bd88",
+        "dest-filename": "stable-hash-0.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+        "sha512": "8c7f4486d2888ee5d9d9c5b19974bc64ff345f20b789ab10c4c0d5f23ce1349a5f0dbed56d02d55b85afb31cfd419bf357e1b862849f05454a0cecb12f38bfb2",
+        "dest-filename": "stat-mode-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+        "sha512": "78ba175bf0c7ca5eb6cf1638482688827461b8cafaae2e23b84600452f04eac084ab32a93a2139db551ca1f771f8a9c3665e719af19869a2829391443b1242a1",
+        "dest-filename": "stop-iteration-iterator-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+        "sha512": "6aa0f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9",
+        "dest-filename": "string-argv-0.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+        "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+        "dest-filename": "string-width-4.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+        "sha512": "1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8",
+        "dest-filename": "string-width-5.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+        "sha512": "b6c693224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691",
+        "dest-filename": "string-width-7.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+        "sha512": "a3bf9cf5b5bace901d2474edba379e3ce0c0864ba271d02bc85b1f54ac00fb01b0f3dc09e064d8e3ce164ee70cf612ed0c43a93af23e6879f3aa70b9947a7846",
+        "dest-filename": "string.prototype.includes-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+        "sha512": "e820bdbb204bfbfe3c7588b345fec7ed501808c08d4c178cefcc7f55351ef5b1446b105ea4f2436b53b0f7d2ea23fd7217b92ecbb437710b1832b72319472c90",
+        "dest-filename": "string.prototype.matchall-4.0.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+        "sha512": "d2efd395d0db283f1b14243fe1fe7e98d46b5f067c860db0ed947cc1ad7a7bccfd5e978f5a5dde1847140f4397a441ff5491ffd86de08d4b51dd93a205ed92ff",
+        "dest-filename": "string.prototype.repeat-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+        "sha512": "46ceba1743ffd6479d9399726321fdb81cee888fe43519b024047daae2ba54eb48a59d86fa131977e1d06dbbf6e4c80203a8047dfa0c658c654e877859c76b28",
+        "dest-filename": "string.prototype.trim-1.2.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+        "sha512": "1bb3a4e42e84fe3e1219fc8b0a5a174eb9e0408414dcf5ad5c6b2ddf233b05e6bd1515117f54b8d991e5659b6c36ab9ed853763e85217d95d82cd5b012be1d2d",
+        "dest-filename": "string.prototype.trimend-1.0.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+        "sha512": "517487dbad82499635b5fbb71b749e72beae18b08554f32122a1e3960094b4209c82285873fc4ab3d76331331439bda3d66552794f0453a35673f890294e867e",
+        "dest-filename": "string.prototype.trimstart-1.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+        "sha512": "864457f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
+        "dest-filename": "string_decoder-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+        "sha512": "2307c1a6d6ad94ef90089528d7d02abeb3cdaa554ca56f5810bd8b21563e469bf6aac8c21b16832cd460786b1058985f22d79bb8986c1922e36816cd490fa27a",
+        "dest-filename": "stringify-entities-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+        "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+        "dest-filename": "strip-ansi-6.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+        "sha512": "c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+        "dest-filename": "strip-ansi-7.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+        "sha512": "bdabc03115ce80154d17a9f210498bdc304ad7d891a437282305beb3043e09b1a2bbb963bbab7e264940d4c1f07a85ad69d82de0849552c5cbc83ab7e1d75cc0",
+        "dest-filename": "strip-bom-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+        "sha512": "06ba6f7cd004ddd72fabb965df156e9b38ca8d9439b48d6c11420aaf752892cd17525e394addc595ab55a9e7fda6b9388d10f3856e96660fb76e4f77cbaa4b8c",
+        "dest-filename": "strip-final-newline-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+        "sha512": "74e112aa362bf7a89663294639bcdddfd12e3536b9549c72bd50049b926787b286a3be55e371e4d6874f424343c97366511ea4fa01220d55e78c1f0727772b5f",
+        "dest-filename": "strip-final-newline-3.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+        "sha512": "e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a",
+        "dest-filename": "strip-json-comments-3.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+        "sha512": "d6d0799a1568ed4f844c128d7fddb14f886b41ade99b4319d0f42fb839d68000061c3b1fa7894f4a9892ea9b2b4a27adf3bc3218f87d7edeb09a138c4348438b",
+        "dest-filename": "strip-json-comments-5.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+        "sha512": "46341eb7126bad424b40f1db2e4bba53fa1c1adcf28db24c3fd94234aec083408d87af749d21fcc28a961fdbb5ea732360102893e8bb24ed4d3f6a4ecbc22c3d",
+        "dest-filename": "style-to-js-1.1.21.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+        "sha512": "2c837bad42c8d2306c716418692b30a6dc9d7ab95aac592343eb7bf67cedcbcb5c20071e5689845652f31f954fe029acbfa32d2a1b3ba9a022c25729f8c81ac7",
+        "dest-filename": "style-to-object-1.0.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+        "sha512": "0e1b939af656bb1e07d543a758c077b24d2c6da0953a84198eff2ed6b0e84d5d074dd19e9bd864019b65e09672f0fdb3e018349d3f9831e385c95af8cdc1b94f",
+        "dest-filename": "sucrase-3.35.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+        "sha512": "32f8d7ce4cff04e7f2543906d2814eb41c475f6bb780a6cc1c817f7576e566c803dc158e14b987a2f229658ec1ca425d02372a442062d5660135d102f7223bbe",
+        "dest-filename": "sumchecker-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+        "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+        "dest-filename": "supports-color-7.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+        "sha512": "a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
+        "dest-filename": "supports-preserve-symlinks-flag-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+        "sha512": "ba98bfd191a462011c2de1a27a8cfc813ef8a161c0d04ec98af5fb68df6601ff9373b050a1106f9c8187a0f0f0f9ff535d35b8b3a906602649b5ab8fe8e629ee",
+        "dest-filename": "swagger2openapi-7.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwind-gradient-mask-image/-/tailwind-gradient-mask-image-1.2.0.tgz",
+        "sha512": "b5425a1a1bea6c916254a26ee845399fffcabc6755bd8dcbdd538536a8f3b64d77fa27c0934d297123470538077d488118e1330e7d201516d29ac7ed515d655c",
+        "dest-filename": "tailwind-gradient-mask-image-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+        "sha512": "de87e9f8b2fc13ea4afc9b8f2cf82054021a12e86f233e2a35c7f79c0d579f6a3fedf6fbb3f4d8a47870183bf5654dcf90196e515685f0fc821dc9b8f1c28b59",
+        "dest-filename": "tailwindcss-3.4.19.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+        "sha512": "b4e1bfec6c97a457af857561f2338f26b9ad469393b18a9422455d568a196094bfcfc5a17d0517f112482e67ae24d8a7180312bb5bde06be1ab121c5b79fe19e",
+        "dest-filename": "tar-7.5.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+        "sha512": "0b9b63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
+        "dest-filename": "temp-file-3.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+        "sha512": "c98aebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+        "dest-filename": "temp-0.9.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+        "sha512": "44dc501ffa88f3fb77b615c90f072cb543b8cdeaa8eb8f94cbffac355441c785e7d8e5fe399f683fe8899cd16aa6516b6b665455e28249ada85568b74f8b9598",
+        "dest-filename": "thenify-all-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+        "sha512": "455652215e481b5d079377a7a2dae1bf3d13f5e9ba7321c12e41ff60066e2aa77c85190a8527c218870fd8a518d043f19ddcc034198d965cd63f06a4f9b85e4b",
+        "dest-filename": "thenify-3.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+        "sha512": "e223152fa1c020d5d67f564a66320f733e7061a39d3e1b4ef004ef67e5eaa7705375aaad03042436628e46a708a3962442a197ab97307ecc03c0caaa40dae924",
+        "dest-filename": "thread-stream-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
+        "sha512": "1e532009bd9317f7532d1b649c19e3513b11f05b03a81638de2b58a29dbe660f36d88f8a77451adafb3c0af7c155e7d790174d0eb2cca114c60882297c2b837b",
+        "dest-filename": "three-0.163.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+        "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+        "dest-filename": "tiny-async-pool-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+        "sha512": "11eb7f79e32190ee935fc9a752d792f7380f6d43106b823a2a4a793918810f9e3bebf9be3c8462ba63f9b668798a82691fb939d4a7a16b0cb65037ec9f1c58f1",
+        "dest-filename": "tiny-case-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+        "sha512": "5cf68191640976c7f7a4b28957da78a8dfd2f9f9b63a3f0020fa35053521839a3192f9bdf92544185761c8ecfbb537544dfbf132202ce2ca7afde64ed84c3ea7",
+        "dest-filename": "tinycolor2-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+        "sha512": "a67f7d561a0009847c9c51e1c6a8b1faebec6d78a77806ac5a6e688d7a0df311302b929ddff4eb84d9f5c01cae0f9d94c5644bcbca6efa444c9e2122e84abd66",
+        "dest-filename": "tinyglobby-0.2.16.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+        "sha512": "47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
+        "dest-filename": "tmp-promise-3.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+        "sha512": "be8cb3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3",
+        "dest-filename": "tmp-0.2.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+        "sha512": "eb93fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1",
+        "dest-filename": "to-regex-range-5.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+        "sha512": "d1ae443a4014a7c0f89a8322d96f1917c8dc81aec181977dd4eff269b242158f1acfe5d2cde1b24cab34028a3cf7b895d4d8fa82e16af28ad60d2f7acfdd681a",
+        "dest-filename": "toposort-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+        "sha512": "37758cb2ea95eba953df40ab5cd6c48f1e06130968c37bfaaebe2609cbfaa6b9dfc214b4d6b920c857633cd05877d6ebecba57575f849a1d357c79ead86760af",
+        "dest-filename": "tr46-0.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+        "sha512": "9118fc07e60764273d91061d59f241dbfa1497dac0f7da9ba3061806daf8ba2e26672010d89a6f54177fe94d989680137ea06105348c853a60047b54d0c7f746",
+        "dest-filename": "trim-lines-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+        "sha512": "b663292b4d018d9894c95cafac12bb9277ab3609a0bdc57f28b572ba66bf482f9340dd7aec6acc45c880353cf4f7e937cd6f0bf2deb48d63b51a97e465d8d36b",
+        "dest-filename": "trough-2.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+        "sha512": "f793eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899",
+        "dest-filename": "truncate-utf8-bytes-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+        "sha512": "389fe26f184f96aacc33452234727fd02290928285db8dff0049a996ddeaa518245bc546ec87ce4b8d61ed5f138c84ea741c87ceb8dc4bfdac8becb894887c34",
+        "dest-filename": "ts-api-utils-2.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+        "sha512": "63f6abbdb9feaebcf72422a5f42e2454d7d37d29b6fe6129e454b3e44b194803463d2950ae9448e4ce0f285fa6267139da338ef743e73d273752bddb4d0c3480",
+        "dest-filename": "ts-interface-checker-0.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+        "sha512": "84f96ded90021114067f4dccdb9df2b4b6377476c6346ac0abda881d6518f571d8975cfbc189e04abdce439c66ba2f28d806b1b0e3712338da7cb522581a3516",
+        "dest-filename": "ts-node-9.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+        "sha512": "eace55ef5997f2a0549a581badf2f7df10d4c0ed1fab8f2bc40bb62c1135d5605e19da423ceb1792c41b6491ef1f086b77742352eb1dde600e3391a0d261412e",
+        "dest-filename": "ts-pattern-5.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+        "sha512": "d80736460cc37bf727e3c1af39edccfa8f36a4415ec03dd43dbca85071dd29ab07c092a376ce1f2d759ffd4c799004c128ddb4a1a146bbe8db125a75a68b349a",
+        "dest-filename": "tsconfig-paths-3.15.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+        "sha512": "5e78b7e4d2b38e032bc1ebf2b074c202bb4b0e93efc9ef3357fd04e04c989f8dcfeffeeabd0c0f87d0469077b06ccba5567b5b8a099c4fbadd5f704da3dc1126",
+        "dest-filename": "tslib-1.14.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+        "sha512": "a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+        "dest-filename": "tslib-2.8.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+        "sha512": "98728ade25172fedd417ac4be64d0f12129150128f042bfff919043a98d15b1c71dbb28a4419a603ad00f6980e52f322f062a144c3c49a30513f3b365bb3b538",
+        "dest-filename": "tsutils-3.21.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
+        "sha512": "656fe554c45a6c44ee60277d3bd66f321021f06b254aa6948f198afc92cf0a1ea5ef70af2c18ae5ecc23ffeecb76758e818b10d77d05a8bcc5cf96864f823752",
+        "dest-filename": "typanion-3.14.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+        "sha512": "5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
+        "dest-filename": "type-check-0.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+        "sha512": "df847b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732",
+        "dest-filename": "type-fest-0.13.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+        "sha512": "4401fcdb6a4074181c34c01f5a708153708565c7d9fe2d5e663c0553f76c2caba6caeb8fde78ae7a0d9402e917605d04d8002873cd994927fd2745900629f31c",
+        "dest-filename": "type-fest-2.19.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+        "sha512": "9c0618c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b",
+        "dest-filename": "typed-array-buffer-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+        "sha512": "05a5e03ae231cfc9fca48ab77bb02d83feecf83a6262bc67e2f768b77c3d29b9c185c450abaa37c5e9907487f29ea49e5de0eb177db1f96bdfce63a33e263d96",
+        "dest-filename": "typed-array-byte-length-1.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+        "sha512": "6d3940141fc505831cb97f3581b2f839ca47e4f9a5147aa5082a4097c025133333e64e77a0d0ef37ca753cd3962c4988db1e28ae9deb68e141e75b6ff57f8c15",
+        "dest-filename": "typed-array-byte-offset-1.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+        "sha512": "dca4b66fe90bedfb2e93f78967b1107671264286a1a3fafa29479fee1c6f96d340e4347c34050cfbcc0931b2726781bdffb8b7bf9ccf04830de5ac9b021dbf26",
+        "dest-filename": "typed-array-length-1.0.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+        "sha512": "57c8929e0f6645b7598e5e78549f4d2abe9907e756d09dd3cd15d119c49b2c87a3f6357ce9946d95879328347f40bc57ca4a1c27989c3736ec976fb94f322f71",
+        "dest-filename": "typescript-eslint-8.58.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+        "sha512": "0b423552caeb0c7a367d8239a1a0866d27a3c17e1c87ef58e634d010bbe8bdf98590adc71d264907c31225c58b982501cd005c842ad9f6b31157a1ae36bbc6b7",
+        "dest-filename": "typescript-4.8.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+        "sha512": "40287ef39982cbe8742067dff2be575b339549b04ef8a7de62b31087b349e7c42e8f0704db6bbe3544a6531a85fae9fbd0ff465cac5ad8708d8934cc2649f28d",
+        "dest-filename": "typescript-4.8.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+        "sha512": "f383154a33041cff854113f2de95fdb13555fc83487b1ef5b3d4cbd869b9146fd61b54aa5de2b267493bfdb958ff815d3b3235d82072d6f19ce2883f7aeb347f",
+        "dest-filename": "typescript-5.7.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+        "sha512": "8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
+        "dest-filename": "typescript-5.9.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+        "sha512": "9d627dd438de3a47a3fd303ca574379b2aee2a9284620aafa70f65cf838f1e3fcd585365b98ae36f3f63d35089f322907768388c5a0e9083424d6d88e4b104cb",
+        "dest-filename": "unbox-primitive-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+        "sha512": "673f9a6564a3f0b13ace8c43fb1ae387855f9081bc61ae8bbd8919aad5101893d98d8979df2a42694c16aa8ede234c7ae8a046791a3e9a504490c49e499dfc37",
+        "dest-filename": "undici-types-7.16.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+        "sha512": "b02f9bd2d075c21382cdbb65c76d1fc775a0097c245badbba78100f6e33efed34d3e4492f9e48495dea902cf670efed66d8d545258c13183edbbd0423ab09628",
+        "dest-filename": "undici-6.24.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+        "sha512": "c4abc684f5b0de4f3842387c6c8dd97898ea9f269d2be18416d6b349f66ffeb29e4e44e3389868ea616a87648cf7a888719a24c623a983bf066b34d283cf8a1c",
+        "dest-filename": "unified-11.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+        "sha512": "5d29c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535",
+        "dest-filename": "unique-filename-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+        "sha512": "f4e75aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e",
+        "dest-filename": "unique-slug-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+        "sha512": "2ec8882dbb41113903cfc23da75750d2ec91516b9a43377f72e11e4b5868452c96e44e571a64f39706353ab373cda906a3023d0ebfc8f0755ac38853b67c72f2",
+        "dest-filename": "unist-util-is-6.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+        "sha512": "7ee72c0bb1e35ef901e51de44c23bb9148d176b4b4049b7733f14fc661cc04e9bc2508b606c1c01c5b32dbb13412894ff2ba743735ec27e8cd3f20d6bce2593c",
+        "dest-filename": "unist-util-position-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+        "sha512": "d00495d3a000a0a083912dbec70e515c9cb0aeebaba5b0b82594a6ee7afb30eb75a23033bf2c9a3be53165fd7c8fc14217a926cc264a70080dff2bb6826d9781",
+        "dest-filename": "unist-util-stringify-position-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+        "sha512": "828875b354c1aea4aaba449cf30ae3c1684bd21889c6003c9b8905c46950fbc1584370bf9b5d45713b386187a6ed5ebae0084756f82840b93cf744ac76caf621",
+        "dest-filename": "unist-util-visit-parents-6.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+        "sha512": "9bebc87727823a976bfd07900aed84cf15ffa21812f0a6e73c38059e2e1d42c7d20ada73f14a83c98e468d1aeef0f0cab989fb16ad7d8f5090fa7252b0628ece",
+        "dest-filename": "unist-util-visit-5.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+        "sha512": "4e69c400402c04955933f0000c42ec2bbea5967c1c7fdbcc2ae3f3f097e53b57eb3bc2dc862b6bd1f35a37d77e029d018cab6a5aa77f275eea7839d787c08bd8",
+        "dest-filename": "universal-user-agent-7.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+        "sha512": "ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492",
+        "dest-filename": "universalify-0.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+        "sha512": "829b4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+        "dest-filename": "universalify-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+        "sha512": "6aaac76950565b52552811e61a8df74f94f178bd2a5b37ef8d6a2439b1c0f5b62637b78d0e4c0ec662e3862a0797df3bf2a0c5300693e755cdae8472bb3ed6c4",
+        "dest-filename": "unplugin-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+        "sha512": "6d28edf698da1019cd88681cf6b5221c62afe65e3f4c6cc3998c374619e4246b4b85b9e703fe6a263ef1ddd343091c7f3c9c6eefbe0b947f2508e941e2111f2a",
+        "dest-filename": "unrs-resolver-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+        "sha512": "26cd26f5cc7ea8e803c68d1e32214612e796cedcfe778f8cdeb1a598a3d3f93e084bf8cfe32970dcdc29bba7294d33fc4753000b5905e156dd2eddc045fdb4f7",
+        "dest-filename": "update-browserslist-db-1.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+        "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+        "dest-filename": "uri-js-4.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/use-double-tap/-/use-double-tap-1.3.7.tgz",
+        "sha512": "38e82902d4f553de83f235fac3f3835a12cc0e94bddb0558210c904348439ce80bacf1cdae46128d39e4a0f4f8d4668edf4c45e4e049ee6031177e2c1f19cb9e",
+        "dest-filename": "use-double-tap-1.3.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+        "sha512": "5e7d30dccb6243ace8cf6bc5c9456bb9a08be773bf0f052f90478ebe3faeba5326d019141985a6058572125a996922e163a643d2e95f537681adad9a553e317c",
+        "dest-filename": "utf8-byte-length-1.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+        "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+        "dest-filename": "util-deprecate-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+        "sha512": "5d07a021a0535548d21e588aa9c9c5a98ca901de12f96098b79348791b3ac3f500af2ef3f18f63e59c1144be24ceaf54dec0fabfef397abf45be411a0698e2db",
+        "dest-filename": "uuid-13.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+        "sha512": "bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
+        "dest-filename": "verror-1.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+        "sha512": "4131f3b067751216d9b3802c436d095f5ac2ddc3a5b7f21626bba4f3ddc37cb46be7b95c9ce78c6961b82b426b46d6b89882592ad87602ede6337bb4dff2562b",
+        "dest-filename": "vfile-message-4.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+        "sha512": "2b321b1fff6d5dab76bb7d237feb26330142b27a38c0755d366cc5c8bf93fcbdd41aaaa4e8929f56a3853991296521c00c7d64e3469be8d5085d9ab8db6a2fdd",
+        "dest-filename": "vfile-6.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+        "sha512": "a396bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+        "dest-filename": "vite-5.4.21.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+        "sha512": "ae9272376db629622f1c9fc5e775d266fd1997f69c72a1d1f1eb7592968c4c3fdf2c2471b55f225fc73333363bb1566ea53237cdc51383c7b2712da4345f65eb",
+        "dest-filename": "warning-4.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+        "sha512": "5c73c4c12d2ae936b172f1bce7ef046246e20aec765ed586da691ce3b360d80efb050bbdf83a8838995d493e0780f92e79aeddbca4a3e55817dcfd5de2b5bc4e",
+        "dest-filename": "wcwidth-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+        "sha512": "d89027df3f0047aae32bc4a6f28ad10b487f6dc97f0ea2fbb513dd199e08d428dd17e11a30b998c411f25ee28bf38f5eb9c3c586f068c4cb1f95f39bf24c5a79",
+        "dest-filename": "webidl-conversions-3.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+        "sha512": "eed3f53dd578bc5fa560f9e4311d23318e7f95adae6f915cffc550aeb53e95792233a0b84e355f1b0ee229fca19d340eb03fba43f88ac34785722ce24600f9f1",
+        "dest-filename": "webpack-sources-3.3.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+        "sha512": "9320e2bc567b64cd0154e52d7956c3161951b7b021fc248fc09762f2106990aed02ee994a9d2ed55f9bf3d7fe191c9ebbebd22efb7cee7e4e367de0f7be0bd8b",
+        "dest-filename": "webpack-virtual-modules-0.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+        "sha512": "b1a139ee7ba9c64eafdc7637e7e8f307061ad2b292cb45d1f094b164fc202ebef2b34201ce11af880d7f4d41892e6495aacf296fd027bc809712e3872e9ad84f",
+        "dest-filename": "whatwg-url-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+        "sha512": "4db5f79a3f27d2874204556563c03192a707012c372fad2322e17c8c53fbf1acf70b6621986bea6c70690234d11f6ff1a98ba7ac9f60d634b28c28e9a16cc800",
+        "dest-filename": "which-boxed-primitive-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+        "sha512": "ea205cce85fe90343b6b7f982419e1dd3f8a651c4cfe260d3d789caa4ebafd07e6d5bf778aefb23889a4834cc76e3e4b34e70dbf54c4003899d316b7e01e2ae9",
+        "dest-filename": "which-builtin-type-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+        "sha512": "2b88d5ca39c1760bdcf3a63a06468b64437ddf74b060eb8116476606ef597e47006dd55ba484e70e68ef67f6908d15d0aefe443e44e70f5b37f468a2a9b9e00b",
+        "dest-filename": "which-collection-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+        "sha512": "2d87e95249aac25d21f40d872f4f4c9ace36ed0d51656b8e1ecba47d570a46af6af79890c5dc348b1d4942ba9b70347d3c7d500f07f9428f0e65be6592c67c5e",
+        "dest-filename": "which-typed-array-1.1.20.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+        "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+        "dest-filename": "which-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+        "sha512": "244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
+        "dest-filename": "which-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+        "sha512": "04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
+        "dest-filename": "word-wrap-1.2.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+        "sha512": "6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+        "dest-filename": "wrap-ansi-7.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+        "sha512": "b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09",
+        "dest-filename": "wrap-ansi-8.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+        "sha512": "e3602d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3",
+        "dest-filename": "wrap-ansi-9.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+        "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+        "dest-filename": "wrappy-1.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+        "sha512": "f9d6c5d6d1f06695dc6ce25d54e9332c3c593f56a296f4b133a6707974de83294f9f2f34ddb16103ebea058c38b37d4d4809384b6433f802972bd6b8c2476371",
+        "dest-filename": "ws-7.5.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+        "sha512": "b00b7c06180d6f30ad8066edd8ec66a6eaf23badd9a0393fb2a681ff39d09bde13e1f084b32ff257eec2742d64261394f656e800453b47792abaec9c0e889b54",
+        "dest-filename": "ws-8.20.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+        "sha512": "83f7b38a24943414ac74326d08b07c6dd60450c8f88d1ec019e528f7aa7fddd4da7e08c78691784620853e24482f08d0a035f1e4caa406be1fc16b51dcacb85a",
+        "dest-filename": "wsl-utils-0.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+        "sha512": "c8ca8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
+        "dest-filename": "xmlbuilder-15.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+        "sha512": "d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+        "dest-filename": "y18n-5.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+        "sha512": "6b850641a58f1f9f663975189c01b67b09dc412e22e05e374efdc9a0033eb365430264bd36c2bc1a90cc2eb0873e4b054fb8772ba4cea14367da96fb4685f1e2",
+        "dest-filename": "yallist-3.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+        "sha512": "df074689d672ab93c1d3ce172c44b94e9392440df08d7025216321ba6da445cbffe354a7d9e990d1dc9c416e2e6572de8f02af83a12cbdb76554bf8560472dec",
+        "dest-filename": "yallist-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+        "sha512": "620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f",
+        "dest-filename": "yallist-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+        "sha512": "bc861e175bb70a39610057a43cf024da1fcabf84f798090ca31e4eca6462250074b290cfd742c7bedf8aec6f4dcba36eb8c01bdb9ffa9f5ab252301c18d7ff00",
+        "dest-filename": "yaml-1.10.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+        "sha512": "02f6da08b38ed8eb70fe55b96e687d77f58475c0c5750a766766541f7a57f54da2872518d27bcbbfb27a4eb5a8c2495118f61b07f22e20c7d88316823e0e41a6",
+        "dest-filename": "yaml-2.8.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+        "sha512": "cb5d67184953215f824f766ff6ded52a5f90de14d0a13f5ad50cdece1865e91a76d6027f2154d6ed9df2f4459786e5010b64a19dff835f46a7b5e72903048ff3",
+        "dest-filename": "yargs-parser-20.2.9.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+        "sha512": "b55a6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+        "dest-filename": "yargs-parser-21.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+        "sha512": "0f59afbed0c6d0be5fb7f8c65a42e91b5fa6d1e43139f681bd33442eb6968f6db049550c5b1654bd880961c2a1ea3186224245847e0864f4214784caa5cf2607",
+        "dest-filename": "yargs-16.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+        "sha512": "edd4b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb",
+        "dest-filename": "yargs-17.7.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+        "sha512": "a786bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde",
+        "dest-filename": "yauzl-2.10.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+        "sha512": "531e328065acbb673b8ac1567bc62ed5896e266a95871a8ad9c2d735003901c0b741f6c636933b7eed18f1bff3d7aa572e7171658bd685dddf84163d0cb982e9",
+        "dest-filename": "yn-3.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+        "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+        "dest-filename": "yocto-queue-0.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+        "sha512": "18a1c55f69d7ba5dbfe03b5fc61a33bfbd358cb40775fe89df8603876704929aa8a3c95ee4c83afcbaddb1e54bac56ab985ca065395f2211f1fd029f6ff4165f",
+        "dest-filename": "yup-1.7.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+        "sha512": "43afe764b7ba8f1b94f34a9bff8b89e2de6fd95119e389734233c385824dced450e30c9673a545dc3dca6ff7c0b8f7ad6509e14b78676a309ff42b167ac8212d",
+        "dest-filename": "zod-validation-error-4.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+        "sha512": "adfb65ae484764e7230f090696752d65992f68f1c2b03013a78a46a6e38e3036937430d717dd70b950c9a16a0fb0a5ffdd83d0e5f1ee1774938dc6322abf9086",
+        "dest-filename": "zod-4.3.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+        "sha512": "6d7138711fe455984a657fd18cf11f94768a56151597ce67a14defe9bf1aa5f404735c7803ecc1c6367894df0ba8677a599ddd97df29638a3bd7b5459a83e9f8",
+        "dest-filename": "zwitch-2.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "inline",
+        "contents": "from __future__ import annotations\n\nimport base64\nimport contextlib\nimport hashlib\nimport json\nimport os\nimport re\nimport sqlite3\nimport struct\nimport sys\nimport tarfile\nimport time\nfrom collections.abc import Mapping\n\n_SANITIZE_RE = re.compile(r'[\\\\/:*?\"<>|]')\n_MAX_LENGTH_WITHOUT_HASH = 120\n\n\ndef _msgpack_pack(obj: object) -> bytes:\n    \"\"\"Minimal msgpack packer matching msgpackr with useRecords: true.\n\n    msgpackr reserves the byte range 0x40-0x7F for record IDs when useRecords\n    is enabled (pnpm's config).  Standard msgpack uses 0x00-0x7F for positive\n    fixints, but this packer caps them at 0x3F and emits a uint 8 prefix (0xcc)\n    for 64-255 to avoid aliasing with record ID bytes.\n    \"\"\"\n\n    def _pack_int(val: int) -> bytes:\n        # Positive fixint capped at 0x3F \u2014 0x40-0x7F are msgpackr record IDs\n        if 0 <= val <= 0x3F:\n            return val.to_bytes(1, 'big')\n        if -32 <= val < 0:\n            return val.to_bytes(1, 'big', signed=True)\n        if val >= 0:\n            if val <= 0xFF:\n                return b'\\xcc' + val.to_bytes(1, 'big')\n            if val <= 0xFFFF:\n                return b'\\xcd' + val.to_bytes(2, 'big')\n            if val <= 0xFFFFFFFF:\n                return b'\\xce' + val.to_bytes(4, 'big')\n            return b'\\xcf' + val.to_bytes(8, 'big')\n        if val >= -0x80:\n            return b'\\xd0' + val.to_bytes(1, 'big', signed=True)\n        if val >= -0x8000:\n            return b'\\xd1' + val.to_bytes(2, 'big', signed=True)\n        if val >= -0x80000000:\n            return b'\\xd2' + val.to_bytes(4, 'big', signed=True)\n        return b'\\xd3' + val.to_bytes(8, 'big', signed=True)\n\n    def _pack_str(val: str) -> bytes:\n        data = val.encode('utf-8')\n        length = len(data)\n        if length <= 0x1F:\n            return (0xA0 | length).to_bytes(1, 'big') + data\n        if length <= 0xFF:\n            return b'\\xd9' + length.to_bytes(1, 'big') + data\n        if length <= 0xFFFF:\n            return b'\\xda' + length.to_bytes(2, 'big') + data\n        return b'\\xdb' + length.to_bytes(4, 'big') + data\n\n    if obj is None:\n        return b'\\xc0'\n    if isinstance(obj, bool):\n        return b'\\xc3' if obj else b'\\xc2'\n    if isinstance(obj, int):\n        return _pack_int(obj)\n    if isinstance(obj, float):\n        return b'\\xcb' + struct.pack('>d', obj)\n    if isinstance(obj, str):\n        return _pack_str(obj)\n    if isinstance(obj, dict):\n        length = len(obj)\n        if length <= 0x0F:\n            result = (0x80 | length).to_bytes(1, 'big')\n        elif length <= 0xFFFF:\n            result = b'\\xde' + length.to_bytes(2, 'big')\n        else:\n            result = b'\\xdf' + length.to_bytes(4, 'big')\n        for key, val in obj.items():\n            result += _msgpack_pack(key) + _msgpack_pack(val)\n        return result\n    if isinstance(obj, (list, tuple)):\n        length = len(obj)\n        if length <= 0x0F:\n            result = (0x90 | length).to_bytes(1, 'big')\n        elif length <= 0xFFFF:\n            result = b'\\xdc' + length.to_bytes(2, 'big')\n        else:\n            result = b'\\xdd' + length.to_bytes(4, 'big')\n        for item in obj:\n            result += _msgpack_pack(item)\n        return result\n    raise TypeError(f'Unsupported type for msgpack: {type(obj)}')\n\n\nRECORD_HEADER = b'\\xd4\\x72'\n\n\ndef _pack_v11_store_entry(\n    files: dict[str, dict[str, object]],\n    manifest: dict[str, str] | None = None,\n) -> bytes:\n    \"\"\"Encode a store v11 entry using msgpackr-compatible record extensions.\n\n    msgpackr with ``useRecords: true, moreTypes: true`` decodes:\n\n    - standard msgpack maps (0x80/0xde/0xdf) as JavaScript ``Map`` objects\n      (iterable, supports ``for..of``)\n    - record extensions (0x72) as plain objects (dot-notation access)\n\n    The ``files`` field must be a Map so pnpm can iterate it with ``for..of``.\n    Everything else must use record extensions so dot-notation works\n    (e.g. ``pkgIndex.algo``, ``info.digest``, ``manifest.name``).\n    \"\"\"\n\n    def _record(obj: Mapping[str, object], struct_id: int) -> bytes:\n        keys = list(obj.keys())\n        result = RECORD_HEADER + struct_id.to_bytes(1, 'big')\n        result += _msgpack_pack(keys)\n        for k in keys:\n            result += _msgpack_pack(obj[k])\n        return result\n\n    def _fixmap(length: int) -> bytes:\n        if length <= 0x0F:\n            return (0x80 | length).to_bytes(1, 'big')\n        if length <= 0xFFFF:\n            return b'\\xde' + length.to_bytes(2, 'big')\n        return b'\\xdf' + length.to_bytes(4, 'big')\n\n    # Pack file entries as records, build files map as standard msgpack map\n    files_map_bytes = _fixmap(len(files))\n    for fname, finfo in files.items():\n        files_map_bytes += _msgpack_pack(fname) + _record(finfo, 0x41)\n\n    # Outer store_entry as record (struct_id 0x40)\n    store_entry_keys = ['algo', 'requiresBuild', 'files']\n    if manifest is not None:\n        store_entry_keys.append('manifest')\n\n    # Record with fixed entries\n    result = RECORD_HEADER + b'\\x40' + _msgpack_pack(store_entry_keys)\n    # This is hardcoded to use sha512 per pnpm's behavior, see @pnpm/store.cafs/index and\n    # file digest logic below\n    result += _msgpack_pack('sha512')  # algo\n    result += _msgpack_pack(False)  # requiresBuild\n    result += files_map_bytes  # files (standard map \u2192 iterable Map in JS)\n\n    if manifest is not None:\n        result += _record(manifest, 0x42)\n    return result\n\n\ndef populate_store(manifest_path: str, tarball_dir: str, store_dir: str) -> None:\n    with open(manifest_path, encoding='utf-8') as f:\n        manifest = json.load(f)\n\n    store_version = manifest['store_version']\n    packages = manifest['packages']\n\n    index_db: sqlite3.Connection | None = None\n\n    store = os.path.join(store_dir, store_version)\n    os.makedirs(os.path.join(store, 'files'), exist_ok=True)\n    if store_version == 'v11':\n        index_db = sqlite3.connect(os.path.join(store, 'index.db'))\n        index_db.execute('PRAGMA busy_timeout=5000')\n        index_db.execute('PRAGMA journal_mode=WAL')\n        index_db.execute('PRAGMA synchronous=NORMAL')\n        index_db.execute('PRAGMA temp_store=MEMORY')\n        index_db.execute(\n            'CREATE TABLE IF NOT EXISTS package_index ('\n            '  key TEXT PRIMARY KEY,'\n            '  data BLOB NOT NULL'\n            ') WITHOUT ROWID'\n        )\n    else:\n        os.makedirs(os.path.join(store, 'index'), exist_ok=True)\n\n    now = int(time.time() * 1000)\n\n    for tarball_name, info in packages.items():\n        tarball_path = os.path.join(tarball_dir, tarball_name)\n        if not os.path.isfile(tarball_path):\n            raise FileNotFoundError(tarball_path)\n\n        _process_tarball(\n            tarball_path=tarball_path,\n            pkg_name=info['name'],\n            pkg_version=info['version'],\n            integrity=info['integrity'],\n            integrity_digest=info['integrity_digest'],\n            integrity_algo=info['integrity_algo'],\n            store=store,\n            now=now,\n            tarball_url=info.get('tarball_url'),\n            store_version=store_version,\n            index_db=index_db,\n        )\n\n    if index_db is not None:\n        index_db.commit()\n        index_db.close()\n\n\ndef _process_tarball(\n    *,\n    tarball_path: str,\n    pkg_name: str,\n    pkg_version: str,\n    integrity: str,\n    integrity_digest: str,\n    integrity_algo: str,\n    store: str,\n    now: int,\n    tarball_url: str | None = None,\n    store_version: str = 'v3',\n    index_db: sqlite3.Connection | None = None,\n) -> None:\n    index_files: dict[str, dict[str, object]] = {}\n    file_digests: dict[str, str] = {}\n    real_pkg_name = pkg_name\n    real_pkg_version = pkg_version\n\n    with tarfile.open(tarball_path, 'r:gz') as tf:\n        for member in tf.getmembers():\n            if not member.isfile():\n                continue\n            fobj = tf.extractfile(member)\n            if fobj is None:\n                continue\n            data = fobj.read()\n\n            if member.name.endswith('package.json') and member.name.count('/') <= 1:\n                with contextlib.suppress(ValueError, TypeError, UnicodeDecodeError):\n                    pkg_data = json.loads(data.decode('utf-8'))\n                    if isinstance(pkg_data, dict):\n                        if 'name' in pkg_data and isinstance(pkg_data['name'], str):\n                            real_pkg_name = pkg_data['name']\n                        if 'version' in pkg_data and isinstance(\n                            pkg_data['version'], str\n                        ):\n                            real_pkg_version = pkg_data['version']\n\n            digest = hashlib.sha512(data).digest()\n            file_hex = digest.hex()\n            is_exec = bool(member.mode & 0o111)\n\n            cas_dir = os.path.join(store, 'files', file_hex[:2])\n            cas_name = file_hex[2:] + ('-exec' if is_exec else '')\n            cas_path = os.path.join(cas_dir, cas_name)\n            if not os.path.exists(cas_path):\n                os.makedirs(cas_dir, exist_ok=True)\n                with open(cas_path, 'wb') as out:\n                    out.write(data)\n                if is_exec:\n                    os.chmod(cas_path, 0o755)\n\n            rel_name = member.name\n            if '/' in rel_name:\n                rel_name = rel_name.split('/', 1)[1]\n\n            b64 = base64.b64encode(digest).decode()\n            index_files[rel_name] = {\n                'checkedAt': now,\n                'integrity': f'sha512-{b64}',\n                'mode': member.mode,\n                'size': len(data),\n            }\n            file_digests[rel_name] = file_hex\n\n    if store_version == 'v11':\n        assert index_db is not None\n        # pnpm v11 store index keys use the raw package name (e.g. @scope/pkg),\n        # not the filesystem-sanitized form (@scope+pkg), since keys are stored\n        # in SQLite, not as filenames.\n        raw_pkg_id = f'{pkg_name}@{pkg_version}'\n        key = f'{integrity_algo}-{integrity}\\t{raw_pkg_id}'\n\n        v11_files: dict[str, dict[str, object]] = {}\n        for rel_name, finfo in index_files.items():\n            checked_at = finfo['checkedAt']\n            assert isinstance(checked_at, int)\n            v11_files[rel_name] = {\n                'checkedAt': float(checked_at),  # float64 avoids msgpackr BigInt\n                'digest': file_digests[rel_name],\n                'mode': finfo['mode'],\n                'size': finfo['size'],\n            }\n\n        manifest = None\n        if real_pkg_name or real_pkg_version:\n            manifest = {\n                'name': real_pkg_name,\n                'version': real_pkg_version,\n            }\n\n        entry_bytes = _pack_v11_store_entry(v11_files, manifest)\n\n        # It's currently not possible to fully determine which store key pnpm will use,\n        # so we insert multiple keys to ensure pnpm can find the entry it wants.\n\n        index_db.execute(\n            'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n            (key, entry_bytes),\n        )\n\n        if tarball_url:\n            url_key = f'{tarball_url}\\t{raw_pkg_id}'\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (url_key, entry_bytes),\n            )\n\n            # pnpm looks up git-hosted tarballs (codeload.github.com,\n            # bitbucket.org, gitlab.com) and tarballs without integrity by\n            # {tarball_url}\\tbuilt(not-built) \u2014 see pickStoreIndexKey in @pnpm/store.index.\n            pkgid_key = f'{tarball_url}\\t'\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (pkgid_key + 'built', entry_bytes),\n            )\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (pkgid_key + 'not-built', entry_bytes),\n            )\n    else:\n        pkg_id = _SANITIZE_RE.sub('+', f'{pkg_name}@{pkg_version}')\n\n        index_data = {\n            'name': real_pkg_name,\n            'version': real_pkg_version,\n            'requiresBuild': False,\n            'files': index_files,\n        }\n\n        idx_prefix = integrity_digest[:2]\n        idx_rest = integrity_digest[2:64]\n        idx_dir = os.path.join(store, 'index', idx_prefix)\n        os.makedirs(idx_dir, exist_ok=True)\n        idx_path = os.path.join(idx_dir, f'{idx_rest}-{pkg_id}.json')\n        with open(idx_path, 'w', encoding='utf-8') as out:\n            json.dump(index_data, out)\n\n        # For tarball-URL packages, also create an index entry keyed by the URL hash\n        # this is how pnpm looks up tarball deps without integrity\n        if tarball_url:\n            if store_version == 'v3':\n                url_hash = hashlib.sha256(tarball_url.encode()).hexdigest()\n                url_idx_prefix = url_hash[:2]\n                url_idx_rest = url_hash[2:64]\n                url_idx_dir = os.path.join(store, 'index', url_idx_prefix)\n                os.makedirs(url_idx_dir, exist_ok=True)\n                url_idx_path = os.path.join(\n                    url_idx_dir, f'{url_idx_rest}-{pkg_id}.json'\n                )\n                with open(url_idx_path, 'w', encoding='utf-8') as out:\n                    json.dump(index_data, out)\n            else:\n                url_dir_name = re.sub(r'[:/]', '+', tarball_url)\n                if (\n                    len(url_dir_name) > _MAX_LENGTH_WITHOUT_HASH\n                    or url_dir_name != url_dir_name.lower()\n                ):\n                    url_dir_name = f'{url_dir_name[: _MAX_LENGTH_WITHOUT_HASH - 33]}_{hashlib.sha256(url_dir_name.encode()).hexdigest()[:32]}'\n                url_idx_dir = os.path.join(store, url_dir_name)\n                os.makedirs(url_idx_dir, exist_ok=True)\n                url_idx_path = os.path.join(url_idx_dir, 'integrity.json')\n                with open(url_idx_path, 'w', encoding='utf-8') as out:\n                    json.dump(index_data, out)\n\n\nif __name__ == '__main__':\n    if len(sys.argv) != 4:\n        print(\n            f'Usage: {sys.argv[0]} <manifest.json> <tarball-dir> <store-dir>',\n            file=sys.stderr,\n        )\n        sys.exit(1)\n    populate_store(sys.argv[1], sys.argv[2], sys.argv[3])\n",
+        "dest-filename": "populate_pnpm_store.py",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"packages\":{\"7zip-bin-5.2.0.tgz\":{\"integrity\":\"ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ba44cf561a86e2337332ba36a80f4748249254937768deed95bfa17ea602b77111d325aba1e036551dfc30dace1cb43f7158fe0da20c69dd24142b565a8c21fc\",\"name\":\"7zip-bin\",\"version\":\"5.2.0\"},\"@alloc__quick-lru-5.2.0.tgz\":{\"integrity\":\"UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f\",\"name\":\"@alloc/quick-lru\",\"version\":\"5.2.0\"},\"@babel__code-frame-7.29.0.tgz\":{\"integrity\":\"9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4d8427988eaf7edeec6076da76d0b4a225726f37415e0ad346a49c6e3056752afddc59435be833a127052f7150b328647ae9cc389e3c0cea1ac92ea80ec1b73\",\"name\":\"@babel/code-frame\",\"version\":\"7.29.0\"},\"@babel__compat-data-7.29.0.tgz\":{\"integrity\":\"T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f534226a4ff8fdf9c9fc7ef92dee3b706cb05f2c2ff5cb573b36d09e5c5460cc64ec69f8baf0c46ff32ce46126a9067140e8bdd4d9549cd367220f3a0026126\",\"name\":\"@babel/compat-data\",\"version\":\"7.29.0\"},\"@babel__core-7.29.0.tgz\":{\"integrity\":\"CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"08639f389a968e0daa5bf31beb336c0e6faee6f150f03c577db334f73ebda7967afa61358a43f68d45f0fa3e363dfd574d8103d919e2e5ff799e961ebb030340\",\"name\":\"@babel/core\",\"version\":\"7.29.0\"},\"@babel__generator-7.29.1.tgz\":{\"integrity\":\"qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"aac685fbd41c9b642ff1244830cb1c02f1b83b7949d05d46b8ca391d1fc1a74d8ba293609d9042fc491b7af1c5786b3896cfe83f3f6ff81b26cdb91b7bed1d53\",\"name\":\"@babel/generator\",\"version\":\"7.29.1\"},\"@babel__helper-compilation-targets-7.28.6.tgz\":{\"integrity\":\"JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"258b65b3786a8b5e5f731e4669234bed209327630d9a3ae41d7838152a4e03f82bc4af0ac326796ee6c7b02abc1570a4b9aeb186e69a062b7eddbefe55945f70\",\"name\":\"@babel/helper-compilation-targets\",\"version\":\"7.28.6\"},\"@babel__helper-globals-7.28.0.tgz\":{\"integrity\":\"+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f96e9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887\",\"name\":\"@babel/helper-globals\",\"version\":\"7.28.0\"},\"@babel__helper-module-imports-7.28.6.tgz\":{\"integrity\":\"l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9795e464aeebef06bd2ee706c3d2f0672c8252c71be31dfb2564cfcfbb30c0513fd05310006a62594667f2ef43ce448158470adb98e6bee6dfa70d9d9c031d6f\",\"name\":\"@babel/helper-module-imports\",\"version\":\"7.28.6\"},\"@babel__helper-module-transforms-7.28.6.tgz\":{\"integrity\":\"67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ebba1714062bd9c0cb0d518b5d3100063741259e9dac4954488ed62a9ef436ba72212b28de9946f52006105eb2ef36e16bfc0ecd40725964c9bc40d534850670\",\"name\":\"@babel/helper-module-transforms\",\"version\":\"7.28.6\"},\"@babel__helper-plugin-utils-7.28.6.tgz\":{\"integrity\":\"S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4bd83367f6f3f37191cac23b8000f8c0f4ff008dee0a763ef719fe331fca3ecd89c07248cf55bc3d9920d9cab2b7744d38133c7a3717855eb2f0e83b972fc3ba\",\"name\":\"@babel/helper-plugin-utils\",\"version\":\"7.28.6\"},\"@babel__helper-string-parser-7.27.1.tgz\":{\"integrity\":\"qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a8c952c4a6e946502b89d0c4c64f769d2a1bc837693e28d4ab60d6ea80e752a77488e1b19908f2aa13088a123dfb3bf82cfc997518ded9c6af58f6c26d69b778\",\"name\":\"@babel/helper-string-parser\",\"version\":\"7.27.1\"},\"@babel__helper-validator-identifier-7.28.5.tgz\":{\"integrity\":\"qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a92b3889fc33289495dfdb9c363b2f73a5951ece9bed2d37b0e87639c1c5f541df54fa965802d4b0d515ce1481888b63459a0b1f1ee721aad58ea295bac519d5\",\"name\":\"@babel/helper-validator-identifier\",\"version\":\"7.28.5\"},\"@babel__helper-validator-option-7.27.1.tgz\":{\"integrity\":\"YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"62f8c9a30f45c5b84514a0d2b859d509ed96c57935cd6736d9f15e3d5344696244bbc22b65595d6ba374b87c3366b50cd6297b342f4c969e0c68961b61df494a\",\"name\":\"@babel/helper-validator-option\",\"version\":\"7.27.1\"},\"@babel__helpers-7.29.2.tgz\":{\"integrity\":\"HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e81ae52ce2c09935ecd510a755730aa664df06a078ab2d470b69854d04ad89d0369d1ad75caa0af70426ef1fcf97528e0d1a3365dd53ad4a310a373a9f1602b\",\"name\":\"@babel/helpers\",\"version\":\"7.29.2\"},\"@babel__parser-7.29.2.tgz\":{\"integrity\":\"4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e06811cf2ffe7ec05aef6fd165526618a3e666ef41ca7f28e0ca0ba6635ed66f197d89f3e5e9872d0cf753880bb9de99c25d1164872088b0fb52aef2485b832c\",\"name\":\"@babel/parser\",\"version\":\"7.29.2\"},\"@babel__plugin-transform-arrow-functions-7.27.1.tgz\":{\"integrity\":\"8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f19e131a273ac56ef414a4e10391d810a2b206938eb2e713383d438d4ddf6710e0f8adf30497173059edff8c908999dfe7e32238c49743d3da10afc8961d4378\",\"name\":\"@babel/plugin-transform-arrow-functions\",\"version\":\"7.27.1\"},\"@babel__plugin-transform-react-jsx-self-7.27.1.tgz\":{\"integrity\":\"6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e94ce40acf9e8c6759e661450bf38252bbf4dbc69bd9fa75ce76660998c03812a204ada35c3d4ef813d27d7f17daa8c9ef97d904c4a7427dd1ab69ab0492b69b\",\"name\":\"@babel/plugin-transform-react-jsx-self\",\"version\":\"7.27.1\"},\"@babel__plugin-transform-react-jsx-source-7.27.1.tgz\":{\"integrity\":\"zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cdbc284ec06bb9378a07d852abbde16baea215e247b9a16451bc2fa84967ca0a0d6e3fe31d1b127a8928c1914ddc267ae08bc4a9c9a69157bcf4e3d773b95d03\",\"name\":\"@babel/plugin-transform-react-jsx-source\",\"version\":\"7.27.1\"},\"@babel__runtime-7.29.2.tgz\":{\"integrity\":\"JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2620d2847e39cca1d6c867b864d551ac28c1cfc361f53326646d648784132bc8420535818bc0dafa2eecd5f270eff958a4ce1c71ea5235fab367f42f001062e6\",\"name\":\"@babel/runtime\",\"version\":\"7.29.2\"},\"@babel__template-7.28.6.tgz\":{\"integrity\":\"YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"600e8c6b62ac09d19bf960ba5290551491972f9f0c0c0ea8c8e35b8f217ffb9b0183163f7709212e881b313d865d7c94f38fc8851c3fd83d4eb3507f822cfe05\",\"name\":\"@babel/template\",\"version\":\"7.28.6\"},\"@babel__traverse-7.29.0.tgz\":{\"integrity\":\"4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e073e242bd17efec1a1dfc973d9a563df58bfc9edd70dd66c7d80be9675054c6cf9c5dfe66148cb3cb42c4dee81dd74913d7e1344efe9717679727a629f251b8\",\"name\":\"@babel/traverse\",\"version\":\"7.29.0\"},\"@babel__types-7.29.0.tgz\":{\"integrity\":\"LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2f07591e949c338433f17c3688a4b34be71f825673246be87d0202cbb5bbbf871aaeee046809b252e3ba046adbc90da6615d755b453c8f998185dd7875ddc1d0\",\"name\":\"@babel/types\",\"version\":\"7.29.0\"},\"@clack__core-0.4.1.tgz\":{\"integrity\":\"Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3f18628f851783c292afbacf7a4e99a309bee4cdb6adb7768359dfa231c9931a7962416a899dbe60b10cfd7195233bc639c3349ea8c8171ae90f05916585988c\",\"name\":\"@clack/core\",\"version\":\"0.4.1\"},\"@clack__prompts-0.9.1.tgz\":{\"integrity\":\"JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"248a7269ba1865e5989723f41fe3a83cfc5dea7aae786fc298dea2c4188d16c2031d111ebe321fd27d0e861e60af90bca440e49f382fcfea4827c74c8735887a\",\"name\":\"@clack/prompts\",\"version\":\"0.9.1\"},\"@develar__schema-utils-2.6.5.tgz\":{\"integrity\":\"0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1ca783ec590ffd6afa9354c0ad67e1a2ae2908037ea292f8ed1f0794e3f8fcc8bb6039b234f8950f858152720c25b5ebde181d6bb770a6f1484dd385dac838a\",\"name\":\"@develar/schema-utils\",\"version\":\"2.6.5\"},\"@discordjs__collection-2.1.1.tgz\":{\"integrity\":\"LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2e24aeb337bd4dceea174dec2c2ba3179899a7b2bebd13440c167ce854fd69002fdefc4c2e2854bcabe9b025a24360c9ab5b55724a292a6d6bc689a035473d86\",\"name\":\"@discordjs/collection\",\"version\":\"2.1.1\"},\"@discordjs__rest-2.6.1.tgz\":{\"integrity\":\"wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3041d82379aa18162686f9ab5bab1e9a243a6a5bb247028d07ad09014db633337fcf2771b079022980494d706676e830943973326b061dd1817bbedafe7d95e\",\"name\":\"@discordjs/rest\",\"version\":\"2.6.1\"},\"@discordjs__util-1.2.0.tgz\":{\"integrity\":\"3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dcb28fec5dbe6ad97dbc91616818e7e2739a4966a167fc968cebc0e1ee699d792ddaac974421cbc68050cbcd4616d2c60aaecaf653e6f51e75eccd54fbff7442\",\"name\":\"@discordjs/util\",\"version\":\"1.2.0\"},\"@dword-design__dedent-0.7.0.tgz\":{\"integrity\":\"OFmAmzKiDUh9m7WRMYcoEOPI7b5tS5hdqQmtKDwF+ZssVJv8a+GHo9VOtFsmlw3h8Roh/9QzFWIsjSFZyQUMdg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3859809b32a20d487d9bb59131872810e3c8edbe6d4b985da909ad283c05f99b2c549bfc6be187a3d54eb45b26970de1f11a21ffd43315622c8d2159c9050c76\",\"name\":\"@dword-design/dedent\",\"version\":\"0.7.0\"},\"@dword-design__endent-1.4.7.tgz\":{\"integrity\":\"yK1ivALMq9Eys6O9SgO+jBpRbQBLruFL2FvWMWPcoqiY1hPDHleY02Vir6jN6j7tDiMog3tjVtqKb4eWXdKo1w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c8ad62bc02ccabd132b3a3bd4a03be8c1a516d004baee14bd85bd63163dca2a898d613c31e5798d36562afa8cdea3eed0e2328837b6356da8a6f87965dd2a8d7\",\"name\":\"@dword-design/endent\",\"version\":\"1.4.7\"},\"@dword-design__eslint-plugin-import-alias-4.0.9.tgz\":{\"integrity\":\"GbDZ0HJOnLgc8X2iGM+SW/2Y2Zi8qJ96+zsJWO4nhfEmHSKPcC3MUldVFLrrHy1z5R+MEba6tp7455U2UYB0bQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"19b0d9d0724e9cb81cf17da218cf925bfd98d998bca89f7afb3b0958ee2785f1261d228f702dcc52575514baeb1f2d73e51f8c11b6bab69ef8e795365180746d\",\"name\":\"@dword-design/eslint-plugin-import-alias\",\"version\":\"4.0.9\"},\"@dword-design__functions-5.0.27.tgz\":{\"integrity\":\"16A97RKtn21xLWI7Y7VhFz4WCWui+TLit/J5/l77BDpWmPi2LzgjQzDbafDDw7OUeY6GEAi/M4jdbuQhsIbSEg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d7a03ded12ad9f6d712d623b63b561173e16096ba2f932e2b7f279fe5efb043a5698f8b62f38234330db69f0c3c3b394798e861008bf3388dd6ee421b086d212\",\"name\":\"@dword-design/functions\",\"version\":\"5.0.27\"},\"@electron__asar-3.4.1.tgz\":{\"integrity\":\"i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088\",\"name\":\"@electron/asar\",\"version\":\"3.4.1\"},\"@electron__asar-4.2.0.tgz\":{\"integrity\":\"npW1NW5yy8EB9XY/vEw9sUdgmq0sJEhmSBb6bqyFOAw1CSkrhvAvO6QWlW8CdIMo8VN1lkdF345l/MeW0LrY0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9e95b5356e72cbc101f5763fbc4c3db147609aad2c2448664816fa6eac85380c3509292b86f02f3ba416956f02748328f15375964745df8e65fcc796d0bad8d1\",\"name\":\"@electron/asar\",\"version\":\"4.2.0\"},\"@electron__fuses-1.8.0.tgz\":{\"integrity\":\"zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13\",\"name\":\"@electron/fuses\",\"version\":\"1.8.0\"},\"@electron__get-2.0.3.tgz\":{\"integrity\":\"Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"424ce9836b3d1a7555d88d818d192c522e375397bafb369031c8e8272d02f82e68c5a2a5f9f99c9060d016d469669655d0d41e92e659fad1b3ec403d4d59d0b5\",\"name\":\"@electron/get\",\"version\":\"2.0.3\"},\"@electron__get-3.1.0.tgz\":{\"integrity\":\"F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17e9ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409\",\"name\":\"@electron/get\",\"version\":\"3.1.0\"},\"@electron__notarize-2.5.0.tgz\":{\"integrity\":\"jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8\",\"name\":\"@electron/notarize\",\"version\":\"2.5.0\"},\"@electron__osx-sign-1.3.3.tgz\":{\"integrity\":\"KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a\",\"name\":\"@electron/osx-sign\",\"version\":\"1.3.3\"},\"@electron__rebuild-4.0.3.tgz\":{\"integrity\":\"u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bbdbe94c744c90e602b3fd452e249500567b15b8ec5caf9b42ecef88965afa51bb047665d67cf9dbf21c1afc1adec93cd3f7dcde596eb4191b0aad74561f1640\",\"name\":\"@electron/rebuild\",\"version\":\"4.0.3\"},\"@electron__universal-2.0.3.tgz\":{\"integrity\":\"Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa\",\"name\":\"@electron/universal\",\"version\":\"2.0.3\"},\"@electron__windows-sign-1.2.2.tgz\":{\"integrity\":\"dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9\",\"name\":\"@electron/windows-sign\",\"version\":\"1.2.2\"},\"@emnapi__core-1.10.0.tgz\":{\"integrity\":\"yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"caae8e909e29f360807cf974bbd99079b40728f26463b5ab22e936d3971362761efa4d99f18061d7516b6d11bf1fa8a18aba9c69c3a09760483bca323102de5f\",\"name\":\"@emnapi/core\",\"version\":\"1.10.0\"},\"@emnapi__runtime-1.10.0.tgz\":{\"integrity\":\"ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b0bd8964f3ac54a06234cd044dabf982fb5e91d5078394a432db52a2de84985cd80b6f8e465753fa03433efecea7c82b8d0ea7b9569698f380735c6c156f014\",\"name\":\"@emnapi/runtime\",\"version\":\"1.10.0\"},\"@emnapi__wasi-threads-1.2.1.tgz\":{\"integrity\":\"uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b93208ece605fbf31eb3f32b708398a79c8eb5230b056488a0b3e9720c22a6888a6e58ba937db6b5ca05b31a082313c3a96d35490180824a38133662d8136fdb\",\"name\":\"@emnapi/wasi-threads\",\"version\":\"1.2.1\"},\"@esbuild__aix-ppc64-0.21.5.tgz\":{\"integrity\":\"1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d520e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75\",\"name\":\"@esbuild/aix-ppc64\",\"version\":\"0.21.5\"},\"@esbuild__aix-ppc64-0.25.12.tgz\":{\"integrity\":\"Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e19b077a0889d9dddc29b864c5f1f246eb2a169ac4e813ebd8803e27cad655c5cbb5ba51e9510440075509f3e375026dcccf8fb1381ca84284997f80fe0a990\",\"name\":\"@esbuild/aix-ppc64\",\"version\":\"0.25.12\"},\"@esbuild__android-arm-0.21.5.tgz\":{\"integrity\":\"vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bc23efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372\",\"name\":\"@esbuild/android-arm\",\"version\":\"0.21.5\"},\"@esbuild__android-arm-0.25.12.tgz\":{\"integrity\":\"VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"549fac2af340fc613b09c69c73d0a16bb6e94bc9f2cd5bf48dd560c0d0da478803302ff64d345cdf7229f2aacd61472990e1d44f9399d1b51c34d55943d44b96\",\"name\":\"@esbuild/android-arm\",\"version\":\"0.25.12\"},\"@esbuild__android-arm64-0.21.5.tgz\":{\"integrity\":\"c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"734b97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc\",\"name\":\"@esbuild/android-arm64\",\"version\":\"0.21.5\"},\"@esbuild__android-arm64-0.25.12.tgz\":{\"integrity\":\"6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e800262c6ef3c03d59d79f6308a3ef03165de32fd54ced15929ad8cbedcdd85b49f3e0505855d4f8ec40448c00e3a739b5d0fd4ac28667fd6872a052fe000a1e\",\"name\":\"@esbuild/android-arm64\",\"version\":\"0.25.12\"},\"@esbuild__android-x64-0.21.5.tgz\":{\"integrity\":\"D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0fb68f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c\",\"name\":\"@esbuild/android-x64\",\"version\":\"0.21.5\"},\"@esbuild__android-x64-0.25.12.tgz\":{\"integrity\":\"5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e636dbfb68610c7c79a61611d81cbc193584ce7e88f54a91d752b07f6da229b36962bb26441d7c697ffd8af73971a6dc522013ff033e60867a486f503ba6bc92\",\"name\":\"@esbuild/android-x64\",\"version\":\"0.25.12\"},\"@esbuild__darwin-arm64-0.21.5.tgz\":{\"integrity\":\"DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0f0a97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91\",\"name\":\"@esbuild/darwin-arm64\",\"version\":\"0.21.5\"},\"@esbuild__darwin-arm64-0.25.12.tgz\":{\"integrity\":\"N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"377ce5fa5c470a27e022570c50fe74d7a11291e4232e3ffde7d471c4d608b61220f82407227ba316e5de59b58c8274e8e1ca795d51ea14f9a9caef49eb90b562\",\"name\":\"@esbuild/darwin-arm64\",\"version\":\"0.25.12\"},\"@esbuild__darwin-x64-0.21.5.tgz\":{\"integrity\":\"se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1efc98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f\",\"name\":\"@esbuild/darwin-x64\",\"version\":\"0.21.5\"},\"@esbuild__darwin-x64-0.25.12.tgz\":{\"integrity\":\"HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1d0f646b82b1db5a875f0b654d455b2893809e61b58a95e17564e635788fccf7d62a95ea01255c59d9dfd9b9cbef7c208cdac55c06b7c98bc149df69cdf108a4\",\"name\":\"@esbuild/darwin-x64\",\"version\":\"0.25.12\"},\"@esbuild__freebsd-arm64-0.21.5.tgz\":{\"integrity\":\"5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e49711c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2\",\"name\":\"@esbuild/freebsd-arm64\",\"version\":\"0.21.5\"},\"@esbuild__freebsd-arm64-0.25.12.tgz\":{\"integrity\":\"gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"800d01c7be7dfbb26f7b4dcad52d2f90ebb92e0ffce5da2edc4b1e38651eb3c7e554e1b16e10c387f8996a87a4d7563c9adc8a3c6177bcff178679031009b37a\",\"name\":\"@esbuild/freebsd-arm64\",\"version\":\"0.25.12\"},\"@esbuild__freebsd-x64-0.21.5.tgz\":{\"integrity\":\"J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"27de643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909\",\"name\":\"@esbuild/freebsd-x64\",\"version\":\"0.21.5\"},\"@esbuild__freebsd-x64-0.25.12.tgz\":{\"integrity\":\"TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4c66cedba630db1b07cf1b5b5451845c1147d054403fb82d70f13b3f9c8fef01b2edc5cada83bb4723a12f934b8aa4e5061e3b5e1988517b867225c4a9815f05\",\"name\":\"@esbuild/freebsd-x64\",\"version\":\"0.25.12\"},\"@esbuild__linux-arm-0.21.5.tgz\":{\"integrity\":\"bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570\",\"name\":\"@esbuild/linux-arm\",\"version\":\"0.21.5\"},\"@esbuild__linux-arm-0.25.12.tgz\":{\"integrity\":\"lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"94f0c6c82d493c3a2ef2419ccb06346082f35a58619d18dda1fdd495ca2a6264bd125f35f0b2df2497373d75e0647ac70802acfd9d92799b4326be4cae4c6d3b\",\"name\":\"@esbuild/linux-arm\",\"version\":\"0.25.12\"},\"@esbuild__linux-arm64-0.21.5.tgz\":{\"integrity\":\"ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1\",\"name\":\"@esbuild/linux-arm64\",\"version\":\"0.21.5\"},\"@esbuild__linux-arm64-0.25.12.tgz\":{\"integrity\":\"8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f1bc17edaf05821220aeea5cc5be1a5266032e9f295f4eab1a1e47a834fb6c1fbc45d7a596cea61efac51c75b624038f6546e78d4a4a4cb83a102cb3bdab3601\",\"name\":\"@esbuild/linux-arm64\",\"version\":\"0.25.12\"},\"@esbuild__linux-ia32-0.21.5.tgz\":{\"integrity\":\"YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e\",\"name\":\"@esbuild/linux-ia32\",\"version\":\"0.21.5\"},\"@esbuild__linux-ia32-0.25.12.tgz\":{\"integrity\":\"0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d32f4aadd5676cc336fef1bc29f5346f285437e1050a7cbdfbc836d36818a924953289dbb027cb8d43beac2722ee933458112dcfea0afcf2301e4cf193285aac\",\"name\":\"@esbuild/linux-ia32\",\"version\":\"0.25.12\"},\"@esbuild__linux-loong64-0.21.5.tgz\":{\"integrity\":\"uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b877f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a\",\"name\":\"@esbuild/linux-loong64\",\"version\":\"0.21.5\"},\"@esbuild__linux-loong64-0.25.12.tgz\":{\"integrity\":\"h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"87ffff2ebe5af6b89bfefd461aa5d51b38cbe1332f553bfeb350cfa3141dcfb97f018bfa2c34b1748c33c64acf5b8dfca145e20edc0cd74a3d3e6c12ffa67436\",\"name\":\"@esbuild/linux-loong64\",\"version\":\"0.25.12\"},\"@esbuild__linux-mips64el-0.21.5.tgz\":{\"integrity\":\"IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"21a8ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e\",\"name\":\"@esbuild/linux-mips64el\",\"version\":\"0.21.5\"},\"@esbuild__linux-mips64el-0.25.12.tgz\":{\"integrity\":\"iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8b246b3353f3cbd1853032ec5e7d621d49b5f2784a9cd316b1c8e6a78fa1a5a7dc663aebd966d3fff776d316869635c30581ea45c97c1e7c5b5fab9a03f78657\",\"name\":\"@esbuild/linux-mips64el\",\"version\":\"0.25.12\"},\"@esbuild__linux-ppc64-0.21.5.tgz\":{\"integrity\":\"1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d611d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3\",\"name\":\"@esbuild/linux-ppc64\",\"version\":\"0.21.5\"},\"@esbuild__linux-ppc64-0.25.12.tgz\":{\"integrity\":\"9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f6678cfe5457c4c8b93d252a117442b558c46411b007b3ff0f8c93f141bf9b021dcded9a578568e94e600f7f91b281d72a41c27d2c592b3983b2c565463d5040\",\"name\":\"@esbuild/linux-ppc64\",\"version\":\"0.25.12\"},\"@esbuild__linux-riscv64-0.21.5.tgz\":{\"integrity\":\"2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d877570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c\",\"name\":\"@esbuild/linux-riscv64\",\"version\":\"0.21.5\"},\"@esbuild__linux-riscv64-0.25.12.tgz\":{\"integrity\":\"Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"66beca478860294a560306f57f7a39ca04f4e0ccea56b18419718b9e3d796100c912b62efc11a0fb09859480ce749a743e607494bbf1148397660151add8d1d3\",\"name\":\"@esbuild/linux-riscv64\",\"version\":\"0.25.12\"},\"@esbuild__linux-s390x-0.21.5.tgz\":{\"integrity\":\"zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ceeb39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4\",\"name\":\"@esbuild/linux-s390x\",\"version\":\"0.21.5\"},\"@esbuild__linux-s390x-0.25.12.tgz\":{\"integrity\":\"MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"32c2a770e7204cdbddb6221273f8d9b3f65ff1dd1c97fb77818597f09f6e6c19d53b0964eb9508104be004e4538a58e5a085a70732ece2a8733e425c8ad23322\",\"name\":\"@esbuild/linux-s390x\",\"version\":\"0.25.12\"},\"@esbuild__linux-x64-0.21.5.tgz\":{\"integrity\":\"1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d\",\"name\":\"@esbuild/linux-x64\",\"version\":\"0.21.5\"},\"@esbuild__linux-x64-0.25.12.tgz\":{\"integrity\":\"uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"baa64c4cbaffcd1fde7788c81a7c122e468798f8ce8c9be79ba4d5562b406b4f122d2f59d1533cc08471ee059b241e7f279e18b883089c3aae5b262f40b66483\",\"name\":\"@esbuild/linux-x64\",\"version\":\"0.25.12\"},\"@esbuild__netbsd-arm64-0.25.12.tgz\":{\"integrity\":\"xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c57c1c4eae0685133b27d03c1afe5ba1a9c78516bf43d28b5667325c709368ce3029f2295a475788ca20fcab27c73274035fa70fece879cbb3a8f9824720468e\",\"name\":\"@esbuild/netbsd-arm64\",\"version\":\"0.25.12\"},\"@esbuild__netbsd-x64-0.21.5.tgz\":{\"integrity\":\"Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5a88b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e\",\"name\":\"@esbuild/netbsd-x64\",\"version\":\"0.21.5\"},\"@esbuild__netbsd-x64-0.25.12.tgz\":{\"integrity\":\"Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2dde694e5ccfcb763019e7383ae1e1d5a095091bce5dd1fc0e04637c3cbfa2e995a2f9ae4b359f9d2260f95b5a901f429b483134ef41cd6923ea6b4ed4531791\",\"name\":\"@esbuild/netbsd-x64\",\"version\":\"0.25.12\"},\"@esbuild__openbsd-arm64-0.25.12.tgz\":{\"integrity\":\"fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7c5f7a4fa2ac068fe991023de74140454f5aa463534a5646b2fd6364102570b2f530b8cb34858f0648f93654b3f1a03360a83e78daa49eb509db8401c9b791e4\",\"name\":\"@esbuild/openbsd-arm64\",\"version\":\"0.25.12\"},\"@esbuild__openbsd-x64-0.21.5.tgz\":{\"integrity\":\"HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1cb34dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3\",\"name\":\"@esbuild/openbsd-x64\",\"version\":\"0.21.5\"},\"@esbuild__openbsd-x64-0.25.12.tgz\":{\"integrity\":\"MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"319c975246478d0c54bf32bbacdf032774919ab56b91ef19c91bac1e53fe92ec2a4dc7d62f2a8c384dec49c3cfc9e21737f9832487c65ef70ca8281829e92843\",\"name\":\"@esbuild/openbsd-x64\",\"version\":\"0.25.12\"},\"@esbuild__openharmony-arm64-0.25.12.tgz\":{\"integrity\":\"rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ae6d185aca94491ae39dc497180ed9bfbf0d6e7c385cbebf773af6d1ccab41fed999172ca2fa5c4417610f8dcdba4df2ed72285b63b1315bf0b91be4f577404a\",\"name\":\"@esbuild/openharmony-arm64\",\"version\":\"0.25.12\"},\"@esbuild__sunos-x64-0.21.5.tgz\":{\"integrity\":\"6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ebe823985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a\",\"name\":\"@esbuild/sunos-x64\",\"version\":\"0.21.5\"},\"@esbuild__sunos-x64-0.25.12.tgz\":{\"integrity\":\"3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"df0192083cae4c7414cedd2757b6e8703cbbdabda5237dd02f78240cd1a4a1ddb612c625d38b0c7f4a8b6fc96e34a4ce9a017f7831033f9045370a01287e38d7\",\"name\":\"@esbuild/sunos-x64\",\"version\":\"0.25.12\"},\"@esbuild__win32-arm64-0.21.5.tgz\":{\"integrity\":\"Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"67480e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0\",\"name\":\"@esbuild/win32-arm64\",\"version\":\"0.21.5\"},\"@esbuild__win32-arm64-0.25.12.tgz\":{\"integrity\":\"rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"acc98baeeafae00efe0ca9674aec2a51d44ac9ddd413ba0f2599a7963a84a6d7ac28cf30c7d27c831e6ed3ef4fab47d0416f2fa9e29e6f035775f3b23fef01b2\",\"name\":\"@esbuild/win32-arm64\",\"version\":\"0.25.12\"},\"@esbuild__win32-ia32-0.21.5.tgz\":{\"integrity\":\"SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4965c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60\",\"name\":\"@esbuild/win32-ia32\",\"version\":\"0.21.5\"},\"@esbuild__win32-ia32-0.25.12.tgz\":{\"integrity\":\"HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e4aa79a606809b0b0c5428a34f062c62583182a50195b2b41f26854660b3d3e355d617c947b84e4de9685589ada7e28e502b9338b58af6d7cdbb7cd862e1bc9\",\"name\":\"@esbuild/win32-ia32\",\"version\":\"0.25.12\"},\"@esbuild__win32-x64-0.21.5.tgz\":{\"integrity\":\"tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b5077fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023\",\"name\":\"@esbuild/win32-x64\",\"version\":\"0.21.5\"},\"@esbuild__win32-x64-0.25.12.tgz\":{\"integrity\":\"alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6a5242d2e099a5316b48bd020838dc8257815cf9c2ac40214c120ba5e029eccfce160a2ab407ad7c1cd7d31334d0c52c5553e956394fb8c6d112a9d90976939c\",\"name\":\"@esbuild/win32-x64\",\"version\":\"0.25.12\"},\"@eslint-community__eslint-utils-4.9.1.tgz\":{\"integrity\":\"phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a61ad898d898a6947bce714476a81f5875d1e8d0a46442bb8705831d95238adff6fd4d2be97be40e5d12627a0ce751eaec584219d2c34facf1082398d617b1b1\",\"name\":\"@eslint-community/eslint-utils\",\"version\":\"4.9.1\"},\"@eslint-community__regexpp-4.12.2.tgz\":{\"integrity\":\"EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"12b8924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b\",\"name\":\"@eslint-community/regexpp\",\"version\":\"4.12.2\"},\"@eslint__config-array-0.21.2.tgz\":{\"integrity\":\"nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c99762864e5adff468cb8a6808aeef95fe6ce048ad000420d046fc70e418d444bed67c7e6ea169a2cdb1fb401e8c9a730177c7080bdb9c7969deccbd556565b\",\"name\":\"@eslint/config-array\",\"version\":\"0.21.2\"},\"@eslint__config-helpers-0.4.2.tgz\":{\"integrity\":\"gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"801af137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483\",\"name\":\"@eslint/config-helpers\",\"version\":\"0.4.2\"},\"@eslint__core-0.17.0.tgz\":{\"integrity\":\"yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c8bfec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5\",\"name\":\"@eslint/core\",\"version\":\"0.17.0\"},\"@eslint__eslintrc-3.3.5.tgz\":{\"integrity\":\"4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e08949c745f4a9fb55b0de44fbfbc6ba34d1205b70b8b6cdb1551eed33bacd83c34753ba9c5c2fc2120a10a4ab97a7597219980484dacf12a85183a376d8e546\",\"name\":\"@eslint/eslintrc\",\"version\":\"3.3.5\"},\"@eslint__js-9.39.4.tgz\":{\"integrity\":\"nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c4ec3108721bed8854f0070e0b7dbbb9f4f1be902a1f863b0a6825b3c53a6de257d18d132a1bab8c073297b847325e1387a14a7dae2026eff69660685767d73\",\"name\":\"@eslint/js\",\"version\":\"9.39.4\"},\"@eslint__object-schema-2.1.7.tgz\":{\"integrity\":\"VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738\",\"name\":\"@eslint/object-schema\",\"version\":\"2.1.7\"},\"@eslint__plugin-kit-0.4.1.tgz\":{\"integrity\":\"43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e37feab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c\",\"name\":\"@eslint/plugin-kit\",\"version\":\"0.4.1\"},\"@exodus__schemasafe-1.3.0.tgz\":{\"integrity\":\"5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e406a9fc6691ba980dc7f7de181c0b2d356ff0e4057efde9ab694f4733e0f51f883819c3820853196ee5ec4b955cebe0e5c73fc52025456f2b06b8c80b736fab\",\"name\":\"@exodus/schemasafe\",\"version\":\"1.3.0\"},\"@fluent__bundle-0.18.0.tgz\":{\"integrity\":\"8Wfwu9q8F9g2FNnv82g6Ch/E1AW1wwljsUOolH5NEtdJdv0sZTuWvfCM7c3teB9dzNaJA8rn4khpidpozHWYEA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f167f0bbdabc17d83614d9eff3683a0a1fc4d405b5c30963b143a8947e4d12d74976fd2c653b96bdf08cedcded781f5dccd68903cae7e2486989da68cc759810\",\"name\":\"@fluent/bundle\",\"version\":\"0.18.0\"},\"@fluent__react-0.15.2.tgz\":{\"integrity\":\"M2klqXTUJTD8o2VDm6vEXApE/pSc16YtB7DSZ/Q8cPYF63FgDkvquVLHjzzG1PvrK9JlKJKPzl3wJ7hTAqSK4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"336925a974d42530fca365439babc45c0a44fe949cd7a62d07b0d267f43c70f605eb71600e4beab952c78f3cc6d4fbeb2bd26528928fce5df027b85302a48ae3\",\"name\":\"@fluent/react\",\"version\":\"0.15.2\"},\"@fluent__sequence-0.8.0.tgz\":{\"integrity\":\"eV5QlEEVV/wR3AFQLXO67x4yPRPQXyqke0c8yucyMSeW36B3ecZyVFlY1UprzrfFV8iPJB4TAehDy/dLGbvQ1Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"795e5094411557fc11dc01502d73baef1e323d13d05f2aa47b473ccae732312796dfa07779c672545958d54a6bceb7c557c88f241e1301e843cbf74b19bbd0d5\",\"name\":\"@fluent/sequence\",\"version\":\"0.8.0\"},\"@fontsource__poppins-5.2.7.tgz\":{\"integrity\":\"6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eae4323e6b1ea3816023ded6221038c9646535aa0b938bd20cafcfc91c1daaa65be73004b9cf8aba7b7c25331cb07614106601b4dd7948d90c6a331da944949a\",\"name\":\"@fontsource/poppins\",\"version\":\"5.2.7\"},\"@formatjs__intl-localematcher-0.2.32.tgz\":{\"integrity\":\"k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93f30406cb5f7f8b2db688721295f10a60b732a6d49fd56f1c6959f1f6ae2f391bc17995ac47b2cd2fb8ba1aef024f43594f7fee8b585b1c83a31e274ff2952d\",\"name\":\"@formatjs/intl-localematcher\",\"version\":\"0.2.32\"},\"@hookform__resolvers-3.10.0.tgz\":{\"integrity\":\"79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efd0effb798317b8bed9a8e3ed2932a52287865d5c6e59f53866afaabb05ee9ea66d4bf5d71a6aa5a70fb060c24d1bc24a310421ecf679fd4dbde4952f76f402\",\"name\":\"@hookform/resolvers\",\"version\":\"3.10.0\"},\"@humanfs__core-0.19.1.tgz\":{\"integrity\":\"5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50\",\"name\":\"@humanfs/core\",\"version\":\"0.19.1\"},\"@humanfs__node-0.16.7.tgz\":{\"integrity\":\"/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711\",\"name\":\"@humanfs/node\",\"version\":\"0.16.7\"},\"@humanwhocodes__module-importer-1.0.1.tgz\":{\"integrity\":\"bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c\",\"name\":\"@humanwhocodes/module-importer\",\"version\":\"1.0.1\"},\"@humanwhocodes__retry-0.4.3.tgz\":{\"integrity\":\"bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285\",\"name\":\"@humanwhocodes/retry\",\"version\":\"0.4.3\"},\"@isaacs__cliui-8.0.2.tgz\":{\"integrity\":\"O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10\",\"name\":\"@isaacs/cliui\",\"version\":\"8.0.2\"},\"@isaacs__fs-minipass-4.0.1.tgz\":{\"integrity\":\"wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3\",\"name\":\"@isaacs/fs-minipass\",\"version\":\"4.0.1\"},\"@jridgewell__gen-mapping-0.3.13.tgz\":{\"integrity\":\"2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c\",\"name\":\"@jridgewell/gen-mapping\",\"version\":\"0.3.13\"},\"@jridgewell__remapping-2.3.5.tgz\":{\"integrity\":\"LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711\",\"name\":\"@jridgewell/remapping\",\"version\":\"2.3.5\"},\"@jridgewell__resolve-uri-3.1.2.tgz\":{\"integrity\":\"bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b\",\"name\":\"@jridgewell/resolve-uri\",\"version\":\"3.1.2\"},\"@jridgewell__sourcemap-codec-1.5.5.tgz\":{\"integrity\":\"cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a\",\"name\":\"@jridgewell/sourcemap-codec\",\"version\":\"1.5.5\"},\"@jridgewell__trace-mapping-0.3.31.tgz\":{\"integrity\":\"zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03\",\"name\":\"@jridgewell/trace-mapping\",\"version\":\"0.3.31\"},\"@malept__cross-spawn-promise-2.0.0.tgz\":{\"integrity\":\"1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d43a4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16\",\"name\":\"@malept/cross-spawn-promise\",\"version\":\"2.0.0\"},\"@malept__flatpak-bundler-0.4.0.tgz\":{\"integrity\":\"9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f503ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed\",\"name\":\"@malept/flatpak-bundler\",\"version\":\"0.4.0\"},\"@mgit-at__typescript-flatbuffers-codegen-0.1.3.tgz\":{\"integrity\":\"sf9vaoiR/SR0dpV568GhsoLbd6659StJ4Gl9jszZL/bsJJaF5VmLYbI57OSI4JDm+L6d3osVMl9mkchox9j6/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1ff6f6a8891fd2474769579ebc1a1b282db77aeb9f52b49e0697d8eccd92ff6ec249685e5598b61b239ece488e090e6f8be9dde8b15325f6691c868c7d8fafe\",\"name\":\"@mgit-at/typescript-flatbuffers-codegen\",\"version\":\"0.1.3\"},\"@napi-rs__wasm-runtime-0.2.12.tgz\":{\"integrity\":\"ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65559471fc18e04ff23e2b50265e3cd458c5a372b6d83eaa1740ee147e98fe76e7135d46639ba0b83c593065cf43c590d35dbc317403ed39df1f22b8a16a0825\",\"name\":\"@napi-rs/wasm-runtime\",\"version\":\"0.2.12\"},\"@nodelib__fs.scandir-2.1.5.tgz\":{\"integrity\":\"vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada\",\"name\":\"@nodelib/fs.scandir\",\"version\":\"2.1.5\"},\"@nodelib__fs.stat-2.0.5.tgz\":{\"integrity\":\"RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"46484f3e9db3aea0c0400ff68cd867ced70f025bfae17761229edaef8e78039a2f23b06e93182decc5fbb9dc00bb7ce0d437293d4d2bcf7555d5279aaaf638f8\",\"name\":\"@nodelib/fs.stat\",\"version\":\"2.0.5\"},\"@nodelib__fs.walk-1.2.8.tgz\":{\"integrity\":\"oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a\",\"name\":\"@nodelib/fs.walk\",\"version\":\"1.2.8\"},\"@nolyfill__is-core-module-1.0.39.tgz\":{\"integrity\":\"nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9e7e68cdd8d8429502665586bb170963f2a9c64590b380dc6cc0a62a88e3cab6031001b2e027b5f4d378bf931db9a7d3c0995b29cf7d500f1885256aabdc8f64\",\"name\":\"@nolyfill/is-core-module\",\"version\":\"1.0.39\"},\"@npmcli__agent-3.0.0.tgz\":{\"integrity\":\"S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4bbf4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5\",\"name\":\"@npmcli/agent\",\"version\":\"3.0.0\"},\"@npmcli__fs-4.0.0.tgz\":{\"integrity\":\"/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ff11a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1\",\"name\":\"@npmcli/fs\",\"version\":\"4.0.0\"},\"@octokit__endpoint-10.1.4.tgz\":{\"integrity\":\"OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3a560e95922c7c45599b91c2491f1a4a0d364f695b5163ac090a0f29f4d72700f3707401ad50467465dbf3d76fd8ac364e865a46db9da7c3b764862868e8ca94\",\"name\":\"@octokit/endpoint\",\"version\":\"10.1.4\"},\"@octokit__openapi-types-25.1.0.tgz\":{\"integrity\":\"idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"89db0882035750a924d3e044c549f5750f76b1fcac26b8ded374346efd1ef8a3cbaefcaa645f0c9c1a45cfc50d7d80f007721eed9d130728d67f3c6deefb1e68\",\"name\":\"@octokit/openapi-types\",\"version\":\"25.1.0\"},\"@octokit__request-9.2.4.tgz\":{\"integrity\":\"q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"abcc9b772b419b16ba2a881694d6bcd7caf4935c25ab3342fb23647100c4087bd0a3c566b2dae0d7c270a891dd25d5221c3dac8e5c018129bd90790e29eda2c8\",\"name\":\"@octokit/request\",\"version\":\"9.2.4\"},\"@octokit__request-error-6.1.8.tgz\":{\"integrity\":\"WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5848bf474266abe2092b275694a0e6af23dc99d6125632f77a46a210bd4bf5ea35b149ea309fa0aea982f5c8e4ec203bf9bdbf4f7f7bb4ee5df182ce1f7a98a5\",\"name\":\"@octokit/request-error\",\"version\":\"6.1.8\"},\"@octokit__types-14.1.0.tgz\":{\"integrity\":\"1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d72e83813cbc26899ca6edf737ea79c39f25eb1cade7902bd88f7544f888034c422415f250085709c99968359200d8a16bb47d6baa89276091a2618f67a7f8ea\",\"name\":\"@octokit/types\",\"version\":\"14.1.0\"},\"@openapi-codegen__cli-3.1.0.tgz\":{\"integrity\":\"w9OO+3rFKWkAdKfjnjBg5pisBAKXtZAbDPNTu46Vcd7yJH1JsMH9SDoyRN2vMZZIR4ir1pLMn8Oom9kzuTAFrQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3d38efb7ac529690074a7e39e3060e698ac040297b5901b0cf353bb8e9571def2247d49b0c1fd483a3244ddaf3196484788abd692cc9fc3a89bd933b93005ad\",\"name\":\"@openapi-codegen/cli\",\"version\":\"3.1.0\"},\"@openapi-codegen__typescript-8.1.1.tgz\":{\"integrity\":\"KGnFyoQc4lhtVVvX6lk2btF9GDDUbu8Jvn5C89aHuyIA4nor/Rlt7f7QHaYpecFDX8RZrPcYGrDZ8OFNUkEOlA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2869c5ca841ce2586d555bd7ea59366ed17d1830d46eef09be7e42f3d687bb2200e27a2bfd196dedfed01da62979c1435fc459acf7181ab0d9f0e14d52410e94\",\"name\":\"@openapi-codegen/typescript\",\"version\":\"8.1.1\"},\"@parcel__watcher-2.5.6.tgz\":{\"integrity\":\"tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b66999de543101efe4ffeacd9d74116b0278363c4eda1aa238b4c7bd6721b466542e9e11c857a1e9a5385dd3980457b6284d684a1413bf801b94eb3688eacd9d\",\"name\":\"@parcel/watcher\",\"version\":\"2.5.6\"},\"@parcel__watcher-android-arm64-2.5.6.tgz\":{\"integrity\":\"YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"610c524b7e2d3c5ffa646eebfc887dc72fa43ff5b079d88452caa6b5fd1cb825794cf3cac3f3d01d186e794a3a25d78525aa95de9ca39b419d623668b5b46dfc\",\"name\":\"@parcel/watcher-android-arm64\",\"version\":\"2.5.6\"},\"@parcel__watcher-darwin-arm64-2.5.6.tgz\":{\"integrity\":\"Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"67665dae7c325efbef76d4472e6338927c9d21d53d69d3b70f89ffd1c562a45deb462c0ffb7fec7f3a40c00fea2852fa8b532875a69b914ec86e978c06089510\",\"name\":\"@parcel/watcher-darwin-arm64\",\"version\":\"2.5.6\"},\"@parcel__watcher-darwin-x64-2.5.6.tgz\":{\"integrity\":\"HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e0bce7f75bd7618ad85cc0e597f6e0d9ca7d655bd47eeed3d9e2cba0f8d1ab188a38464d610172c46dc1f54d04aac6db343585d794e5aa569bd2d52152e1f46\",\"name\":\"@parcel/watcher-darwin-x64\",\"version\":\"2.5.6\"},\"@parcel__watcher-freebsd-x64-2.5.6.tgz\":{\"integrity\":\"vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bc9562f3277fab327110a1e479e9a1ef0dd8027e91242b58944e073cca159c2a485c4cd2af112b056e5224180a2db5d4dd6748a648c14de50db720559fc4d19e\",\"name\":\"@parcel/watcher-freebsd-x64\",\"version\":\"2.5.6\"},\"@parcel__watcher-linux-arm-glibc-2.5.6.tgz\":{\"integrity\":\"9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f498987c1ea1e81815e740827dab1f2dffeebce709b24312c1c747d4f1c7f6bbd2d48acdcbccda77a21454f5547e65ebfaef8a9bd23171f30bce074eb9dcfd11\",\"name\":\"@parcel/watcher-linux-arm-glibc\",\"version\":\"2.5.6\"},\"@parcel__watcher-linux-arm-musl-2.5.6.tgz\":{\"integrity\":\"Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"55ede05021b9ee7b94512ca306afcc00cd02cc0aedb883b1b01750f9fb73ea1a3c9fbb358bd13536693fc663f7db7af660bd1238db3512ec2a069daed64e5fc6\",\"name\":\"@parcel/watcher-linux-arm-musl\",\"version\":\"2.5.6\"},\"@parcel__watcher-linux-arm64-glibc-2.5.6.tgz\":{\"integrity\":\"f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7f683f0d3dcd8463dd066316628c62c6a62bdeffd45dc98b398cb5e81c744ccdb44dc85dbb0af811a09b9b1875df6d53001a8f183a52f03fe080e4da9638a338\",\"name\":\"@parcel/watcher-linux-arm64-glibc\",\"version\":\"2.5.6\"},\"@parcel__watcher-linux-arm64-musl-2.5.6.tgz\":{\"integrity\":\"qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a9bea768c0c695b0b07612e3ea182854a265da874bdf8cf6b2a902ed9ea4ce2afc6f95bae56603a4b07a474e8a69bbd9760a0723fcf191ee1bdf3474c006c34c\",\"name\":\"@parcel/watcher-linux-arm64-musl\",\"version\":\"2.5.6\"},\"@parcel__watcher-linux-x64-glibc-2.5.6.tgz\":{\"integrity\":\"kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"91b4f9c2f350971ecd6868f33c5bbc9d5216d6b5aa57bf343bb66d923b9668f520a6fd8d305a636044558b45188f59ac64dc82cc695a09612dcdcf9ec633066d\",\"name\":\"@parcel/watcher-linux-x64-glibc\",\"version\":\"2.5.6\"},\"@parcel__watcher-linux-x64-musl-2.5.6.tgz\":{\"integrity\":\"1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d49445782fa1ed1757c25747cd3b2676d611fcabbc4b294b81353fade32ea9d543ec2b4bc1fd1547516a7a9ad9d1e1d090ed2faac6ef14b5d49989bfb8d28906\",\"name\":\"@parcel/watcher-linux-x64-musl\",\"version\":\"2.5.6\"},\"@parcel__watcher-win32-arm64-2.5.6.tgz\":{\"integrity\":\"3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dee93279b8dce9e1a5c3dc91b7aefc0f1545eeb8d76ad5a21ef4d7aa98592efa3b682e4d744805b9f5708c57d8e758a36045a95dba85e63b6b2b6ef9cf9d83e1\",\"name\":\"@parcel/watcher-win32-arm64\",\"version\":\"2.5.6\"},\"@parcel__watcher-win32-ia32-2.5.6.tgz\":{\"integrity\":\"k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"937e722e9d59330c1e7b7133fe9c418b971fe00a012985e3d34099f348d4cf987ca6ba62690b2244f290331a0bb2d36ea9edaf47844d3c4004723105ce1133fe\",\"name\":\"@parcel/watcher-win32-ia32\",\"version\":\"2.5.6\"},\"@parcel__watcher-win32-x64-2.5.6.tgz\":{\"integrity\":\"hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"85b42561c0aae5d9405fd431fa415bd051ee7babdb8e57f416b37348a7582b600f51feed19f1b14029368a11111266d1e9931cd0c5400f94485ffe358295334f\",\"name\":\"@parcel/watcher-win32-x64\",\"version\":\"2.5.6\"},\"@pinojs__redact-0.4.0.tgz\":{\"integrity\":\"k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93610d9e606e804febcd07c471d58770263efc533754bcc7f5c604b1b76ca2aaefcc029185465e44d84066f07c3a2b502754c179ddf2a96b5d8f34bac09281c2\",\"name\":\"@pinojs/redact\",\"version\":\"0.4.0\"},\"@pkgjs__parseargs-0.11.0.tgz\":{\"integrity\":\"+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fb55648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e\",\"name\":\"@pkgjs/parseargs\",\"version\":\"0.11.0\"},\"@react-hookz__deep-equal-3.0.4.tgz\":{\"integrity\":\"QpcSUTP1I0lI8/GvSEvclkoEGRWjbYxuUWaecxr8eJRceivGF18wHoJwaej2NYxMn7SqhKaZ9JYQvmdATiSG8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4297125133f5234948f3f1af484bdc964a041915a36d8c6e51669e731afc78945c7a2bc6175f301e827069e8f6358c4c9fb4aa84a699f49610be67404e2486f0\",\"name\":\"@react-hookz/deep-equal\",\"version\":\"3.0.4\"},\"@remix-run__router-1.23.2.tgz\":{\"integrity\":\"Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"21cea6d94feb3234e48444486bfd19b5724fd7b4148b609b584edcab1e09e7c33c680dd04df5bed94950e29b2f4d7f483b545f35584ade97297637a3ecbfaddb\",\"name\":\"@remix-run/router\",\"version\":\"1.23.2\"},\"@rolldown__pluginutils-1.0.0-beta.27.tgz\":{\"integrity\":\"+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f9dd05e0c28c09b795509c06f7ab90e12800ce764d4aaf7723757ef4d1c0e0ea6fa86f26442a4674a98af25fdd974da1d820831f05b616a8a59d3c837009ea8c\",\"name\":\"@rolldown/pluginutils\",\"version\":\"1.0.0-beta.27\"},\"@rollup__rollup-android-arm-eabi-4.60.1.tgz\":{\"integrity\":\"d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"77a1629c404b74888afb5b80094b6d24a7e0651117ac5d107364a62c823b5b6003f057e267d5a377eac3fe246e7f9b39756aebd468305c2bcfa8eb83aae3a8c0\",\"name\":\"@rollup/rollup-android-arm-eabi\",\"version\":\"4.60.1\"},\"@rollup__rollup-android-arm64-4.60.1.tgz\":{\"integrity\":\"YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6231bf130203bef608d58bd86c7bc3cff0581ed918e328142171e74dd2e11be84a2101418a8b1f5a20025a8aedb0a3ca53ff9d53041008a40cdeaac37bc73d04\",\"name\":\"@rollup/rollup-android-arm64\",\"version\":\"4.60.1\"},\"@rollup__rollup-darwin-arm64-4.60.1.tgz\":{\"integrity\":\"mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9a30a917b1a6911b52270a27f91ab537cfa923ef25ef0e60f59def5a3e13eda6e0b82e02cf08b762efe915a2ef0374d378c5639eeddcb6282eb2a5947e3673bf\",\"name\":\"@rollup/rollup-darwin-arm64\",\"version\":\"4.60.1\"},\"@rollup__rollup-darwin-x64-4.60.1.tgz\":{\"integrity\":\"haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"85a67b849d494f87bd86a9284fd47fd7d5d6d902aa8df255bfe8b9006839ed2fa72e4f6542727517f79996844ede8f52732f42337c10f65f9d917b5c06037913\",\"name\":\"@rollup/rollup-darwin-x64\",\"version\":\"4.60.1\"},\"@rollup__rollup-freebsd-arm64-4.60.1.tgz\":{\"integrity\":\"czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"733c3dd30a50ab766c0150658a76630184ca76e3a34f2c251bb7c479629403ba029a903cc5d4e4c59665c0d24a5aa20b96ad307a1a1970961f06f3b284f4d0eb\",\"name\":\"@rollup/rollup-freebsd-arm64\",\"version\":\"4.60.1\"},\"@rollup__rollup-freebsd-x64-4.60.1.tgz\":{\"integrity\":\"KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"295076aeab314c7b81b5f39ec92132cc4381ee5b6507fbb1dfc8aedab050ce48dbc115659210062040e28989ceda414e909a7e67ba545cacab45116e1542adfa\",\"name\":\"@rollup/rollup-freebsd-x64\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-arm-gnueabihf-4.60.1.tgz\":{\"integrity\":\"L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2fedf842a8a5fafe6e0b4cc4b9b5bbb81ca8efc58e088ac1bdc8baf44eec1404919745fb6ff301e82a9dd65932fc2b5c4954f27566b6599c05b967b18d2e68ea\",\"name\":\"@rollup/rollup-linux-arm-gnueabihf\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-arm-musleabihf-4.60.1.tgz\":{\"integrity\":\"n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9fcdcef2bb78bf7e21805ce591bd7272788987b211e51088aadea6cf5551243ea99a1462d025dd99f9cbbbd748512e9bbb387ad08bc008cf38d857dbdf177a1a\",\"name\":\"@rollup/rollup-linux-arm-musleabihf\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-arm64-gnu-4.60.1.tgz\":{\"integrity\":\"Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36a97bb13780ce14c08dadd05de008e3cfbff868c127e426007d77b279f400948d2f9d09b03aa8b72b9d1f231b3b645b264b246cc6c525f20929603a4752c225\",\"name\":\"@rollup/rollup-linux-arm64-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-arm64-musl-4.60.1.tgz\":{\"integrity\":\"+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fa953298385dd32b3d19c2993cf5a516267aeec4d6579514eb33896add36335f8f8ae4860f38b246e23fa4fb9ede1a14c26dae19fc5d2feb6b4fa67daf19e530\",\"name\":\"@rollup/rollup-linux-arm64-musl\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-loong64-gnu-4.60.1.tgz\":{\"integrity\":\"VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"552be0bd078872c12f6386ca0c710359ca56e18c3b06d94a1b51944f81730549442902b4ad61d806a42de859b6b5a5d2fb56d7bc94fa9080aee59c2a2829ef95\",\"name\":\"@rollup/rollup-linux-loong64-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-loong64-musl-4.60.1.tgz\":{\"integrity\":\"4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e0baa1528989ab07bae3582c3e9eb12df86a58c6d0574e0ab4fa7bfdd229d27ccfc4090d63501bc0be56d0c42971a94b624d3bbda5bd2a9d4f06176965861c13\",\"name\":\"@rollup/rollup-linux-loong64-musl\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-ppc64-gnu-4.60.1.tgz\":{\"integrity\":\"tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b4b410f5a3ef901c4e73f1144fa8f7a7278c0fa1dbf1017605306709058ffeebb596173d008ac88ca9cb60c12ba08cff26fb4662023d745dc0c4764d6841f4af\",\"name\":\"@rollup/rollup-linux-ppc64-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-ppc64-musl-4.60.1.tgz\":{\"integrity\":\"RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"44cc45849c1cf5f4973fa3ea980cf871bbf7900caf0f57ad2458d3c7838da853fd0e44e45ec00c538bf7572739060cc2f9a9f3ee74bff6da78a1bb0a7ea9031e\",\"name\":\"@rollup/rollup-linux-ppc64-musl\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-riscv64-gnu-4.60.1.tgz\":{\"integrity\":\"QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40a80597e61cd5e124e8c98e05f447605ea54f18a2895dffcff051adb4a25b623b0054d7a0116f74c132825a213e3fffda6652e210cea9e0741f5002877b016e\",\"name\":\"@rollup/rollup-linux-riscv64-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-riscv64-musl-4.60.1.tgz\":{\"integrity\":\"RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4408d78cfffc73a66dcdab59700d51690afa3b54d18730be69d9fc6190e70a1962647be2a888e6bc5c077318b824a3d20c0b7a5217ffeefa9c073409cb43c326\",\"name\":\"@rollup/rollup-linux-riscv64-musl\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-s390x-gnu-4.60.1.tgz\":{\"integrity\":\"wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c1cba872968e95a2f508e058880f3d3bac9f8e5a77470283793200d2133b3a99a1475063a3d8f7d46d6e415a43953bf0c469f69d0b3ae5f0452f950577be8571\",\"name\":\"@rollup/rollup-linux-s390x-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-x64-gnu-4.60.1.tgz\":{\"integrity\":\"77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efb3e9b0541408e89947df8b404160f460a5c9f90d5e3d4c3fac119f362cd047966cf707b34d805eee31b946ccd738709f7c2a6a2ce57b7004620e5a7a8a2186\",\"name\":\"@rollup/rollup-linux-x64-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-linux-x64-musl-4.60.1.tgz\":{\"integrity\":\"5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e5c2004db939bf29c08eaaa6c818e5722309975f91fc2c17f682e4fc4ca21570d677de4aa4776b3894fffeb9d497871472c92b7748c20b0df0a599e1207743f7\",\"name\":\"@rollup/rollup-linux-x64-musl\",\"version\":\"4.60.1\"},\"@rollup__rollup-openbsd-x64-4.60.1.tgz\":{\"integrity\":\"cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"725d30d3d5ac0a2d7b99c996aaa8257b3f4693c8ac81e5afa146775a2245612477ce3050736279fe28528e997e54b8cfaa343fd6125172a05f2e3b2c4444082f\",\"name\":\"@rollup/rollup-openbsd-x64\",\"version\":\"4.60.1\"},\"@rollup__rollup-openharmony-arm64-4.60.1.tgz\":{\"integrity\":\"4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e02bf6dd9ace3516cdb5b65adfb98b4ae797502b4decc5dc70286d2a952740d805d35d2b8eb8df1f1dd0c644b63c8ecba864f9c57c98b356bb2dbcc0c13d2208\",\"name\":\"@rollup/rollup-openharmony-arm64\",\"version\":\"4.60.1\"},\"@rollup__rollup-win32-arm64-msvc-4.60.1.tgz\":{\"integrity\":\"i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8b5a24598900e052480adafb2a96331694531e0cb98dd0db66259fbe7cb6d6220a932e581318835cffb36d7ce6ddd51c169904798347810e5fb86db7e893ead2\",\"name\":\"@rollup/rollup-win32-arm64-msvc\",\"version\":\"4.60.1\"},\"@rollup__rollup-win32-ia32-msvc-4.60.1.tgz\":{\"integrity\":\"u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bb4f66dc2bb02f34a103411828c3621607238f3c2ab5430b9ae0892de6568e3398037213d838b4f4a6b11814cff71573b56c885a355db01d84f60a0c8d9bd342\",\"name\":\"@rollup/rollup-win32-ia32-msvc\",\"version\":\"4.60.1\"},\"@rollup__rollup-win32-x64-gnu-4.60.1.tgz\":{\"integrity\":\"k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93eeb4d15f5997508cede6712603324d4ce6ae6841ff45d99c5e29472a4a025020c6679d500fb5bfd47e5ce16fe7a5b84a51c4cdf78cb73ba32c90f6d94cf9ce\",\"name\":\"@rollup/rollup-win32-x64-gnu\",\"version\":\"4.60.1\"},\"@rollup__rollup-win32-x64-msvc-4.60.1.tgz\":{\"integrity\":\"lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9563278b1abf433c7285357a363409e12168d49e8fbce5fcbd4c7959be1b04fb046fef3167cf41cfa90e5e97d78fd6a4f401d3415433960cc111cd52c8cdbbc5\",\"name\":\"@rollup/rollup-win32-x64-msvc\",\"version\":\"4.60.1\"},\"@rtsao__scc-1.1.0.tgz\":{\"integrity\":\"zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cede8e76a683a0e9c9d5962c0981adf58996cc35e5e2f41d293c897afeb680585118a771ee6713e7857d2888e0f9ddb08bd117b0fbc03ca7bb8bb5a37d5581f2\",\"name\":\"@rtsao/scc\",\"version\":\"1.1.0\"},\"@ryuziii__discord-rpc-1.0.1-rc.1.tgz\":{\"integrity\":\"q9YgU8Rj9To1LWzo4u8cXOHUorEkB5KZ5cdW80KoYtAUx+nQy7wYCEFiNh8kcmqFqQ8m3Fsx1IXx3UpVymkaSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"abd62053c463f53a352d6ce8e2ef1c5ce1d4a2b124079299e5c756f342a862d014c7e9d0cbbc18084162361f24726a85a90f26dc5b31d485f1dd4a55ca691a4b\",\"name\":\"@ryuziii/discord-rpc\",\"version\":\"1.0.1-rc.1\"},\"@sapphire__async-queue-1.5.5.tgz\":{\"integrity\":\"cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"72f1b3c5b6daeac6afdb36641fc18f7f6a0693dc98a03e6aacd59dbbd7d17a189f82715924c57e9eecb69ce376ae844ee32410fafecc2bf3e4b65fc781fb145e\",\"name\":\"@sapphire/async-queue\",\"version\":\"1.5.5\"},\"@sapphire__snowflake-3.5.5.tgz\":{\"integrity\":\"xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c73bc1af54357389427bb8bab119eba1fc5e3b54133ff2ca43a03aab2d22078c79c9f8927c044c1101208688f34cd00b0d372ff049f4e2a60d21ca3dfcaf5e65\",\"name\":\"@sapphire/snowflake\",\"version\":\"3.5.5\"},\"@sentry-internal__browser-utils-10.29.0.tgz\":{\"integrity\":\"M3kycMY6f3KY9a8jDYac+yG0E3ZgWVWSxlOEC5MhYyX+g7mqxkwrb3LFQyuxSm/m+CCgMTCaPOOaB2twXP6EQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33793270c63a7f7298f5af230d869cfb21b4137660595592c653840b93216325fe83b9aac64c2b6f72c5432bb14a6fe6f820a031309a3ce39a076b705cfe8442\",\"name\":\"@sentry-internal/browser-utils\",\"version\":\"10.29.0\"},\"@sentry-internal__feedback-10.29.0.tgz\":{\"integrity\":\"Y7IRsNeS99cEONu1mZWZc3HvbjNnu59Hgymm0swFFKbdgbCgdT6l85kn2oLsuq4Ew8Dw/pL/Sgpwsl9UgYFpUg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63b211b0d792f7d70438dbb59995997371ef6e3367bb9f478329a6d2cc0514a6dd81b0a0753ea5f39927da82ecbaae04c3c0f0fe92ff4a0a70b25f5481816952\",\"name\":\"@sentry-internal/feedback\",\"version\":\"10.29.0\"},\"@sentry-internal__replay-10.29.0.tgz\":{\"integrity\":\"45NVw9PwB9TQ8z+xJ6G6Za+wmQ1RTA35heBSzR6U4bknj8LmA04k2iwnobvxCBEQXeLfcJEO1vFgagMoqMZMBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e39355c3d3f007d4d0f33fb127a1ba65afb0990d514c0df985e052cd1e94e1b9278fc2e6034e24da2c27a1bbf10811105de2df70910ed6f1606a0328a8c64c07\",\"name\":\"@sentry-internal/replay\",\"version\":\"10.29.0\"},\"@sentry-internal__replay-canvas-10.29.0.tgz\":{\"integrity\":\"typY4JrpAQQGPuSyd/BD8+nNCbvTV2UVvKzr+iKgI0m1qc4Dz8tHZ4Nfais2Z8eYn/pL1kqVQN5ERTmJoYFdIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b72a58e09ae90104063ee4b277f043f3e9cd09bbd3576515bcacebfa22a02349b5a9ce03cfcb4767835f6a2b3667c7989ffa4bd64a9540de44453989a1815d23\",\"name\":\"@sentry-internal/replay-canvas\",\"version\":\"10.29.0\"},\"@sentry__babel-plugin-component-annotate-2.23.1.tgz\":{\"integrity\":\"l1z8AvI6k9I+2z49OgvP3SlzB1M0Lw24KtceiJibNaSyQwxsItoT9/XftZ/8BBtkosVmNOTQhL1eUsSkuSv1LA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"975cfc02f23a93d23edb3e3d3a0bcfdd29730753342f0db82ad71e88989b35a4b2430c6c22da13f7f5dfb59ffc041b64a2c56634e4d084bd5e52c4a4b92bf52c\",\"name\":\"@sentry/babel-plugin-component-annotate\",\"version\":\"2.23.1\"},\"@sentry__browser-10.29.0.tgz\":{\"integrity\":\"XdbyIR6F4qoR9Z1JCWTgunVcTJjS9p2Th+v4wYs4ME+ZdLC4tuKKmRgYg3YdSIWCn1CBfIgdI6wqETSf7H6Njw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dd6f2211e85e2aa11f59d490964e0ba755c4c98d2f69d9387ebf8c18b38304f9974b0b8b6e28a99181883761d4885829f50817c881d23ac2a11349fec7e8d8f\",\"name\":\"@sentry/browser\",\"version\":\"10.29.0\"},\"@sentry__bundler-plugin-core-2.23.1.tgz\":{\"integrity\":\"JA6utNiwMKv6Jfj0Hmk0DI/XUizSHg7HhhkFETKhRlYEhZAdkyz1atDBg0ncKNgRBKyHeSYWcMFtUyo26VB76w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"240eaeb4d8b030abfa25f8f41e69340c8fd7522cd21e0ec78619051132a146560485901d932cf56ad0c18349dc28d81104ac8779261670c16d532a36e9507beb\",\"name\":\"@sentry/bundler-plugin-core\",\"version\":\"2.23.1\"},\"@sentry__cli-2.39.1.tgz\":{\"integrity\":\"JIb3e9vh0+OmQ0KxmexMXg9oZsR/G7HMwxt5BUIKAXZ9m17Xll4ETXTRnRUBT3sf7EpNGAmlQk1xEmVN9pYZYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2486f77bdbe1d3e3a64342b199ec4c5e0f6866c47f1bb1ccc31b7905420a01767d9b5ed7965e044d74d19d15014f7b1fec4a4d1809a5424d7112654df6961961\",\"name\":\"@sentry/cli\",\"version\":\"2.39.1\"},\"@sentry__cli-darwin-2.39.1.tgz\":{\"integrity\":\"kiNGNSAkg46LNGatfNH5tfsmI/kCAaPA62KQuFZloZiemTNzhy9/6NJP8HZ/GxGs8GDMxic6wNrV9CkVEgFLJQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"922346352024838e8b3466ad7cd1f9b5fb2623f90201a3c0eb6290b85665a1989e993373872f7fe8d24ff0767f1b11acf060ccc6273ac0dad5f4291512014b25\",\"name\":\"@sentry/cli-darwin\",\"version\":\"2.39.1\"},\"@sentry__cli-linux-arm-2.39.1.tgz\":{\"integrity\":\"DkENbxyRxUrfLnJLXTA4s5UL/GoctU5Cm4ER1eB7XN7p9WsamFJd/yf2KpltkjEyiTuplv0yAbdjl1KX3vKmEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e410d6f1c91c54adf2e724b5d3038b3950bfc6a1cb54e429b8111d5e07b5cdee9f56b1a98525dff27f62a996d923132893ba996fd3201b763975297def2a611\",\"name\":\"@sentry/cli-linux-arm\",\"version\":\"2.39.1\"},\"@sentry__cli-linux-arm64-2.39.1.tgz\":{\"integrity\":\"5VbVJDatolDrWOgaffsEM7znjs0cR8bHt9Bq0mStM3tBolgAeSDHE89NgHggfZR+DJ2VWOy4vgCwkObrUD6NQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e556d52436ada250eb58e81a7dfb0433bce78ecd1c47c6c7b7d06ad264ad337b41a258007920c713cf4d8078207d947e0c9d9558ecb8be00b090e6eb503e8d43\",\"name\":\"@sentry/cli-linux-arm64\",\"version\":\"2.39.1\"},\"@sentry__cli-linux-i686-2.39.1.tgz\":{\"integrity\":\"pXWVoKXCRrY7N8vc9H7mETiV9ZCz+zSnX65JQCzZxgYrayQPJTc+NPRnZTdYdk5RlAupXaFicBI2GwOCRqVRkg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a57595a0a5c246b63b37cbdcf47ee6113895f590b3fb34a75fae49402cd9c6062b6b240f25373e34f467653758764e51940ba95da1627012361b038246a55192\",\"name\":\"@sentry/cli-linux-i686\",\"version\":\"2.39.1\"},\"@sentry__cli-linux-x64-2.39.1.tgz\":{\"integrity\":\"IwayNZy+it7FWG4M9LayyUmG1a/8kT9+/IEm67sT5+7dkMIMcpmHDqL8rWcPojOXuTKaOBBjkVdNMBTXy0mXlA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2306b2359cbe8adec5586e0cf4b6b2c94986d5affc913f7efc8126ebbb13e7eedd90c20c7299870ea2fcad670fa23397b9329a38106391574d3014d7cb499794\",\"name\":\"@sentry/cli-linux-x64\",\"version\":\"2.39.1\"},\"@sentry__cli-win32-i686-2.39.1.tgz\":{\"integrity\":\"NglnNoqHSmE+Dz/wHeIVRnV2bLMx7tIn3IQ8vXGO5HWA2f8zYJGktbkLq1Lg23PaQmeZLPGlja3gBQfZYSG10Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"360967368a874a613e0f3ff01de2154675766cb331eed227dc843cbd718ee47580d9ff336091a4b5b90bab52e0db73da4267992cf1a58dade00507d96121b5d1\",\"name\":\"@sentry/cli-win32-i686\",\"version\":\"2.39.1\"},\"@sentry__cli-win32-x64-2.39.1.tgz\":{\"integrity\":\"xv0R2CMf/X1Fte3cMWie1NXuHmUyQPDBfCyIt6k6RPFPxAYUgcqgMPznYwVMwWEA1W43PaOkSn3d8ZylsDaETw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c6fd11d8231ffd7d45b5eddc31689ed4d5ee1e653240f0c17c2c88b7a93a44f14fc4061481caa030fce763054cc16100d56e373da3a44a7dddf19ca5b036844f\",\"name\":\"@sentry/cli-win32-x64\",\"version\":\"2.39.1\"},\"@sentry__core-10.29.0.tgz\":{\"integrity\":\"olQ2DU9dA/Bwsz3PtA9KNXRMqBWRQSkPw+MxwWEoU1K1qtiM9L0j6lbEFb5iSY3d7WYD5MB+1d5COugjSBrHtw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a254360d4f5d03f070b33dcfb40f4a35744ca8159141290fc3e331c161285352b5aad88cf4bd23ea56c415be62498ddded6603e4c07ed5de423ae823481ac7b7\",\"name\":\"@sentry/core\",\"version\":\"10.29.0\"},\"@sentry__react-10.29.0.tgz\":{\"integrity\":\"YGaEUXubzil7qssD1koh1fyt0aS8tHB61/6+oNShJ6xZPg03AB42bNMr2/y8fIFx36kb3MiCA5sFoH/ubF0LnQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"606684517b9bce297baacb03d64a21d5fcadd1a4bcb4707ad7febea0d4a127ac593e0d37001e366cd32bdbfcbc7c8171dfa91bdcc882039b05a07fee6c5d0b9d\",\"name\":\"@sentry/react\",\"version\":\"10.29.0\"},\"@sentry__vite-plugin-2.23.1.tgz\":{\"integrity\":\"avtjtIQ019sZW3FklpmNNsQOnYZjCHpnVxgDGElfZb+AaR4AvtHNlxXLJp+iqEfSK+Xok8MJarJqIgCaWcF40Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6afb63b48434d7db195b716496998d36c40e9d8663087a6757180318495f65bf80691e00bed1cd9715cb269fa2a847d22be5e893c3096ab26a22009a59c178d1\",\"name\":\"@sentry/vite-plugin\",\"version\":\"2.23.1\"},\"@sindresorhus__is-4.6.0.tgz\":{\"integrity\":\"t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b74f6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03\",\"name\":\"@sindresorhus/is\",\"version\":\"4.6.0\"},\"@sindresorhus__is-5.6.0.tgz\":{\"integrity\":\"TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4d5eedf062986895ac9f4d2d143a81c3cf94aa6afc0347d1535b6f4d08726731afd2c24219140bdc918c237b9cb8aa375c865d50ff8bc7bfe0876b7795ec32ee\",\"name\":\"@sindresorhus/is\",\"version\":\"5.6.0\"},\"@stylistic__eslint-plugin-5.10.0.tgz\":{\"integrity\":\"nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9cf2b9d991efa2df09bbfd00e2e7125f575c3d5dbfd5c971d242dc1f9c039ab1389da2aca3b4d40bfbe85325353bd393293ad1e8c622a7a2cfd28804310f633d\",\"name\":\"@stylistic/eslint-plugin\",\"version\":\"5.10.0\"},\"@swc__core-1.15.26.tgz\":{\"integrity\":\"tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b609591b2c7c3793c2fb1d4d77f26b671aa9aa5719a12b86f604c328ee80b854e8162541dee4bc1ef6ca16e3bb837949cef15ff6b8806fde31b3d1d4d948401d\",\"name\":\"@swc/core\",\"version\":\"1.15.26\"},\"@swc__core-darwin-arm64-1.15.26.tgz\":{\"integrity\":\"OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3a670ff7a085b0d3b06bae6d6a641ac9171faa1365710dd80963aafb459bf8200ce2e07b90e32b5d8e351a3e1ab6d871ac684b43da60ed5936ea20296fcf2274\",\"name\":\"@swc/core-darwin-arm64\",\"version\":\"1.15.26\"},\"@swc__core-darwin-x64-1.15.26.tgz\":{\"integrity\":\"liTTTpKSv89ivIxcZ+iU1cRige9Y7JkOjVnJ2Ystzl+DsWNHqt7wLTTgm/u7gEqmmAS2JKryODLQn3q1UtFNPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9624d34e9292bfcf62bc8c5c67e894d5c46281ef58ec990e8d59c9d98b2dce5f83b16347aadef02d34e09bfbbb804aa69804b624aaf23832d09f7ab552d14d3d\",\"name\":\"@swc/core-darwin-x64\",\"version\":\"1.15.26\"},\"@swc__core-linux-arm-gnueabihf-1.15.26.tgz\":{\"integrity\":\"Y/g+m3I8CeBof5A3kWWOS6QA2HOIUytF5EeTgfwcAK+GKT/tGe7Xqo5svBtaqflU5od2zzbMTWqkinPXgRWGgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63f83e9b723c09e0687f903791658e4ba400d87388532b45e4479381fc1c00af86293fed19eed7aa8e6cbc1b5aa9f954e68776cf36cc4d6aa48a73d781158680\",\"name\":\"@swc/core-linux-arm-gnueabihf\",\"version\":\"1.15.26\"},\"@swc__core-linux-arm64-gnu-1.15.26.tgz\":{\"integrity\":\"19IvwyPfBN/rz9s7qXhOTQmW0922+pjpRUUvIebu+CMM75nX6YuDzHsGx8hSmn5dS89SNaMCh1lgUuXqm++6jg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d7d22fc323df04dfebcfdb3ba9784e4d0996d3ddb6fa98e945452f21e6eef8230cef99d7e98b83cc7b06c7c8529a7e5d4bcf5235a30287596052e5ea9befba8e\",\"name\":\"@swc/core-linux-arm64-gnu\",\"version\":\"1.15.26\"},\"@swc__core-linux-arm64-musl-1.15.26.tgz\":{\"integrity\":\"iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"88d95bbd3228e36e6b90acc32cb5852469c55ebde6c844d47480c7723ba23cd644f1bd28826700ba2942e321095fb1521c66e796ca097024f6c5fe1bdd526699\",\"name\":\"@swc/core-linux-arm64-musl\",\"version\":\"1.15.26\"},\"@swc__core-linux-ppc64-gnu-1.15.26.tgz\":{\"integrity\":\"AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02eb843ad1be6172888c852ea7846cc58364971e97541dd62967e1c46ea19df3eb9fbbe9f3d44d38b6dbcb2a6b823e9293b93dba5c06553244944be604d3d208\",\"name\":\"@swc/core-linux-ppc64-gnu\",\"version\":\"1.15.26\"},\"@swc__core-linux-s390x-gnu-1.15.26.tgz\":{\"integrity\":\"JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"25c303590bd6d41721532460f04d231e24f1ec2418a54af9b8310bd5d9cf0c40ab123044186db29e62775d7ef4b165ea97425a82a475b7756900d60559d527a8\",\"name\":\"@swc/core-linux-s390x-gnu\",\"version\":\"1.15.26\"},\"@swc__core-linux-x64-gnu-1.15.26.tgz\":{\"integrity\":\"FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"156ed5ecc6e9ab8f8f03b06202aefa2c9b3c31d36e512ca5cae4557d0464848c9e59a745ae867e28e3e08e4bbc67f7d7ce7831051bec93e3c6181d2df2619c8c\",\"name\":\"@swc/core-linux-x64-gnu\",\"version\":\"1.15.26\"},\"@swc__core-linux-x64-musl-1.15.26.tgz\":{\"integrity\":\"w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3c7aba8c1ec55c746c147c9c45e8b6a24ee3e82a7c8b39c51b84b731897ae52ede4c2e3b6581c21e518fcd58afe83e8caa9201fefe2f293899cc4f1be5f3765\",\"name\":\"@swc/core-linux-x64-musl\",\"version\":\"1.15.26\"},\"@swc__core-win32-arm64-msvc-1.15.26.tgz\":{\"integrity\":\"uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b8309608da548aa91bbcf9acb8f5139ff3fb6a0f52a8d5c3d894ff5b7754bbbc99da4af337e9e69a8436c515fadff27a45888723b693e23a3b67efa5b258e53c\",\"name\":\"@swc/core-win32-arm64-msvc\",\"version\":\"1.15.26\"},\"@swc__core-win32-ia32-msvc-1.15.26.tgz\":{\"integrity\":\"2k1ax1QmmqLEnpC0uRCw7OXhBfyvdPqERBXupDasjYbChT6ZSO/uha28Bp38cw0viKIG79L27aTDkbkABsMW3w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"da4d5ac754269aa2c49e90b4b910b0ece5e105fcaf74fa844415eea436ac8d86c2853e9948efee85adbc069dfc730d2f88a206efd2f6eda4c391b90006c316df\",\"name\":\"@swc/core-win32-ia32-msvc\",\"version\":\"1.15.26\"},\"@swc__core-win32-x64-msvc-1.15.26.tgz\":{\"integrity\":\"aUuYecSEGa4SUSdyCWaI/vk8jdseifYnsF1GZQx2+piL8GIuT/5QrVcFfmes4Iwy7FIVXxtzD063z/FfpZ7K7w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"694b9879c48419ae12512772096688fef93c8ddb1e89f627b05d46650c76fa988bf0622e4ffe50ad57057e67ace08c32ec52155f1b730f4eb7cff15fa59ecaef\",\"name\":\"@swc/core-win32-x64-msvc\",\"version\":\"1.15.26\"},\"@swc__counter-0.1.3.tgz\":{\"integrity\":\"e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b6051e25b09924465299fea0873f0f59692c5cd0c55477b82d6ed681eda32f1de25561ef2c381f0305990fd83b4848719292ef6c08ae93e9c9d8d02b57ace09\",\"name\":\"@swc/counter\",\"version\":\"0.1.3\"},\"@swc__types-0.1.26.tgz\":{\"integrity\":\"lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"97233077b586806efd452ec4111655dd3f3031d98fab7c70ca0fb59e600ceb8908871e7297e8ee3b63d82076fbbd388f80f0a3f0b623b0d5764f9c224075046b\",\"name\":\"@swc/types\",\"version\":\"0.1.26\"},\"@szmarczak__http-timer-4.0.6.tgz\":{\"integrity\":\"4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e0101f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb\",\"name\":\"@szmarczak/http-timer\",\"version\":\"4.0.6\"},\"@szmarczak__http-timer-5.0.1.tgz\":{\"integrity\":\"+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f8f9905f43e20183cc79561edb7ecb24062f38c616d63dab1f96113b24b76f8093549ba6df81df46f2af033a331c0406d139c735d51f63d9c2794c9102cfff73\",\"name\":\"@szmarczak/http-timer\",\"version\":\"5.0.1\"},\"@tailwindcss__forms-0.5.11.tgz\":{\"integrity\":\"h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"87dc1e81b6433eeaf11b6db1652a16b5dcdce35fce94d11440444da88ff47cec1ad9a565586bbb0b7e44ff1e8b0f20f7960b73b454928ca672b9533487185b80\",\"name\":\"@tailwindcss/forms\",\"version\":\"0.5.11\"},\"@tailwindcss__typography-0.5.19.tgz\":{\"integrity\":\"w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c37d5d77c1cec7793dbcfb5c421e501cff46c0a7206cca7cee3e7caa2eb1822067145b4a1008025a70f0e2a513f1a1f0902a7c6cabdbfca18a5961de74fd0002\",\"name\":\"@tailwindcss/typography\",\"version\":\"0.5.19\"},\"@tanstack__query-core-5.99.0.tgz\":{\"integrity\":\"3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dc9bf75901b4042707ec6fbb95ffdb3fc43205f24e5de63e4f4f118a7dc66756ec86fc256cfb7b36b0c7304cc674a20e98ecef2109b18e4dbc604417eb493ba5\",\"name\":\"@tanstack/query-core\",\"version\":\"5.99.0\"},\"@tanstack__react-query-5.99.0.tgz\":{\"integrity\":\"OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"398d9b0aa3de993d4b96a27c6360946aee0a10b9c88611bd3a5dd99dd3db767074f79a516cfa35707b974e7760f22230b681d3830663c9a0e7434c43d2663003\",\"name\":\"@tanstack/react-query\",\"version\":\"5.99.0\"},\"@tweenjs__tween.js-23.1.3.tgz\":{\"integrity\":\"vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bc99afbf017162e1a71766b146d3d8a1c6a0e8295b6f9612ee42cbf923bf4de545cc7a83216acd298b5cb0f3226e30f1f4ef9bbbea6c032f4d29f5a495ab2c50\",\"name\":\"@tweenjs/tween.js\",\"version\":\"23.1.3\"},\"@tweenjs__tween.js-25.0.0.tgz\":{\"integrity\":\"XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5ca2c0eacc9e05468fcf1e23deac0cab3ceaf95e2ea3bd819e56ce8e6ba58cbad1a9db1ddea9f3bd9668c6f307676de776c452e1ab9f53a24e658a426d4e93d4\",\"name\":\"@tweenjs/tween.js\",\"version\":\"25.0.0\"},\"@twemoji__svg-15.0.0.tgz\":{\"integrity\":\"ZSPef2B6nBaYnfgdTbAy4jgW95o7pi2xPGwGCU+WMTxo7J6B1lMPTWwSq/wTuiMq+N0khQ90CcvYp1wFoQpo/w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6523de7f607a9c16989df81d4db032e23816f79a3ba62db13c6c06094f96313c68ec9e81d6530f4d6c12abfc13ba232af8dd24850f7409cbd8a75c05a10a68ff\",\"name\":\"@twemoji/svg\",\"version\":\"15.0.0\"},\"@tybys__wasm-util-0.10.1.tgz\":{\"integrity\":\"9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f6d4da3c92d289e8d92b1f819a8838b92b9bb5ea93bc5ad5ad44709261e2c41a341b8b1e0f4cd4c69f7c1350f35012712d0dcd3f05eb18a0e2563c31fc3a4fb2\",\"name\":\"@tybys/wasm-util\",\"version\":\"0.10.1\"},\"@types__babel__core-7.20.5.tgz\":{\"integrity\":\"qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"aa8429ad9bf3e70405270303a9eb1e4575afdeba8cbe18296d715f5725a16f1f57e3b3ce200ea2ffe75779f12664aa0080e69375a22035232a30853ad72472cc\",\"name\":\"@types/babel__core\",\"version\":\"7.20.5\"},\"@types__babel__generator-7.27.0.tgz\":{\"integrity\":\"ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b9f15dd978bdd8e0153d8b32f8fe27eff53b7baf1f7b1d3e11ef20486f4a5fb7a8d3ce025a2438b1dc64b6f765d1b38fba95ed5493d8d7dce4e84c16a9443c96\",\"name\":\"@types/babel__generator\",\"version\":\"7.27.0\"},\"@types__babel__template-7.4.4.tgz\":{\"integrity\":\"h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"87f354692c86e44cb1048a7c611c68e1131edbfa9082fca8c11c1533385884108e35b5bc3d4b20e2590532b86066151ee73dcbdcc88b0eebf227f09a3dad80f0\",\"name\":\"@types/babel__template\",\"version\":\"7.4.4\"},\"@types__babel__traverse-7.28.0.tgz\":{\"integrity\":\"8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f0fbdc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1\",\"name\":\"@types/babel__traverse\",\"version\":\"7.28.0\"},\"@types__cacheable-request-6.0.3.tgz\":{\"integrity\":\"IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"210dc46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab\",\"name\":\"@types/cacheable-request\",\"version\":\"6.0.3\"},\"@types__debug-4.1.13.tgz\":{\"integrity\":\"KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2925609909b33303e59ad9633a899aca847cf56e05ca70808b713c3cfb3bbe60d53def38853faf18f2a425f4e19265ecd31d2301a6bd53cb96f1b6dfc92d9f5b\",\"name\":\"@types/debug\",\"version\":\"4.1.13\"},\"@types__estree-1.0.8.tgz\":{\"integrity\":\"dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb\",\"name\":\"@types/estree\",\"version\":\"1.0.8\"},\"@types__estree-jsx-1.0.5.tgz\":{\"integrity\":\"52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7609c515345c9f6f503600ba1c430fc377505014d992764b82dc1919ea2aa174c7d0cfb25638546e2459683b38e4fba5a28d4e7a9bda0a5c501773ba374e8c2\",\"name\":\"@types/estree-jsx\",\"version\":\"1.0.5\"},\"@types__file-saver-2.0.7.tgz\":{\"integrity\":\"dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74d2957c777f8e4d12911fdec4a1a3da0824078e4c024cef5826aa2d45209328c84e418dcc7f07fb2530afe04b25406364e7bdc3c5f7c209978590d1835103e8\",\"name\":\"@types/file-saver\",\"version\":\"2.0.7\"},\"@types__fs-extra-9.0.13.tgz\":{\"integrity\":\"nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c49f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4\",\"name\":\"@types/fs-extra\",\"version\":\"9.0.13\"},\"@types__hast-3.0.4.tgz\":{\"integrity\":\"WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"58fb3e6db430e5a0a3fb1ea568d1962c7df0be21eda02bff3f7fa8b4185b3a12601bcaada5d00c9530b12edb13580ecb1f53a1fdb1421ec067d133d2e66df411\",\"name\":\"@types/hast\",\"version\":\"3.0.4\"},\"@types__http-cache-semantics-4.2.0.tgz\":{\"integrity\":\"L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2f72e08a62c75ed1a45a290a9ec3e0d3f545c7d38665a0be78dd6ee2bf8e0755d1a87de6781200542db3af559d307f911e69d192a962400387349fc4d23fded1\",\"name\":\"@types/http-cache-semantics\",\"version\":\"4.2.0\"},\"@types__json-schema-7.0.15.tgz\":{\"integrity\":\"5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c\",\"name\":\"@types/json-schema\",\"version\":\"7.0.15\"},\"@types__json5-0.0.29.tgz\":{\"integrity\":\"dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7512e30961d8838a1a03bedcc4eeb8a0efbb2700b09c8ce464f76bac2ef58d0990b6584ce79ea9c0aa396d4ceabd99dd9156de14b2088bef530b8d09345e6135\",\"name\":\"@types/json5\",\"version\":\"0.0.29\"},\"@types__keyv-3.1.4.tgz\":{\"integrity\":\"BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"050e5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422\",\"name\":\"@types/keyv\",\"version\":\"3.1.4\"},\"@types__mdast-4.0.4.tgz\":{\"integrity\":\"kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"90668d6cf87593b005ce0a6e77f80c76f226e71b840b291147e26758a427a3d4c05d56ba5885421933ef6067a42032f8bb009941261b53134149bd5a528efda0\",\"name\":\"@types/mdast\",\"version\":\"4.0.4\"},\"@types__ms-2.1.0.tgz\":{\"integrity\":\"GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654\",\"name\":\"@types/ms\",\"version\":\"2.1.0\"},\"@types__node-24.12.2.tgz\":{\"integrity\":\"A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"035b2b7b6ea47bb1c322e63f336de777d81f07e9eb9a1b58c8c20d6e3235cc727162d78a47aa92317e7a16c9a331c0dbdd231c8c983906245180e082ff2043d2\",\"name\":\"@types/node\",\"version\":\"24.12.2\"},\"@types__plist-3.0.5.tgz\":{\"integrity\":\"E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"13a3826919807b858399636c2fff5132a7649330c26357adbad91f95693873e01c8c3534ecf733d5f4304d7d13433f8fc6a9fd8b82f54d4dd41698e7adc0e0c4\",\"name\":\"@types/plist\",\"version\":\"3.0.5\"},\"@types__prop-types-15.7.15.tgz\":{\"integrity\":\"F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23\",\"name\":\"@types/prop-types\",\"version\":\"15.7.15\"},\"@types__react-18.3.28.tgz\":{\"integrity\":\"z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cfd557a42ecc5ab85f5a2a62b6335d8026aea0c2d174820b42c00457e65eb08cc1abfa149719349b702966e3050977674b853b2ab23e977591504190f0ad502b\",\"name\":\"@types/react\",\"version\":\"18.3.28\"},\"@types__react-dom-18.3.7.tgz\":{\"integrity\":\"MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad\",\"name\":\"@types/react-dom\",\"version\":\"18.3.7\"},\"@types__react-helmet-6.1.11.tgz\":{\"integrity\":\"0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1071d18b75d4c4468b425e8dd516551258edf3b6b6b0f2767a7b7cc94a01bb6a9c15e71b7ea49512f1ec0f06a4f8358075a29b462e9acd43316578863ce2efe\",\"name\":\"@types/react-helmet\",\"version\":\"6.1.11\"},\"@types__react-modal-3.16.3.tgz\":{\"integrity\":\"xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c57b866afc8419a1500e006fe14566f3f66c1beab1790edfefbc8dad6de7fb527a5c0b2d532e6b6077881cf8752b3b0673a22408876eea5436c56ceed630532e\",\"name\":\"@types/react-modal\",\"version\":\"3.16.3\"},\"@types__responselike-1.0.3.tgz\":{\"integrity\":\"H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1fff8bf94913577dee7f8f4f1f9a420140553cd8f69c30574cdfaa4b574ec32ca0db897709c89c89c080edc6be1ccbc9059705825e6bf1ef9147a7a5b1be0bcb\",\"name\":\"@types/responselike\",\"version\":\"1.0.3\"},\"@types__semver-7.7.1.tgz\":{\"integrity\":\"FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1668097eef8c39c437ef4483d1ebfb108f1394201f29853e0789b94f7c977350a244df7883f4993edb02924e74e9a503b65327159bdab03c071d4719504698b8\",\"name\":\"@types/semver\",\"version\":\"7.7.1\"},\"@types__stats.js-0.17.4.tgz\":{\"integrity\":\"jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8c806f5964a10af941a8134866dd0a02c856a6f4a3864c2412ee1951c012a00be19ab800508dadd5d5eb8d22f8c5754b0781739cfac8b17de7297165fc3b78bc\",\"name\":\"@types/stats.js\",\"version\":\"0.17.4\"},\"@types__three-0.163.0.tgz\":{\"integrity\":\"uIdDhsXRpQiBUkflBS/i1l3JX14fW6Ot9csed60nfbZNXHDTRsnV2xnTVwXcgbvTiboAR4IW+t+lTL5f1rqIqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b8874386c5d1a508815247e5052fe2d65dc95f5e1f5ba3adf5cb1e77ad277db64d5c70d346c9d5db19d35705dc81bbd389ba00478216fadfa54cbe5fd6ba88a8\",\"name\":\"@types/three\",\"version\":\"0.163.0\"},\"@types__unist-2.0.11.tgz\":{\"integrity\":\"CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0a604a88be8d368fceaa098c9fde4593d5a1969da6b6f22ff8a36940a3761784a3beb11eb2e6d34561984a0f819d664e9e509a493535b0ca6c04ece06d8867b0\",\"name\":\"@types/unist\",\"version\":\"2.0.11\"},\"@types__unist-3.0.3.tgz\":{\"integrity\":\"ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"928fe0205251bf5efb5e066c65c0709ea24de71fc689e9fca8d3a7d03e5b414ff303355ff59b7706571488baa157dcb801193419b4f7b675223cd8274d7cdcfd\",\"name\":\"@types/unist\",\"version\":\"3.0.3\"},\"@types__verror-1.10.11.tgz\":{\"integrity\":\"RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4650e6f4aefea39b2dbf40a8f22f19446c436eb4f1849b608ea8c5c9587fb5743297fad8b532a59d3bd9f3ca124de611116babc31db426ce244ee282b05914b6\",\"name\":\"@types/verror\",\"version\":\"1.10.11\"},\"@types__webxr-0.5.24.tgz\":{\"integrity\":\"h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"87c7e011dfc3a684bd081ae31105d1f9d203adaa290047eee30615358dad10fc24eb4b2d3d686f64c7f8168a3915a92e43b1c56686bc59c79a5857abbcad8ebe\",\"name\":\"@types/webxr\",\"version\":\"0.5.24\"},\"@types__ws-8.18.1.tgz\":{\"integrity\":\"ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4e1545e83095840f24506cbe69acc543891743b1354f2ec0df2a4539ed0870957c3bf339d751bdf405b6e22acaad6e7a5ade38c86f7e8a3f056aaa011a4b815e\",\"name\":\"@types/ws\",\"version\":\"8.18.1\"},\"@types__yauzl-2.10.3.tgz\":{\"integrity\":\"oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a09a1fb6fd0b4ae683644dcb7b80db297f8a4bd1b7e8dcce7926a9f745082b4c8c03f36128986a9521ad3433913516886d07f38d70eb41ad32b49ea63511b3fd\",\"name\":\"@types/yauzl\",\"version\":\"2.10.3\"},\"@typescript-eslint__eslint-plugin-8.58.2.tgz\":{\"integrity\":\"aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"682daa739b6141a86eb4a8cff9c97c72037d0d67b7654a95928df408c4991e71441f284e628652ce41ad008da6730677f31788983b9c238767aac1e2398bae0b\",\"name\":\"@typescript-eslint/eslint-plugin\",\"version\":\"8.58.2\"},\"@typescript-eslint__parser-8.58.2.tgz\":{\"integrity\":\"/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd96ffc5a2037f17899ef8ac86319d711e239abed2f9b75af0f28d85119d9630ccf9e957865bcdd05c8f4ac3272e6254ad51bd68f3ba7687fcd308cc6b0b004a\",\"name\":\"@typescript-eslint/parser\",\"version\":\"8.58.2\"},\"@typescript-eslint__project-service-8.58.2.tgz\":{\"integrity\":\"Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0aae947e9659935e7eafcec1908879ac3a62dfc5b86fe4a39dbf304023cf0c3c1e4bf2d10858c2c958846f31e4e429377f64037e09a5c6a49aed2edc943b657e\",\"name\":\"@typescript-eslint/project-service\",\"version\":\"8.58.2\"},\"@typescript-eslint__scope-manager-8.58.2.tgz\":{\"integrity\":\"SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4a09b2bc33dec5611341e93eab3667ac6ebce3821a3b4d9457238b848e30a68f3676964963dfba61908a00c1735dbeea871dfb9852b541c3d0d7cb6e77ebe8e9\",\"name\":\"@typescript-eslint/scope-manager\",\"version\":\"8.58.2\"},\"@typescript-eslint__tsconfig-utils-8.58.2.tgz\":{\"integrity\":\"3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dd247e46e922a43be490aa7f7748cfd1dcb3ba5b370db1a6c03a5511ce70aa4e5fdfc2854e16a4a8000ed17322ad6004fa44f4d284dab936f330518fa00cc1d0\",\"name\":\"@typescript-eslint/tsconfig-utils\",\"version\":\"8.58.2\"},\"@typescript-eslint__type-utils-8.58.2.tgz\":{\"integrity\":\"Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"67b125a0d47f077f3d16f69b746793a365ccb385bd4e3b4f88ef4302c993d32a26d1bc253f2463909d6e09d5b50efaebad83f9d00259f57737b01c9903df9d72\",\"name\":\"@typescript-eslint/type-utils\",\"version\":\"8.58.2\"},\"@typescript-eslint__types-8.58.2.tgz\":{\"integrity\":\"9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f53ba45f20130507ff26af403105dfbeeae4f86e51d8cc1fa901834761b31b3dbc1ef63f95734a1a1918fba20eb9bc1caae8a45a4e5c8e580fbc3dae000ee1b5\",\"name\":\"@typescript-eslint/types\",\"version\":\"8.58.2\"},\"@typescript-eslint__typescript-estree-8.58.2.tgz\":{\"integrity\":\"ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"10b1aea287ee861a02bcd6d08c5162a1b15c1a07030849b44e159d98ee19d14ccba8f5d2dca16f9c467e4877b0c0e6078ccd3db64cce597353bfdbba1aab72bb\",\"name\":\"@typescript-eslint/typescript-estree\",\"version\":\"8.58.2\"},\"@typescript-eslint__utils-8.58.2.tgz\":{\"integrity\":\"QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4197e31cd1333d8f3e974f9f21732fb90dac265a65078ce00d9bc0f8d9af66c66fdc443039c7350ee214d552544d667f44aa2e04c843c8d681331e2c5afaf344\",\"name\":\"@typescript-eslint/utils\",\"version\":\"8.58.2\"},\"@typescript-eslint__visitor-keys-8.58.2.tgz\":{\"integrity\":\"f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7f558ed8bc7c6bdb7c0c04667160143c96eed06db46c9963f0be33ef62b4d1331e240a322ebfed1e123fa736012eb4787575a47313b571661910e5fc0ca1d3a8\",\"name\":\"@typescript-eslint/visitor-keys\",\"version\":\"8.58.2\"},\"@ungap__structured-clone-1.3.0.tgz\":{\"integrity\":\"WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5a6a0df2a688028ed64d859b019b86f0f604867e5f933edd66ba93059eddb6dfff94bd86c26b3521c9d0e721ea8c37d7f05b798f86330ccdb77fcef305f0def6\",\"name\":\"@ungap/structured-clone\",\"version\":\"1.3.0\"},\"@unrs__resolver-binding-android-arm-eabi-1.11.1.tgz\":{\"integrity\":\"ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a692d15201d5686456531d11d14b74e8c8e8f6005a064837bfff00c6eb062e1b08a2d6c12ee464e75ac0cea2c2f20aba372c80a23117825363cdfe91f78f0337\",\"name\":\"@unrs/resolver-binding-android-arm-eabi\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-android-arm64-1.11.1.tgz\":{\"integrity\":\"lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"942c6456d6f8c29d6ff84a0df878c81bd7082333e45f93ad334de9418906f94e4eff02f9dcb0b841b21e6b38222aa96e19e5447819596a11da942681bd4d5ada\",\"name\":\"@unrs/resolver-binding-android-arm64\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-darwin-arm64-1.11.1.tgz\":{\"integrity\":\"gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"80f540d548d1bb563f22c07f75012ca76575a66e3839febe2d6bdb2dcf520e4d5cd8a8610d10c152440261559ee9fdbab896f77ce2bcb1a58c82d5fc22b324de\",\"name\":\"@unrs/resolver-binding-darwin-arm64\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-darwin-x64-1.11.1.tgz\":{\"integrity\":\"cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"705ccfeeb58a777959682b03cded3b417d520b6e253bc98fb72f6f74ff9855adcc19d5603e615ce7ddf5edbda2a17b6008c2868822f12781d0b3ada8cfa19f45\",\"name\":\"@unrs/resolver-binding-darwin-x64\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-freebsd-x64-1.11.1.tgz\":{\"integrity\":\"fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7eab4681a937cd7e03081e8f169b07e7e2a6b7ff02222e01af2e2b6f5868e80bf64074d110cfb8ef2dbcd94aa2bb76511792108a8250e6a59157a8ddb80fa21b\",\"name\":\"@unrs/resolver-binding-freebsd-x64\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-arm-gnueabihf-1.11.1.tgz\":{\"integrity\":\"u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bbdda6be5718b69f4c44a98ff99bcc9ad3cddf8fbfde5307972323ef05c90de5f1b8cd15833cf4f8f3c936cae8d66dc864f602848927f78e305bc4d88062851f\",\"name\":\"@unrs/resolver-binding-linux-arm-gnueabihf\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-arm-musleabihf-1.11.1.tgz\":{\"integrity\":\"cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"70835aa18db3ecb542adf1e421c9af8fba2c4ceb66e95553d7a6f9a10752e1b7a26d7d92601c2060b9aa8418c0d6de7509aad2681b97e5836c58b8eca9f5b90b\",\"name\":\"@unrs/resolver-binding-linux-arm-musleabihf\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-arm64-gnu-1.11.1.tgz\":{\"integrity\":\"34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"df8830ecf8c3181f4981e3c9126844a81856bc28a2582b97b0bf6162984317b72b5bb520234e60c81022e8c179f2e19c30e88ea92276c9b11e0af1dcab404299\",\"name\":\"@unrs/resolver-binding-linux-arm64-gnu\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-arm64-musl-1.11.1.tgz\":{\"integrity\":\"RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"472308c7a51fe778613ad24321a9926d3b2403df6c3c74bdeb0c5513f6c9b5e3c926da5d2865ced7063dd2845d5ee60e18e4eeaa34fc00271c31ce0ae90993df\",\"name\":\"@unrs/resolver-binding-linux-arm64-musl\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-ppc64-gnu-1.11.1.tgz\":{\"integrity\":\"D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0fc55a7bbe00e3f6be9991f415b3a41492fd0d22b647a4c53c2f4cfa30966226bfab67a29c2b9b5f5d2979ca438939a4255507fb2f0adc1642972703f2709284\",\"name\":\"@unrs/resolver-binding-linux-ppc64-gnu\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-riscv64-gnu-1.11.1.tgz\":{\"integrity\":\"frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7ebc4be0eaf3396555b0e73debe5776aa4c8425d4ed938e013157810a811634f4027d95e669120f0093da6169d6ee5f4040e24f14e6ab6f31241018699a26a71\",\"name\":\"@unrs/resolver-binding-linux-riscv64-gnu\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-riscv64-musl-1.11.1.tgz\":{\"integrity\":\"mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"989e6fb8368867e97f69cbf4d6c1e85dfa67cab34a3a4ff7683a0474b3bf5ed9fd1ee6650c3ea32b11e590df19856c8b26c441c5fbfd198336bad43548284a7b\",\"name\":\"@unrs/resolver-binding-linux-riscv64-musl\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-s390x-gnu-1.11.1.tgz\":{\"integrity\":\"kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9042e8f1e6c156d6fdb00eeb31ed42a61e101eb781ca1699d901000ddf4dcc842c60d429b7d52433d8aaaf69611abe5a7e1f3ce5dfdc07941e4d749b6474d83e\",\"name\":\"@unrs/resolver-binding-linux-s390x-gnu\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-x64-gnu-1.11.1.tgz\":{\"integrity\":\"C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b76401ee80a828bd5e58bc032cc61ab482d5eec0449429ce4c844b630692e81cf2d833e8aec128f795f945c0adc33e6ebcebad2b67b1bc04c7304aba3b843e7\",\"name\":\"@unrs/resolver-binding-linux-x64-gnu\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-linux-x64-musl-1.11.1.tgz\":{\"integrity\":\"rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad5d184a8ca12b69d9e2f12cc13fd0c2acea417c3923a0a3a1a60c397d13a819568688d47fc3fde26bc8ee7b894de68292476cdd0138fb34bc2a8f86757b99b4\",\"name\":\"@unrs/resolver-binding-linux-x64-musl\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-wasm32-wasi-1.11.1.tgz\":{\"integrity\":\"5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e6ee1191fc499be360ec85a09338b7aab14ebcbbd06273c19a399943cfaccd32bf6f7d5f4029e578d9751a012dee722c65121fe4f2e13f04f458cfaae39c7f51\",\"name\":\"@unrs/resolver-binding-wasm32-wasi\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-win32-arm64-msvc-1.11.1.tgz\":{\"integrity\":\"nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9d1733e48978967d243217cbf12de12e4c48f39057b37a3c118a1ab6db0935db17e18514f3d88e9159fb834547491c45b9531d3384358c4a4821dd488629bf53\",\"name\":\"@unrs/resolver-binding-win32-arm64-msvc\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-win32-ia32-msvc-1.11.1.tgz\":{\"integrity\":\"DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0c2108eade62d4d980669ea91689e90f99bb8ba685ae9a1f729e0b0368bc208abad09ca8dbc85a98a07136b65cc8ec15399920b11a7d3b6b1758158ff0c9ef21\",\"name\":\"@unrs/resolver-binding-win32-ia32-msvc\",\"version\":\"1.11.1\"},\"@unrs__resolver-binding-win32-x64-msvc-1.11.1.tgz\":{\"integrity\":\"lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"96b5b6d3485975b7d1b73b5bca0c9aabfea33fa00a13ca903762af3dc27ec7bc220f4dfc62d9d8b59f3620c349ebd18989b57b6f02f7cbd1602bee70fe962dea\",\"name\":\"@unrs/resolver-binding-win32-x64-msvc\",\"version\":\"1.11.1\"},\"@vitejs__plugin-react-4.7.0.tgz\":{\"integrity\":\"gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"814bbd8707d6bef1030419a0b40a30402a23c19989e6670b9f76ae7de0ac8ad8a3b37f9fd8db2b3ed94058847a38f8aa96397de8654251b2ded07caa22955aa0\",\"name\":\"@vitejs/plugin-react\",\"version\":\"4.7.0\"},\"@vladfrangu__async_event_emitter-2.4.7.tgz\":{\"integrity\":\"Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5df7baae9093c52c5f6ecc22fd6fcfcfbce9d56592367e00d1e5b898b91051ec02ad75ed323df594283e890c93921fc292eb194aaf5e0df96eeed8c40d7518ea\",\"name\":\"@vladfrangu/async_event_emitter\",\"version\":\"2.4.7\"},\"@xhayper__discord-rpc-1.3.3.tgz\":{\"integrity\":\"Ih48GHiua7TtZgKO+f0uZPhCeQqb84fY2qUys/oMh8UbUfiUkUJLVCmd/v2AK0/pV33euh0aqSXo7+9LiPSwGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"221e3c1878ae6bb4ed66028ef9fd2e64f842790a9bf387d8daa532b3fa0c87c51b51f89491424b54299dfefd802b4fe9577ddeba1d1aa925e8efef4b88f4b01b\",\"name\":\"@xhayper/discord-rpc\",\"version\":\"1.3.3\"},\"@xmldom__xmldom-0.8.12.tgz\":{\"integrity\":\"9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f64fe01c5ea7fe9022ffdb6aaf79b76aa92e88da2c613bab2cb52d73bc50f6cc41ff09bb58fca00aff0661aea64b47cb2441e1a8c0b5013621cfef94fe5447aa\",\"name\":\"@xmldom/xmldom\",\"version\":\"0.8.12\"},\"abbrev-3.0.1.tgz\":{\"integrity\":\"AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"00ed9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282\",\"name\":\"abbrev\",\"version\":\"3.0.1\"},\"acorn-8.16.0.tgz\":{\"integrity\":\"UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51527213d32db4eb014080cac35b246fd9c0c10b91e70b860f7fbcd8ae89809966fd8f8a23dda836c30d199098743b15b511d26a4d29715e439e8e7ee2387db3\",\"name\":\"acorn\",\"version\":\"8.16.0\"},\"acorn-jsx-5.3.2.tgz\":{\"integrity\":\"rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781\",\"name\":\"acorn-jsx\",\"version\":\"5.3.2\"},\"agent-base-6.0.2.tgz\":{\"integrity\":\"RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d\",\"name\":\"agent-base\",\"version\":\"6.0.2\"},\"agent-base-7.1.4.tgz\":{\"integrity\":\"MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d\",\"name\":\"agent-base\",\"version\":\"7.1.4\"},\"ajv-6.14.0.tgz\":{\"integrity\":\"IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"216ae8b26ff2ae7e377a22aa91f9078aced08a80e579a5d01dd0d53ca834152c3077f0eebf25fbf5366714e9d8a41edd72c140326b45ced66e5cf0ef49e3e417\",\"name\":\"ajv\",\"version\":\"6.14.0\"},\"ajv-8.18.0.tgz\":{\"integrity\":\"PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3e55cf78458c5cc67bb0f60e1ea983c8227371f36b52bddf18d2ad7b35f5e3291738422fc8af3577eab2771f3d298e4eef514a30f690daf05f04523934747adc\",\"name\":\"ajv\",\"version\":\"8.18.0\"},\"ajv-keywords-3.5.2.tgz\":{\"integrity\":\"5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e69e964cdd03753195424e958dc123bb5f4881a1ee75a95c7da6c3ef284319e03a6dc42798bf82a6f78b26aff786f7f07756a87fa2f7f3a3ae824c7a45fc8c21\",\"name\":\"ajv-keywords\",\"version\":\"3.5.2\"},\"ansi-escapes-7.3.0.tgz\":{\"integrity\":\"BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06f53c9d8806401c5c98cb84794126353beb3158c93521fb4605b6e2f5dec4de157a7eaa0afcb84e7b67be59f09cc2d356571141075b458f0d2a7688a1e58336\",\"name\":\"ansi-escapes\",\"version\":\"7.3.0\"},\"ansi-regex-5.0.1.tgz\":{\"integrity\":\"quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15\",\"name\":\"ansi-regex\",\"version\":\"5.0.1\"},\"ansi-regex-6.2.2.tgz\":{\"integrity\":\"Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa\",\"name\":\"ansi-regex\",\"version\":\"6.2.2\"},\"ansi-styles-4.3.0.tgz\":{\"integrity\":\"zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212\",\"name\":\"ansi-styles\",\"version\":\"4.3.0\"},\"ansi-styles-6.2.3.tgz\":{\"integrity\":\"4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be\",\"name\":\"ansi-styles\",\"version\":\"6.2.3\"},\"any-promise-1.3.0.tgz\":{\"integrity\":\"7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ed4be629a95646dd708232f546b1b1a12256ff44191487a0a5e1af646f648e9f2fad1bb9e574c76f09eaab61a95e6f6e2db72e8719b722a5fd381e0c651d5bd8\",\"name\":\"any-promise\",\"version\":\"1.3.0\"},\"anymatch-3.1.3.tgz\":{\"integrity\":\"KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"28c45e154af4078b7e0fe381923477298aafa1ca765da4b33b9e54701ea681031ddca6dc13e9964f2bd557b0ffcec7446cd9d5e9a71952eb64887417bd3af547\",\"name\":\"anymatch\",\"version\":\"3.1.3\"},\"app-builder-bin-5.0.0-alpha.12.tgz\":{\"integrity\":\"j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8fcee8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb\",\"name\":\"app-builder-bin\",\"version\":\"5.0.0-alpha.12\"},\"app-builder-lib-26.9.0.tgz\":{\"integrity\":\"f/1GhVrDfBH7sSzhAwiXa1rpR/7pB7Av5woUjmt+QYE0QyNvrOAiY05rngtR/PK4/1BzS6/zVoYobIwDAsrtBA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7ffd46855ac37c11fbb12ce10308976b5ae947fee907b02fe70a148e6b7e41813443236face022634e6b9e0b51fcf2b8ff50734baff35686286c8c0302caed04\",\"name\":\"app-builder-lib\",\"version\":\"26.9.0\"},\"arg-4.1.3.tgz\":{\"integrity\":\"58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7c4bd403a86d17c76ed8c0f4adf5f2718af8d8978df6602c1f0cc7d9fbbd5102a52b65e7fb2eb2906772c72cec024b814b341a653f9df7671f3de5278e087bc\",\"name\":\"arg\",\"version\":\"4.1.3\"},\"arg-5.0.2.tgz\":{\"integrity\":\"PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3d88f214e2ca43dcb9ec9bd0e902e8f1d02036ab3087c33544c25875076e4fac5b59280adfa3ff67fbfea7cf3ca4cebd8cc31f4bc5ddf05e88d6443f23d1d41a\",\"name\":\"arg\",\"version\":\"5.0.2\"},\"argparse-2.0.1.tgz\":{\"integrity\":\"8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd\",\"name\":\"argparse\",\"version\":\"2.0.1\"},\"aria-query-5.3.2.tgz\":{\"integrity\":\"COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"08e44ea676a86a9d44d85d34d12eb6afa03ad2e1d99e696fa2685fc93d8395372b6353ab04a9f65211fbaa7e704c2f7332f0f4018edcb1d3d237028ffbb5a243\",\"name\":\"aria-query\",\"version\":\"5.3.2\"},\"array-buffer-byte-length-1.0.2.tgz\":{\"integrity\":\"LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2c713ef01b91ed16060cabe7ae672e4aaded0dc2aff4e1445d0b7f1e96d9858ed5ea1d339545eeb67003f361a2171f6b76278232392fb5cb0fa81c20525d488b\",\"name\":\"array-buffer-byte-length\",\"version\":\"1.0.2\"},\"array-find-index-1.0.2.tgz\":{\"integrity\":\"M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3351d0c885dc046b55cb006df1655d8a6fa5acd68aed51e9f7d42de6948dce25f39ca1d588805b5d6b5f453a4416917f73815d7f1340b020b03e9e69841609b7\",\"name\":\"array-find-index\",\"version\":\"1.0.2\"},\"array-includes-3.1.9.tgz\":{\"integrity\":\"FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1667820807a7cc7d0a1f7f3548f4f91599a203f4e6a6776971a4a185f80437d7825639c506aab7975c6b238db2f3e3cf2c8ea1ca9ce8bb8197c34d161e63c12d\",\"name\":\"array-includes\",\"version\":\"3.1.9\"},\"array.prototype.findlast-1.2.5.tgz\":{\"integrity\":\"CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"095bdde851e0d59dcf3a904bc4ee84eb3afead228443d2faad91c0698ee52df84ab166140413ae32cd1ef68db8a28a63e87fa0791097d1827e4c92c12b6787c9\",\"name\":\"array.prototype.findlast\",\"version\":\"1.2.5\"},\"array.prototype.findlastindex-1.2.6.tgz\":{\"integrity\":\"F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17f4ca013933b1e504c4f95fbe6c102862133370c64cafaf900b026680dce5d695ca06c90678c45026e0900bd516c81f5df5f8608a99ff6ec6de4ded757ad3c5\",\"name\":\"array.prototype.findlastindex\",\"version\":\"1.2.6\"},\"array.prototype.flat-1.3.3.tgz\":{\"integrity\":\"rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"af01bf8dad677b22ea0ae199e5862bce703ad83e266578348b5708b242142928aa1770a37bdff05c096cf41f6cd566b67e898cb08bfc73307c8d970f9b109716\",\"name\":\"array.prototype.flat\",\"version\":\"1.3.3\"},\"array.prototype.flatmap-1.3.3.tgz\":{\"integrity\":\"Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63b5ade7578a252ca2f34845ac909e3c618da3992d242b2516e6e8a89b1b7f9ec208f726e73ced96e3e5738fda0fcb16b0abe5c1ab5ece957853579f93c9298e\",\"name\":\"array.prototype.flatmap\",\"version\":\"1.3.3\"},\"array.prototype.tosorted-1.1.4.tgz\":{\"integrity\":\"p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a7a171f01edbed984bfe0994b00cb40f5e5686f0dc730de69c635b6698b7a66789771b56b23da311a23863aa28dd78877f3b9280fc0a734e0c62de8a82f0bfc0\",\"name\":\"array.prototype.tosorted\",\"version\":\"1.1.4\"},\"arraybuffer.prototype.slice-1.0.4.tgz\":{\"integrity\":\"BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04da0263a4975cf43b805da8a483f818113e5f0ed4fa91cc60abb38e008ddc6c22688474f5451e29f85ec88af2efb42dac20650b428ad2ae7f4c447fb588773d\",\"name\":\"arraybuffer.prototype.slice\",\"version\":\"1.0.4\"},\"assert-plus-1.0.0.tgz\":{\"integrity\":\"NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"35f27853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b\",\"name\":\"assert-plus\",\"version\":\"1.0.0\"},\"ast-types-flow-0.0.8.tgz\":{\"integrity\":\"OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"387ff6139160db487668fadb7be40bf09650164a34619685fa3e269d0ec11a17dabceecea522daf1ad32f6c070a261dd49b9214d2f1340d6b205f9d6e43c1bbd\",\"name\":\"ast-types-flow\",\"version\":\"0.0.8\"},\"astral-regex-2.0.0.tgz\":{\"integrity\":\"Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"67bb4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd\",\"name\":\"astral-regex\",\"version\":\"2.0.0\"},\"async-3.2.6.tgz\":{\"integrity\":\"htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600\",\"name\":\"async\",\"version\":\"3.2.6\"},\"async-exit-hook-2.0.1.tgz\":{\"integrity\":\"NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707\",\"name\":\"async-exit-hook\",\"version\":\"2.0.1\"},\"async-function-1.0.0.tgz\":{\"integrity\":\"hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"86c535f007bc0834d1e8a82ef4361fd046c2aff6b98862f4af2b500e86d471da5838aa2493c2c48d5a619d7903920a62d30615b2aad7b8fd1b67125a4ea760a0\",\"name\":\"async-function\",\"version\":\"1.0.0\"},\"asynckit-0.4.0.tgz\":{\"integrity\":\"Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"39e8bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1\",\"name\":\"asynckit\",\"version\":\"0.4.0\"},\"at-least-node-1.0.0.tgz\":{\"integrity\":\"+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"faafedec492fd440d8da5e8675ae8b2e25f5e2b53d4d5db459ade87de426c0f1596ce328f435eb2db3a315a69c9645ca5a27486a8a7000e6d00eac16b46523aa\",\"name\":\"at-least-node\",\"version\":\"1.0.0\"},\"atomic-sleep-1.0.0.tgz\":{\"integrity\":\"kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"90d3a30ea021ee9c745d6348fb841bce8891fe74e41c058db9ddaebe726ab83d7fc796bb11064c253d00733a8ad109faee863f4d34352db50a6a3669a7723db5\",\"name\":\"atomic-sleep\",\"version\":\"1.0.0\"},\"autoprefixer-10.5.0.tgz\":{\"integrity\":\"FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"14c84ea19578faa47a6935002ca5f6ac4a861bea32013bf006df48233551e6b31ad874563e4c5ff8ff8f0092c3d48fc7e7f208f87b99701258105069ab7f689e\",\"name\":\"autoprefixer\",\"version\":\"10.5.0\"},\"available-typed-arrays-1.0.7.tgz\":{\"integrity\":\"wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c2f52306d48637bfbb4a3369abff4cd93837e745190f7abad881592db4404756d23250a8d5969e5be049f83d3dd1ee2120864b05c4c359ee0c8788ef5036a3cd\",\"name\":\"available-typed-arrays\",\"version\":\"1.0.7\"},\"axe-core-4.11.3.tgz\":{\"integrity\":\"zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cc1428b998b10d36e8de3306a872b278fc58c6bd5ee56f1475398143bb0db5a03d3366c4df675ac713cb4bf8e88e128e1f143b2d6c0f8df8b07ff7e16895b396\",\"name\":\"axe-core\",\"version\":\"4.11.3\"},\"axobject-query-4.1.0.tgz\":{\"integrity\":\"qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a888f41bdc196cc18d2e32e68353d3eafda613d007db3967003243ff6b42e84d348609a150e7c407a82b7873c07cb452b9f1ea44e2144e4c3a13e337947d0f4d\",\"name\":\"axobject-query\",\"version\":\"4.1.0\"},\"babel-plugin-add-module-exports-1.0.4.tgz\":{\"integrity\":\"g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"83ef32c47519eb445cc9a5297cdcf2e7a3ad596fb1f5cc847bd8fe0ab6a7a8b8aa6e3bb6c9ffc2cba66d60ae34119c6dadd1e59739556602e670e5024e527b26\",\"name\":\"babel-plugin-add-module-exports\",\"version\":\"1.0.4\"},\"babel-plugin-module-resolver-5.0.3.tgz\":{\"integrity\":\"h8h6H71ZvdLJZxZrYkaeR30BojTaV7O9GfqacY14SNj5CNB8ocL9tydNzTC0JrnNN7vY3eJhwCmkDj7tuEUaqQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"87c87a1fbd59bdd2c967166b62469e477d01a234da57b3bd19fa9a718d7848d8f908d07ca1c2fdb7274dcd30b426b9cd37bbd8dde261c029a40e3eedb8451aa9\",\"name\":\"babel-plugin-module-resolver\",\"version\":\"5.0.3\"},\"bail-2.0.2.tgz\":{\"integrity\":\"0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d313ba99877b241d987acc432a995a7d1a6c88eccfb7d574d9d74f08b6d8d716063ce5f6e0d4f2379d2a9d4c6008f712a183212a902e0538d0a1164202450347\",\"name\":\"bail\",\"version\":\"2.0.2\"},\"balanced-match-1.0.2.tgz\":{\"integrity\":\"3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f\",\"name\":\"balanced-match\",\"version\":\"1.0.2\"},\"balanced-match-4.0.4.tgz\":{\"integrity\":\"BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04bae011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c\",\"name\":\"balanced-match\",\"version\":\"4.0.4\"},\"base64-js-1.5.1.tgz\":{\"integrity\":\"AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"00aa5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58\",\"name\":\"base64-js\",\"version\":\"1.5.1\"},\"baseline-browser-mapping-2.10.19.tgz\":{\"integrity\":\"qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a8290d2e2dac7c13a7f17859434157b13d4a8bf628e4ff7486b9116a6545452eff295f61a5f0381e4a16354d79dbef30d333e39f1a39a6cc7934bdcf48682fe6\",\"name\":\"baseline-browser-mapping\",\"version\":\"2.10.19\"},\"binary-extensions-2.3.0.tgz\":{\"integrity\":\"Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"09e87eee8c79a9eecb26e2c7a18d1f7a1de91ee5031c071151ec8bd95620859c1fa64348cbffbc39c8346b752e4a86336af9b2970b8b59039fde19748e330c23\",\"name\":\"binary-extensions\",\"version\":\"2.3.0\"},\"bindings-1.5.0.tgz\":{\"integrity\":\"p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a76abfb7f9a1bee3a3fd478b955eb9eba183fe0ba8c25af4847c42948d16f66ecc59890bd45d212e8fb401ec6cf4748f0ad4754974344c3dcc30aad765a8db89\",\"name\":\"bindings\",\"version\":\"1.5.0\"},\"bl-4.1.0.tgz\":{\"integrity\":\"1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d56d3b70cf604ba0dc2e97ab65f1528fe6d62ed68f1923875a13e21b35e6bd525b44b746f36b07fca9fc12d5b556a595039e0029fda1e64e416e721bc05de1eb\",\"name\":\"bl\",\"version\":\"4.1.0\"},\"boolean-3.2.0.tgz\":{\"integrity\":\"d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"774208fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3\",\"name\":\"boolean\",\"version\":\"3.2.0\"},\"brace-expansion-1.1.14.tgz\":{\"integrity\":\"MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3163c67c3c67cb3294eeb34e5bd48ffdce74be2df1ae6aee6bffba85f3db092d8004d59fc76e2f3e2773bc2ee4ae353f453a36df9b15efbeb29a5b0cb462a3f2\",\"name\":\"brace-expansion\",\"version\":\"1.1.14\"},\"brace-expansion-2.1.0.tgz\":{\"integrity\":\"TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4cdd64099020760c1e261596a60298ad068c34770350b1e45b0408b2976d8d5e18e5abab45d6698c0aa7eb25f714fa9303d9e01c2738849c4c00c8067ef7bce7\",\"name\":\"brace-expansion\",\"version\":\"2.1.0\"},\"brace-expansion-5.0.5.tgz\":{\"integrity\":\"VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"559ce72e0b70867f8c69cb7db5f8b0c7ae1f03d7ab1c7fcc0971147c1ff46d7ffa173ea7cb91064d7625b4ca1caa0e31140419b673b70c75965e2f118ae37b71\",\"name\":\"brace-expansion\",\"version\":\"5.0.5\"},\"braces-3.0.3.tgz\":{\"integrity\":\"yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc\",\"name\":\"braces\",\"version\":\"3.0.3\"},\"browser-fs-access-0.35.0.tgz\":{\"integrity\":\"sLoadumpRfsjprP8XzVjpQc0jK8yqHBx0PtUTGYj2fftT+P/t+uyDAQdMgGAPKD011in/O+YYGh7fIs0oG/viw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b0ba1a76e9a945fb23a6b3fc5f3563a507348caf32a87071d0fb544c6623d9f7ed4fe3ffb7ebb20c041d3201803ca0f4d758a7fcef9860687b7c8b34a06fef8b\",\"name\":\"browser-fs-access\",\"version\":\"0.35.0\"},\"browserslist-4.28.2.tgz\":{\"integrity\":\"48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e3cc52ae2658620fbca979daf64c2a8c8573b90c62f8a616a76fb99c262760a3d3af42ef0fcf49aa4d8eaf9a20c73d0d50c7c88e1876948517fcbc97f41e2822\",\"name\":\"browserslist\",\"version\":\"4.28.2\"},\"buffer-5.7.1.tgz\":{\"integrity\":\"EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"10773220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15\",\"name\":\"buffer\",\"version\":\"5.7.1\"},\"buffer-crc32-0.2.13.tgz\":{\"integrity\":\"VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"54ef47b7ffa9dd237b48a5aa72b804ce319b4522584f1f90d694d00b4c2b5aa1f1d2fa49ada43a1ad1f1f2dbdc835ae52b56f2854e6071cc603a08fb0744c391\",\"name\":\"buffer-crc32\",\"version\":\"0.2.13\"},\"buffer-from-1.1.2.tgz\":{\"integrity\":\"E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"13e5d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d\",\"name\":\"buffer-from\",\"version\":\"1.1.2\"},\"builder-util-26.9.0.tgz\":{\"integrity\":\"+eocmbdisnyb40B9nAp/KREfYLXvGagxV50KZv/Zh4aflsr1fdY9Qxs6QG1Jtx1vH5d5NQ3hIcemUi4RSlFK/Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f9ea1c99b762b27c9be3407d9c0a7f29111f60b5ef19a831579d0a66ffd987869f96caf57dd63d431b3a406d49b71d6f1f9779350de121c7a6522e114a514afd\",\"name\":\"builder-util\",\"version\":\"26.9.0\"},\"builder-util-runtime-9.6.0.tgz\":{\"integrity\":\"k9V5I18PXLepLZ8jVmPzsH+gVCVZ+9aMVLyCZ0ZLOkT2KSyiBblDCCN8WxDbjOpfLGNHZqqJPBmW0HYeqxlgkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93d579235f0f5cb7a92d9f235663f3b07fa0542559fbd68c54bc8267464b3a44f6292ca205b94308237c5b10db8cea5f2c634766aa893c1996d0761eab196091\",\"name\":\"builder-util-runtime\",\"version\":\"9.6.0\"},\"bundle-name-4.1.0.tgz\":{\"integrity\":\"tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b63c0ce5ec4c83a046448fa43664e7b4db2f7594b55fc045612ead9c9da1747d2457133afde559db1cbe16a4ad496bd89ad7c53032c8c6eae8ac7c0329f0f3e5\",\"name\":\"bundle-name\",\"version\":\"4.1.0\"},\"cac-6.7.14.tgz\":{\"integrity\":\"b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6fa225bacf9cdd1add0e4f8984b2940107f3ce02c43f2eb0717a92edfff17b51044efb033fa18e446ed216e3ace9c203e5892a7215bf2d765b5f96dcf23ed971\",\"name\":\"cac\",\"version\":\"6.7.14\"},\"cacache-19.0.1.tgz\":{\"integrity\":\"hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"85db14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015\",\"name\":\"cacache\",\"version\":\"19.0.1\"},\"cacheable-lookup-5.0.4.tgz\":{\"integrity\":\"2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dbf90db1c3e1a5cc6b3a280c6736e2585eddcfc8a585bfe72075371326625d65e97aafdabbca89f1585d7ed324b72de7ec68fa1c819a9501bca2204d07700980\",\"name\":\"cacheable-lookup\",\"version\":\"5.0.4\"},\"cacheable-lookup-7.0.0.tgz\":{\"integrity\":\"+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"faa272c78c622ab6bc999adcc218cc44c5210f9351d51f1eb0f933218c57f7a26279c168c405c5bb3fc6a51dfe7afe0f13559a9878a9efcc15d2f7263d0b69f3\",\"name\":\"cacheable-lookup\",\"version\":\"7.0.0\"},\"cacheable-request-10.2.14.tgz\":{\"integrity\":\"zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ce40d3e56005e21492a148327e0e6d148c73f1740afb6e56fd32d5a2325330a05ac5ebcb041b4bc60aa0b80b95401f0f556efd1558c7714f8627db556c367d99\",\"name\":\"cacheable-request\",\"version\":\"10.2.14\"},\"cacheable-request-7.0.4.tgz\":{\"integrity\":\"v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bfea7aa2782cae9d324c66c95e38313e8c36f832fddc30123f891708329bf3f6f046db7d384177c218209240e418dce0716cb65da1786bc9d98250bbb8496c72\",\"name\":\"cacheable-request\",\"version\":\"7.0.4\"},\"cached-iterable-0.3.0.tgz\":{\"integrity\":\"MDqM6TpBVebZD4UDtmlFp8EjVtRcsB6xt9aRdWymjk0fWVUUGgmt/V7o0H0gkI2Tkvv8B0ucjidZm4mLosdlWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"303a8ce93a4155e6d90f8503b66945a7c12356d45cb01eb1b7d691756ca68e4d1f5955141a09adfd5ee8d07d20908d9392fbfc074b9c8e27599b898ba2c7655b\",\"name\":\"cached-iterable\",\"version\":\"0.3.0\"},\"call-bind-1.0.9.tgz\":{\"integrity\":\"a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6bf872fa936c1544d1f88cfc4c226f5ee74a54b027cff0f2792528d74239caf143409045536b3dbaa429a12ac996ba0750aa0aab383e7a9c723fd96a15dcdf05\",\"name\":\"call-bind\",\"version\":\"1.0.9\"},\"call-bind-apply-helpers-1.0.2.tgz\":{\"integrity\":\"Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4a9d5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31\",\"name\":\"call-bind-apply-helpers\",\"version\":\"1.0.2\"},\"call-bound-1.0.4.tgz\":{\"integrity\":\"+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e\",\"name\":\"call-bound\",\"version\":\"1.0.4\"},\"call-me-maybe-1.0.2.tgz\":{\"integrity\":\"HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e95fae68d479ebf471f6e688c2d581acec70902ead0608e89b49a58447478da6027f675319bf699373bfb187a58e3f16d155c9a06efe21194fae490ff6c4565\",\"name\":\"call-me-maybe\",\"version\":\"1.0.2\"},\"callsites-3.1.0.tgz\":{\"integrity\":\"P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69\",\"name\":\"callsites\",\"version\":\"3.1.0\"},\"camelcase-css-2.0.1.tgz\":{\"integrity\":\"QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40e4af7af86c9628e0630471e91bfbcca74c17c95b466c7eb901b1dbebc373e288fde067b32f648ade5a8f6dc0806bb7a5ae2df408306e75d6a92fa2398fb668\",\"name\":\"camelcase-css\",\"version\":\"2.0.1\"},\"caniuse-lite-1.0.30001788.tgz\":{\"integrity\":\"6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eaaf07169fa5390b5c7fbc012beb847a7c729955a418a9231690afc395b6e5c98cc040d4e39a75c5014142ff090e530caf2ede371c81691faac6099351990845\",\"name\":\"caniuse-lite\",\"version\":\"1.0.30001788\"},\"case-1.6.3.tgz\":{\"integrity\":\"mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9b30d25c83da170543bd9007a99f5595bc85e32c9746e5fa22f074e96bcf624a8954edb8917d4f3e1bfd6dfa4a345672c581669a0a34dc75220fc8a496625845\",\"name\":\"case\",\"version\":\"1.6.3\"},\"ccount-2.0.1.tgz\":{\"integrity\":\"eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b2ac5d23885a58fb776b4fadfcddfd6a8646c6b0b4a27cd02303ad4852366398b0968c8b58e8b07d7edf588680e0c1f99c941db386ee752dcefef796fc35102\",\"name\":\"ccount\",\"version\":\"2.0.1\"},\"chalk-4.1.2.tgz\":{\"integrity\":\"oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898\",\"name\":\"chalk\",\"version\":\"4.1.2\"},\"chalk-5.6.2.tgz\":{\"integrity\":\"7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ecdcc12f4acde9f3145be7fb03a228e21e34a90946fb11a6b4cc5f6e71ff2bb4c0b6df094165502beea0d145ca31e549a3257912490db04ad0f29543ddb2c76c\",\"name\":\"chalk\",\"version\":\"5.6.2\"},\"character-entities-2.0.2.tgz\":{\"integrity\":\"shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b21c7ba10d00c1e9ff05121d92392fcf9e0f9c4108fc48f05c3488669f3afca29d6da7c78750dffd16060619f885b7b6fae282f459d3e540847723f3dda8bd85\",\"name\":\"character-entities\",\"version\":\"2.0.2\"},\"character-entities-html4-2.1.0.tgz\":{\"integrity\":\"1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d6fedf810463ea19d2c05a6ad44bb4ca7aff083130d2b5e8d81eb5a97acb35d1d998f2a06fb7ea4b56b6270174ac84a8f6aefb8c323c54c107a00a67f2a0e864\",\"name\":\"character-entities-html4\",\"version\":\"2.1.0\"},\"character-entities-legacy-3.0.0.tgz\":{\"integrity\":\"RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4693e9d1ab13ffab9f466fff009570a558996c633f3248d017125c710447988485ff6d8d06db07a805a62fefe99a43d6a08509756c9e565793975c3274701355\",\"name\":\"character-entities-legacy\",\"version\":\"3.0.0\"},\"character-reference-invalid-2.0.1.tgz\":{\"integrity\":\"iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"881678178c116f239156cbb48cf57b81790eb066231873e6032bfe1e21c6f208b93ed0bd288da3d7ebfcfed9626d1be3a165f4dbbca9986fe7d07b4ee6deee9f\",\"name\":\"character-reference-invalid\",\"version\":\"2.0.1\"},\"chokidar-3.6.0.tgz\":{\"integrity\":\"7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ed54f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f\",\"name\":\"chokidar\",\"version\":\"3.6.0\"},\"chokidar-4.0.3.tgz\":{\"integrity\":\"Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"420ceef247c1be8f9c038f7ada39cfd4a912e83a29e4d4ba83b4792c5609af86fc51bf783cf417524b02c3d3ef5e87973d145d751342e42d4941447648c1ad9c\",\"name\":\"chokidar\",\"version\":\"4.0.3\"},\"chownr-3.0.0.tgz\":{\"integrity\":\"+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa\",\"name\":\"chownr\",\"version\":\"3.0.0\"},\"chromium-pickle-js-0.2.0.tgz\":{\"integrity\":\"1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d51e45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b\",\"name\":\"chromium-pickle-js\",\"version\":\"0.2.0\"},\"ci-info-4.3.1.tgz\":{\"integrity\":\"Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474\",\"name\":\"ci-info\",\"version\":\"4.3.1\"},\"ci-info-4.4.0.tgz\":{\"integrity\":\"77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efb3d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42\",\"name\":\"ci-info\",\"version\":\"4.4.0\"},\"classnames-2.5.1.tgz\":{\"integrity\":\"saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1a1d83b384842ceb0cb6b15c5333a6d40ec40ee05e7457d450db6a81a447425be23efd69a47b61ce97a952e9d4e97715616fcf3f23af87b3ee37f1cde57d4a3\",\"name\":\"classnames\",\"version\":\"2.5.1\"},\"cli-cursor-3.1.0.tgz\":{\"integrity\":\"I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"23fcc7030b0a7fd16a1a85cce16591002a1bf7e48dba465377de03585e7b138b68a2e46e95b0b171487a44a5043909584c7267ce43ccc92bcf35a6922cd7cb67\",\"name\":\"cli-cursor\",\"version\":\"3.1.0\"},\"cli-cursor-5.0.0.tgz\":{\"integrity\":\"aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6828f83b9c0acacce33260d3e2d663f77931cb274dfcae733d64827baff4015fc0035a6a7b9641230d1ad997cf415ee52f9ff26f91ec52b789e94140175b4443\",\"name\":\"cli-cursor\",\"version\":\"5.0.0\"},\"cli-highlight-2.1.11.tgz\":{\"integrity\":\"9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4a0dca04570c945eb8dc24dbc70f434573f862c1efd63d560895e421d8ed4dd99ae8e6058967f2bedc31a7f30f0ffc5e85c4e833c82e5bc43c872200923e11a\",\"name\":\"cli-highlight\",\"version\":\"2.1.11\"},\"cli-spinners-2.9.2.tgz\":{\"integrity\":\"ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cb0a95fb9326c8be04ef26d780acace03ba065b5f4142e8b9f0ae18eeca42239caf64f0e41a710edac462a78c35d63619ecd31a2dddb648e61e791fcca8f5c26\",\"name\":\"cli-spinners\",\"version\":\"2.9.2\"},\"cli-truncate-2.1.0.tgz\":{\"integrity\":\"n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9fc7ce8b1c030fa6ff39b8a7cd3ae9d59285cdb82f299beecff4ef7a39cb9f56907c2eabe765c4c7ce459ae0bedc723e24cedca0145752f36a114d8f1d5ac7a6\",\"name\":\"cli-truncate\",\"version\":\"2.1.0\"},\"cli-truncate-4.0.0.tgz\":{\"integrity\":\"nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9cf75a15d43487f1848a06cf0a5cf5d43d2ffd9244c3199e55919e328dd9e52b4fb544e403da35943e90c288ab622483cdb7309f65dc8f0982a7af16d484b84c\",\"name\":\"cli-truncate\",\"version\":\"4.0.0\"},\"clipanion-4.0.0-rc.4.tgz\":{\"integrity\":\"CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"09790c43153ab3d1a494eff57fbd7876428132ed65a294b558517407ca380313f2911d61a68cf14a2519e5951e0637cf8025aa6dc34eb59545841f0b91fa75f9\",\"name\":\"clipanion\",\"version\":\"4.0.0-rc.4\"},\"cliui-7.0.4.tgz\":{\"integrity\":\"OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"39c444ebc70eb15317a7562fa2797f7f39103b28cb4aeffc6e13c37d0b747b4fc46f6f374ca3f6d05b3632aa0fb2bf52c00e7de6b44203e40ccd873d9c13fe25\",\"name\":\"cliui\",\"version\":\"7.0.4\"},\"cliui-8.0.1.tgz\":{\"integrity\":\"BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"05278d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61\",\"name\":\"cliui\",\"version\":\"8.0.1\"},\"clone-1.0.4.tgz\":{\"integrity\":\"JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2501d9d90316ea5dda1ff8fac42a904e163ff4e1f80fff65b37e1c8245018847a87114d4d38b477ca3c1b142b53ea64251033b1a20342085c94ae5c723ae0a6e\",\"name\":\"clone\",\"version\":\"1.0.4\"},\"clone-response-1.0.3.tgz\":{\"integrity\":\"ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"44ea0bf788c91f675454c2f663fe4f10335a48781e39d48389c5324bb8b3705eb71bab1373f1538cbb9be1bf0897d4bc4b46de39f62dd13680e6abc52bec34c0\",\"name\":\"clone-response\",\"version\":\"1.0.3\"},\"color-convert-2.0.1.tgz\":{\"integrity\":\"RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529\",\"name\":\"color-convert\",\"version\":\"2.0.1\"},\"color-name-1.1.4.tgz\":{\"integrity\":\"dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40\",\"name\":\"color-name\",\"version\":\"1.1.4\"},\"colorette-2.0.20.tgz\":{\"integrity\":\"IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"21f103c70a1622391e5cbd5e5dc0e2a30e146ca8e12ddabafc4b92551f4630deca547debf6043cddeef786ccf535dd53de28dde71bf5c1c59160ef83ea4088db\",\"name\":\"colorette\",\"version\":\"2.0.20\"},\"combined-stream-1.0.8.tgz\":{\"integrity\":\"FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1503783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476\",\"name\":\"combined-stream\",\"version\":\"1.0.8\"},\"comma-separated-tokens-2.0.3.tgz\":{\"integrity\":\"Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"16ee2125dbf37b29427d03e9f5219689da73accb3bb53ae5bba55bf1719a446724f1048d649269e77f16adbeb42dac787cfc11eb8562638ebc3885136d194666\",\"name\":\"comma-separated-tokens\",\"version\":\"2.0.3\"},\"commander-13.1.0.tgz\":{\"integrity\":\"/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"feb15e0a934941b852663195c0ef51155df13ea6e71114bc326210cc2b43ff397a82926e57f6cc2ee37dda81b717b77ca031071d1aee8d25cd52bf1fa639ed2b\",\"name\":\"commander\",\"version\":\"13.1.0\"},\"commander-14.0.3.tgz\":{\"integrity\":\"H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1fecb4268fd3d5167da8f3f8121d6991c41c2d1825ada25a48ba323ad1f1bba01aa648d6542cb64a2b75410e31dc39e0f2a0e54ac6447adee0e4fab4e8cbd383\",\"name\":\"commander\",\"version\":\"14.0.3\"},\"commander-4.1.1.tgz\":{\"integrity\":\"NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"34e2a6f31864cc08f3171f01dafe4e0074febb9a5141cd9409ad95abd8d82ffdf5a36c22f66c4103b2c816cdec5795520b8f73ea91217db3142ef4a12a3dba58\",\"name\":\"commander\",\"version\":\"4.1.1\"},\"commander-5.1.0.tgz\":{\"integrity\":\"P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3f40b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66\",\"name\":\"commander\",\"version\":\"5.1.0\"},\"commander-9.5.0.tgz\":{\"integrity\":\"KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905\",\"name\":\"commander\",\"version\":\"9.5.0\"},\"compare-version-0.1.2.tgz\":{\"integrity\":\"pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a490e1e7fe30ac49d75ff556459bebb8018793329daf8eb3d753a54cf37e56b0139565a148a7b03422757eeb423b90bb7890779cf305640d4b798b5c15ba19d8\",\"name\":\"compare-version\",\"version\":\"0.1.2\"},\"concat-map-0.0.1.tgz\":{\"integrity\":\"/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa\",\"name\":\"concat-map\",\"version\":\"0.0.1\"},\"convert-5.14.1.tgz\":{\"integrity\":\"zp1UyVnTL7g/T+sw1Bb1yCIDZIR50eKFnYJXsmRP2SXs3RfzligO3JWc2ZtqzdJX0/7xwfma/J8j69JD5MB2aA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ce9d54c959d32fb83f4feb30d416f5c82203648479d1e2859d8257b2644fd925ecdd17f396280edc959cd99b6acdd257d3fef1c1f99afc9f23ebd243e4c07668\",\"name\":\"convert\",\"version\":\"5.14.1\"},\"convert-source-map-2.0.0.tgz\":{\"integrity\":\"Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126\",\"name\":\"convert-source-map\",\"version\":\"2.0.0\"},\"core-util-is-1.0.2.tgz\":{\"integrity\":\"3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"de5ab3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69\",\"name\":\"core-util-is\",\"version\":\"1.0.2\"},\"crc-3.8.0.tgz\":{\"integrity\":\"iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505\",\"name\":\"crc\",\"version\":\"3.8.0\"},\"create-require-1.1.1.tgz\":{\"integrity\":\"dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"75c2855f78e7d0ca486978e2b2846f7b12095442b36aaef3dab64ac5ff8c4abf5391d9879ac5389b695c2e88eb8ff14797c9a4e55c4c99803e7ed4643ffde829\",\"name\":\"create-require\",\"version\":\"1.1.1\"},\"cross-dirname-0.1.0.tgz\":{\"integrity\":\"+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9\",\"name\":\"cross-dirname\",\"version\":\"0.1.0\"},\"cross-spawn-7.0.6.tgz\":{\"integrity\":\"uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc\",\"name\":\"cross-spawn\",\"version\":\"7.0.6\"},\"css-mediaquery-0.1.2.tgz\":{\"integrity\":\"COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"08eb67e0444e5b97411a513fe0f88a9e1eab66900fc437852da104c2de22d748e90cc16dd84850192efd4269ab3be88a087bf43d4fc7ace5848628c5775c7df5\",\"name\":\"css-mediaquery\",\"version\":\"0.1.2\"},\"cssesc-3.0.0.tgz\":{\"integrity\":\"/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd36ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56\",\"name\":\"cssesc\",\"version\":\"3.0.0\"},\"csstype-3.2.3.tgz\":{\"integrity\":\"z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021\",\"name\":\"csstype\",\"version\":\"3.2.3\"},\"damerau-levenshtein-1.0.8.tgz\":{\"integrity\":\"sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1d412141efe9657d47101d440edfe07c111463d0e6b8c3d3ce58c23fa6e1adb9fee0172c069a468b084967b9d7d388a655f8dbc7a8bd227f376b23c468ec448\",\"name\":\"damerau-levenshtein\",\"version\":\"1.0.8\"},\"data-view-buffer-1.0.2.tgz\":{\"integrity\":\"EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"12628ee55dce2d7875aed2b6c205d16a7b1a2b5fe6b557535048842345bc464be04f4e647f1687dbd3e588b9e92cfef7c983bad78d90ef640d6bc5b1fc0e42a9\",\"name\":\"data-view-buffer\",\"version\":\"1.0.2\"},\"data-view-byte-length-1.0.2.tgz\":{\"integrity\":\"tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b6e8466c4e827d333dfb900d19ffa841bef62b2ff4facdf1294a47bd285f8b3d91c4c16014f8ec5ee44b05532dbccb35e5ac1ee394916fcdc3eb01f87b0eb095\",\"name\":\"data-view-byte-length\",\"version\":\"1.0.2\"},\"data-view-byte-offset-1.0.1.tgz\":{\"integrity\":\"BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"052f0f7e6b431a7ae061d3a89c665074b66c95621e08614ff6da5a9f4862d42a3666bd8d2800ecbc6600f17c6e1bfe145a027a0a3b6ff9826707a30cebd40695\",\"name\":\"data-view-byte-offset\",\"version\":\"1.0.1\"},\"date-fns-4.1.0.tgz\":{\"integrity\":\"Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"524ab4a306d05f16bf537106b6c755064475c3b28e43980806a747da192f927cd93d8bc1c5bfda6ba13c2fbb668c5b64c1906edd45c16e32203e8fc4cf8c5a36\",\"name\":\"date-fns\",\"version\":\"4.1.0\"},\"dateformat-4.6.3.tgz\":{\"integrity\":\"2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d8fd29d29146cc74b910c9e1771422eda24dfa23217ae7745211b87651350cb025bcbf091e32494d7fc24a6e095f057429ae671a4df30b999c6f96d4414c7130\",\"name\":\"dateformat\",\"version\":\"4.6.3\"},\"debug-3.2.7.tgz\":{\"integrity\":\"CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0858f3618022e1385f890be2ceb1507af4d35c7b670aa59f7bbc75021804b1c4f3e996cb6dfa0b44b3ee81343206d87a7fc644455512c961c50ffed6bb8b755d\",\"name\":\"debug\",\"version\":\"3.2.7\"},\"debug-4.4.3.tgz\":{\"integrity\":\"RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8\",\"name\":\"debug\",\"version\":\"4.4.3\"},\"decode-named-character-reference-1.3.0.tgz\":{\"integrity\":\"GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1ada50601dbcdcaacfa7a9d1c39d2add4f7f55f3aeb5939ed74dea94dec13cfe80776ef16273885afe253f3a3c1c200bfa6319a1f27d284cb7d1faba31f68ae9\",\"name\":\"decode-named-character-reference\",\"version\":\"1.3.0\"},\"decompress-response-6.0.0.tgz\":{\"integrity\":\"aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"696df9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309\",\"name\":\"decompress-response\",\"version\":\"6.0.0\"},\"deep-equal-2.2.3.tgz\":{\"integrity\":\"ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"648c299debcebab4bc6e94f8d7ddaca80a3058cefa2432921d8ccc2edcb7059192b3082aea905a1f70e10925b9c5501920267229d3813e3c30c39c1f813ffa3c\",\"name\":\"deep-equal\",\"version\":\"2.2.3\"},\"deep-is-0.1.4.tgz\":{\"integrity\":\"oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d\",\"name\":\"deep-is\",\"version\":\"0.1.4\"},\"deepmerge-4.3.1.tgz\":{\"integrity\":\"3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dec52a6cc11cefb5eaa5d34eec547246883e796de987e19809b8feacafae63244cbb0b15cb4acc895b4f9fe40994a16f58fff53d8a5aa6a627d0c7b6927167f8\",\"name\":\"deepmerge\",\"version\":\"4.3.1\"},\"default-browser-5.5.0.tgz\":{\"integrity\":\"H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1fd2cc2ebe73c086d2c6b9af8a41ae23fe4a1a167c136cc7decb643203392e93960eeb463362596a3e3ad147677f56bef78eb373b60182ba845b06e4ef31ef1b\",\"name\":\"default-browser\",\"version\":\"5.5.0\"},\"default-browser-id-5.0.1.tgz\":{\"integrity\":\"x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c75542c5d5f8b7ef3055f775b28ffdc3ebd0e2fc7b94a776429e6d0d1bad12bc2647ce4e8267d7ed194b44c59a7d1318ee16c489721bb9d36b8ce00f6bf84bf1\",\"name\":\"default-browser-id\",\"version\":\"5.0.1\"},\"defaults-1.0.4.tgz\":{\"integrity\":\"eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"785b9a2e8cbf4716a5bf692bfa5a8c9549eb0d657ede3e299633882602c8848d39f0841f589eef5e1c84207bbe1ed0bbdfc9251802d8c4e2833b46d03f7b60f0\",\"name\":\"defaults\",\"version\":\"1.0.4\"},\"defer-to-connect-2.0.1.tgz\":{\"integrity\":\"4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e2dbedb5ea571b555a606ad189b93913025dd6de2e76e9d239531d2d200bea621dd62c78dfca0fc0f64c00b638d450a28ee90ed4bd2dc0d706b1dcd2edd1e00e\",\"name\":\"defer-to-connect\",\"version\":\"2.0.1\"},\"define-data-property-1.1.4.tgz\":{\"integrity\":\"rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ac132f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8\",\"name\":\"define-data-property\",\"version\":\"1.1.4\"},\"define-lazy-prop-2.0.0.tgz\":{\"integrity\":\"Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0ecd3da8d87ccb0de48528e22638942276865fdc65a990d8ec956bc86c5dc55ecd3debaa41fa653a943aeb224566eb778cb6b9ccec245f0d60f44236b8a8783a\",\"name\":\"define-lazy-prop\",\"version\":\"2.0.0\"},\"define-lazy-prop-3.0.0.tgz\":{\"integrity\":\"N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"37e31e5d8a2aaf7a4e827f317f244f44437b8076a42d88e1b07856193ddf58088be08900b74883c35e108a2126d9b137d1ce575f9ab416d000dc22b97fdfc152\",\"name\":\"define-lazy-prop\",\"version\":\"3.0.0\"},\"define-properties-1.2.1.tgz\":{\"integrity\":\"8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f109902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e\",\"name\":\"define-properties\",\"version\":\"1.2.1\"},\"delay-5.0.0.tgz\":{\"integrity\":\"ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45e1012a421f7b8c9ae3bc253d87ff82ee626fac941b4fc07b3d09419433f789225ad450bd92106d389e86c9f01ef2d25899d076155ea98b9eec877574aaf4ab\",\"name\":\"delay\",\"version\":\"5.0.0\"},\"delayed-stream-1.0.0.tgz\":{\"integrity\":\"ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"672483ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731\",\"name\":\"delayed-stream\",\"version\":\"1.0.0\"},\"dequal-2.0.3.tgz\":{\"integrity\":\"0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d237bea8f28710ca21bdf453084a370ab3c6e9c033018826ccacb1462612483912e9e1897725499bb59a600e4409a003f702c1d93e0411eca603968555c61708\",\"name\":\"dequal\",\"version\":\"2.0.3\"},\"detect-libc-2.1.2.tgz\":{\"integrity\":\"Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5\",\"name\":\"detect-libc\",\"version\":\"2.1.2\"},\"detect-node-2.1.0.tgz\":{\"integrity\":\"T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f4348b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee\",\"name\":\"detect-node\",\"version\":\"2.1.0\"},\"devlop-1.1.0.tgz\":{\"integrity\":\"RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"456988aa17057f5951601bcd9abeea4cdbb20adffbfe7b368dba69d7e3da96013fac341c053d1f8a848c52927dde2ae55210b986b838718a9ee94fb42265b4ac\",\"name\":\"devlop\",\"version\":\"1.1.0\"},\"didyoumean-1.2.2.tgz\":{\"integrity\":\"gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"831b727ea320ec62b285099bd39e8aeccdf1b33cbf9b21fcc3e078453f905c142cbc039d7375f29aa0c33c7c750603e0b1d000e522227e89daf3d62d4404c3cf\",\"name\":\"didyoumean\",\"version\":\"1.2.2\"},\"diff-4.0.4.tgz\":{\"integrity\":\"X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5f4ee7b6d25093091f29fbd33c6fca4a713638c75c5026a8ebe797177c269c84119f668f0071f75710db0ce75e82477a25b3ec5ea4a1a6f10e1df013fa708dc1\",\"name\":\"diff\",\"version\":\"4.0.4\"},\"dir-compare-4.2.0.tgz\":{\"integrity\":\"2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db130298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55\",\"name\":\"dir-compare\",\"version\":\"4.2.0\"},\"discord-api-types-0.38.46.tgz\":{\"integrity\":\"Ae7NcagMG+FPxwuQxGCPEHmLCKMm8YBMPWEuF5J3L+KWrlH4XGR3UoVo4Ne8bwhhHXbpf+DxDqOeW2jBFupXCQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"01eecd71a80c1be14fc70b90c4608f10798b08a326f1804c3d612e1792772fe296ae51f85c6477528568e0d7bc6f08611d76e97fe0f10ea39e5b68c116ea5709\",\"name\":\"discord-api-types\",\"version\":\"0.38.46\"},\"discord-rich-presence-0.0.8.tgz\":{\"integrity\":\"IpVMPjv15C9UvppxvrrGdv6bzQHOW1P1vLoMH15HvdJwGJ3dBd2bnrJ63Uy36YRUfrAMxGLiwUDHncvC8AuPaQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"22954c3e3bf5e42f54be9a71bebac676fe9bcd01ce5b53f5bcba0c1f5e47bdd270189ddd05dd9b9eb27add4cb7e984547eb00cc462e2c140c79dcbc2f00b8f69\",\"name\":\"discord-rich-presence\",\"version\":\"0.0.8\"},\"discord-rpc-https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec.tgz\":{\"integrity\":\"Khm6DIXv3V3NybL7yPKhn67GNCO8kx73223kSCVB33M=\",\"integrity_algo\":\"sha256\",\"integrity_digest\":\"2a19ba0c85efdd5dcdc9b2fbc8f2a19faec63423bc931ef7db6de4482541df73\",\"name\":\"discord-rpc\",\"tarball_url\":\"https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec\",\"version\":\"https://codeload.github.com/discordjs/rpc/tar.gz/9e7de2a6d917591f10a66389e62e1dc053c04fec\"},\"dlv-1.1.3.tgz\":{\"integrity\":\"+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f87972b728e53ca9c81bc5ee446f16be604ff31b3c3fbd72f9228a4ba6575a81202ee78fc6d0e8504887ed691d78f5ab439241a44e9aa15a9f65f2544248d7c0\",\"name\":\"dlv\",\"version\":\"1.1.3\"},\"dmg-builder-26.9.0.tgz\":{\"integrity\":\"5uSyg0yY+JRMMGwFjIweaukYkCGcZSZwvH5VPlBHiKkTEP1a1/uV+bs4y+VAxPMgzg67YB4CF1vD4U/2d3chfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e6e4b2834c98f8944c306c058c8c1e6ae91890219c652670bc7e553e504788a91310fd5ad7fb95f9bb38cbe540c4f320ce0ebb601e02175bc3e14ff67777217e\",\"name\":\"dmg-builder\",\"version\":\"26.9.0\"},\"dmg-license-1.0.11.tgz\":{\"integrity\":\"ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65dce6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9\",\"name\":\"dmg-license\",\"version\":\"1.0.11\"},\"doctrine-2.1.0.tgz\":{\"integrity\":\"35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"df999292ee195cad2f7c2b87103030b79e5d8368cd6a31d9d6876f17ef124abf3612c658e109977ee5aca3ca0477ccd185539b48dd7c68cd028d2768057ef323\",\"name\":\"doctrine\",\"version\":\"2.1.0\"},\"dotenv-16.6.1.tgz\":{\"integrity\":\"uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3\",\"name\":\"dotenv\",\"version\":\"16.6.1\"},\"dotenv-expand-11.0.7.tgz\":{\"integrity\":\"zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478\",\"name\":\"dotenv-expand\",\"version\":\"11.0.7\"},\"dunder-proto-1.0.1.tgz\":{\"integrity\":\"KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"28837f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8\",\"name\":\"dunder-proto\",\"version\":\"1.0.1\"},\"eastasianwidth-0.2.0.tgz\":{\"integrity\":\"I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"23cf1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58\",\"name\":\"eastasianwidth\",\"version\":\"0.2.0\"},\"ebnf-1.9.1.tgz\":{\"integrity\":\"uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b96d94292b2eb72f40349dd807221013800d903f27a943ceeebe85c1c73500328f7bd15175c3e9325dd5129bade094af28127827cea7a480b630b3f4a58902bb\",\"name\":\"ebnf\",\"version\":\"1.9.1\"},\"ebnf-parser-0.1.10.tgz\":{\"integrity\":\"urvSxVQ6XJcoTpc+/x2pWhhuOX4aljCNQpwzw+ifZvV1andZkAmiJc3Rq1oGEAQmcjiLceyMXOy1l8ms8qs2fQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"babbd2c5543a5c97284e973eff1da95a186e397e1a96308d429c33c3e89f66f5756a77599009a225cdd1ab5a0610042672388b71ec8c5cecb597c9acf2ab367d\",\"name\":\"ebnf-parser\",\"version\":\"0.1.10\"},\"ejs-3.1.10.tgz\":{\"integrity\":\"UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51e26615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004\",\"name\":\"ejs\",\"version\":\"3.1.10\"},\"electron-40.9.1.tgz\":{\"integrity\":\"dgUqGjpTJeLZQEbvZQlnjMtPCUfOGRBNJIYjw8yC2ZN9O1QS172r09trhLke+rC8JCLBGbf2DeU63AArd0tbhQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"76052a1a3a5325e2d94046ef6509678ccb4f0947ce19104d248623c3cc82d9937d3b5412d7bdabd3db6b84b91efab0bc2422c119b7f60de53adc002b774b5b85\",\"name\":\"electron\",\"version\":\"40.9.1\"},\"electron-builder-26.9.0.tgz\":{\"integrity\":\"7BEeGz8Xlk7Qvitj70nGAQaq7WQIZ2amsDvsyKSZbxgtL2pM9fm/woZrtn0hoID6Fl7wkn456dK3OmtFNzgiOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ec111e1b3f17964ed0be2b63ef49c60106aaed64086766a6b03becc8a4996f182d2f6a4cf5f9bfc2866bb67d21a080fa165ef0927e39e9d2b73a6b4537382238\",\"name\":\"electron-builder\",\"version\":\"26.9.0\"},\"electron-builder-squirrel-windows-26.9.0.tgz\":{\"integrity\":\"Jzsxa3Kjv94ZRZDK7pc8bzu5iglwGsDOBMWTqLpWx2sCEvb3TLW9PMWqOjpDwizqkMBp8GjP6rceLzQYLFIVow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"273b316b72a3bfde194590caee973c6f3bb98a09701ac0ce04c593a8ba56c76b0212f6f74cb5bd3cc5aa3a3a43c22cea90c069f068cfeab71e2f34182c5215a3\",\"name\":\"electron-builder-squirrel-windows\",\"version\":\"26.9.0\"},\"electron-publish-26.9.0.tgz\":{\"integrity\":\"gsy+U7JfDuD1lPOrCXeECDQoUsWjFah3s1Fv3pqKnjdJuKYDDvGdvC74kLHVG6nl5G0uQ7YN0eftCQ4rUmhvVw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"82ccbe53b25f0ee0f594f3ab09778408342852c5a315a877b3516fde9a8a9e3749b8a6030ef19dbc2ef890b1d51ba9e5e46d2e43b60dd1e7ed090e2b52686f57\",\"name\":\"electron-publish\",\"version\":\"26.9.0\"},\"electron-to-chromium-1.5.339.tgz\":{\"integrity\":\"Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"22cfb40411c9e0dadda40622a5eaeb9a9e77a4bcb01bfc95ffa948313027871bf38ff0a69f943fa204870ba00a7bb5fef243cbc71164d1cb39a1cff78ff7f122\",\"name\":\"electron-to-chromium\",\"version\":\"1.5.339\"},\"electron-vite-5.0.0.tgz\":{\"integrity\":\"OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"387a7fbe3765b9b36584d90f90bffedc90f7e228b9a2feccd06a6e5c455d41ea9d437ba5bd547b0e0feb3412df4b95cf205c20a012c37fdb238eb2fe0ae0f245\",\"name\":\"electron-vite\",\"version\":\"5.0.0\"},\"electron-winstaller-5.4.0.tgz\":{\"integrity\":\"bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6cedf2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be\",\"name\":\"electron-winstaller\",\"version\":\"5.4.0\"},\"emoji-regex-10.6.0.tgz\":{\"integrity\":\"toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b68508f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec\",\"name\":\"emoji-regex\",\"version\":\"10.6.0\"},\"emoji-regex-8.0.0.tgz\":{\"integrity\":\"MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8\",\"name\":\"emoji-regex\",\"version\":\"8.0.0\"},\"emoji-regex-9.2.2.tgz\":{\"integrity\":\"L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca\",\"name\":\"emoji-regex\",\"version\":\"9.2.2\"},\"encoding-0.1.13.tgz\":{\"integrity\":\"ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"11305aba8c354f7e58fd664c922a3d8e2334679c631c7989e179a364eab597f757cf796bdac467f3b9c9cb6d11ba9a928751769b71c73d2a7c4a120f409ac9dc\",\"name\":\"encoding\",\"version\":\"0.1.13\"},\"end-of-stream-1.4.5.tgz\":{\"integrity\":\"ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a\",\"name\":\"end-of-stream\",\"version\":\"1.4.5\"},\"env-paths-2.2.1.tgz\":{\"integrity\":\"+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8\",\"name\":\"env-paths\",\"version\":\"2.2.1\"},\"environment-1.1.0.tgz\":{\"integrity\":\"xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c54b683e432081bcf430fc8f8885abd4aa7869e5898c367a48cbd44618a68dd660b11b83a65179fecf617201a1c97321b3eeafa67ba8899da4162bb714c9d2f1\",\"name\":\"environment\",\"version\":\"1.1.0\"},\"err-code-2.0.3.tgz\":{\"integrity\":\"2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d9b9a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214\",\"name\":\"err-code\",\"version\":\"2.0.3\"},\"es-abstract-1.24.2.tgz\":{\"integrity\":\"2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d85a47f50e62d91470c843f50329577ba9d82d1e4e85a2536709a570fd1d2fff8909b820ef2c84a3fb042ba1de19945fddd1695b04e16911d50295d2916df17a\",\"name\":\"es-abstract\",\"version\":\"1.24.2\"},\"es-define-property-1.0.1.tgz\":{\"integrity\":\"e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b79d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de\",\"name\":\"es-define-property\",\"version\":\"1.0.1\"},\"es-errors-1.3.0.tgz\":{\"integrity\":\"Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3\",\"name\":\"es-errors\",\"version\":\"1.3.0\"},\"es-get-iterator-1.1.3.tgz\":{\"integrity\":\"sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b0f666a8705ee892224df379ab6a448bffd3c31980147c23fd712e6234eeb1eefc8bc2b16aa3134f3c4fa052aecd1a43a5327ed0d01ba5f7a79261f6ade3edbb\",\"name\":\"es-get-iterator\",\"version\":\"1.1.3\"},\"es-iterator-helpers-1.3.2.tgz\":{\"integrity\":\"HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1d52c0096d53a691988c9f07ebf8ea1ffa6a3ad291c3ac0c96b076df17c4c66156c45aae0085829b0a0bb0ec8df7a2b86b929b98e7f902df5950edc665b7ad03\",\"name\":\"es-iterator-helpers\",\"version\":\"1.3.2\"},\"es-object-atoms-1.1.1.tgz\":{\"integrity\":\"FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"146807da1f3328d8a6f658e3edd6a79053dc20220af42a796e6f9cda041261e3e1a5a1b9f9eb2b2ce0e2848a2b9fe3dee85189cd6857428b4fbfbde34da95d5c\",\"name\":\"es-object-atoms\",\"version\":\"1.1.1\"},\"es-set-tostringtag-2.1.0.tgz\":{\"integrity\":\"j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8fabd6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850\",\"name\":\"es-set-tostringtag\",\"version\":\"2.1.0\"},\"es-shim-unscopables-1.1.0.tgz\":{\"integrity\":\"d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"77d4fcb9cb04861f018b5c285c27fe4c828321138b1b958293183c81e0426ef936da4cf00b91b63a75d530ee8552cbd09605145d0da2b5ea615832ea0f36de0b\",\"name\":\"es-shim-unscopables\",\"version\":\"1.1.0\"},\"es-to-primitive-1.3.0.tgz\":{\"integrity\":\"w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3ee662771ae14bf8d8d5b4996fc9d4a1a84d5e3778773db23bff92c0b1824fff6aadb8c5e37cbd8ba47491aa8e1be1e485e4afc31f5257294007481d945b9d2\",\"name\":\"es-to-primitive\",\"version\":\"1.3.0\"},\"es6-error-4.1.1.tgz\":{\"integrity\":\"Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456\",\"name\":\"es6-error\",\"version\":\"4.1.1\"},\"es6-promise-3.3.1.tgz\":{\"integrity\":\"SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"48ea7d3e1aafaa7ee3b445313d67567d6a0b9b2b7655a27a329bcff42a26cb531c78c5ea13a6f1bda4eee226b1a5860fce19f2dbc2dcf8cf3bfdcd9c3caea50e\",\"name\":\"es6-promise\",\"version\":\"3.3.1\"},\"esbuild-0.21.5.tgz\":{\"integrity\":\"mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9a0dce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab\",\"name\":\"esbuild\",\"version\":\"0.21.5\"},\"esbuild-0.25.12.tgz\":{\"integrity\":\"bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6db3c1618aed65b92de8eb3a1624cb093171beae2db7724a6a5975bd1c2c840ddf755cedb0b01ab45699a1b864042f3f06b3deb686b4a24b18a0a5e81b8af226\",\"name\":\"esbuild\",\"version\":\"0.25.12\"},\"escalade-3.2.0.tgz\":{\"integrity\":\"WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c\",\"name\":\"escalade\",\"version\":\"3.2.0\"},\"escape-string-regexp-4.0.0.tgz\":{\"integrity\":\"TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80\",\"name\":\"escape-string-regexp\",\"version\":\"4.0.0\"},\"escape-string-regexp-5.0.0.tgz\":{\"integrity\":\"/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fef798ef925b30ae23d728efb94c6e56c892fe1affe221ecf454d3e9c8137b1c5d1342f2fe095c7010249681ff0e87e48d16d95376e7a23dfc98e9a1919d251f\",\"name\":\"escape-string-regexp\",\"version\":\"5.0.0\"},\"eslint-9.39.4.tgz\":{\"integrity\":\"XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5e83237413b07bf7ac56012f2e636c0f72111e49bb7db288506beb95e9682575198031e283620f58d9e2bfe1b08f2257cee36a56396be7ee32554663c9c2707d\",\"name\":\"eslint\",\"version\":\"9.39.4\"},\"eslint-import-resolver-node-0.3.10.tgz\":{\"integrity\":\"tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b51acaa85c8268a89cb7984e776e38b0be844053727273109c17be8fcbaa18d5d8cec22619b19453889bb686819afe452f027070524d7a0d467958d07db32b0d\",\"name\":\"eslint-import-resolver-node\",\"version\":\"0.3.10\"},\"eslint-import-resolver-typescript-3.10.1.tgz\":{\"integrity\":\"A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"035ac761bd3ace330603174b4a43767d73c1c2e49a43488ee4cfe17724b40238f5541691a74b0f0f7767d4584c13773f265b8615bc12c7209fa9d49bb502c01d\",\"name\":\"eslint-import-resolver-typescript\",\"version\":\"3.10.1\"},\"eslint-module-utils-2.12.1.tgz\":{\"integrity\":\"L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2fc8d2593cdeecada64e0d2fa2cfd1b8b452e6ca289a4b033e824b5c8b250bb73c5a6badddbc7b08fa498a30dc059b7143996b6d474cfacd0e94d6f3d0308337\",\"name\":\"eslint-module-utils\",\"version\":\"2.12.1\"},\"eslint-plugin-import-2.32.0.tgz\":{\"integrity\":\"whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c21384d47168fea243c97e129d7ccfe0deb33969fbf5686709463f88347498f7d064ef30718138242973236a19ae10679cc5020421d984ee95432a0153de6664\",\"name\":\"eslint-plugin-import\",\"version\":\"2.32.0\"},\"eslint-plugin-jsx-a11y-6.10.2.tgz\":{\"integrity\":\"scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1c0779f3e16986ef9a55f3edde45440e1d994d49484536adfbc67a6046408210b5375ccbd70312e4d5ea965b2136d8a8b8434d459ecc3d040ddc2470cf827d9\",\"name\":\"eslint-plugin-jsx-a11y\",\"version\":\"6.10.2\"},\"eslint-plugin-react-7.37.5.tgz\":{\"integrity\":\"Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"42d7aea744aa535e6476871ec4534024cbc22447dadb150a355e020b5c6c54cac822a132dd243faeacb10963737eb777fe5772e873250f67b42435690e0daa20\",\"name\":\"eslint-plugin-react\",\"version\":\"7.37.5\"},\"eslint-plugin-react-hooks-7.0.1.tgz\":{\"integrity\":\"O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3b47749b4e1ebda37310fa125bee7d31ecdff10b742277e01880499e90b4877347fd68d4011ec120a51fcac0bab68766b6267f034a14552f0671ed16841ac7b0\",\"name\":\"eslint-plugin-react-hooks\",\"version\":\"7.0.1\"},\"eslint-scope-8.4.0.tgz\":{\"integrity\":\"sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e\",\"name\":\"eslint-scope\",\"version\":\"8.4.0\"},\"eslint-visitor-keys-3.4.3.tgz\":{\"integrity\":\"wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a\",\"name\":\"eslint-visitor-keys\",\"version\":\"3.4.3\"},\"eslint-visitor-keys-4.2.1.tgz\":{\"integrity\":\"Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25\",\"name\":\"eslint-visitor-keys\",\"version\":\"4.2.1\"},\"eslint-visitor-keys-5.0.1.tgz\":{\"integrity\":\"tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b43e34787c40df98743c421935e223907a034786238c9a77e1b88cd260efa6505efff981f881c2a870c657ba7117eecc9254ef8a085c08f3d90bbca75b28dd4c\",\"name\":\"eslint-visitor-keys\",\"version\":\"5.0.1\"},\"espree-10.4.0.tgz\":{\"integrity\":\"j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261\",\"name\":\"espree\",\"version\":\"10.4.0\"},\"esquery-1.7.0.tgz\":{\"integrity\":\"Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"029e86d16430714fcb1ecbcbc0e3757c0417f59a7403663a63f709065f6bfc96d6f74672838ff36c6eb3cca6b639300b10b6ab60798abb41a1a4ce443beed3d2\",\"name\":\"esquery\",\"version\":\"1.7.0\"},\"esrecurse-4.3.0.tgz\":{\"integrity\":\"KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a\",\"name\":\"esrecurse\",\"version\":\"4.3.0\"},\"estraverse-5.3.0.tgz\":{\"integrity\":\"MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004\",\"name\":\"estraverse\",\"version\":\"5.3.0\"},\"estree-util-is-identifier-name-3.0.0.tgz\":{\"integrity\":\"hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"845b6a20365321467d0572dbf32e29606ca4ebec1e9088af3554dc9af93c3683a1f957919f9cba7041f36d446b59b7e9d5f22a7558a98a5ce3fa57da69d3599a\",\"name\":\"estree-util-is-identifier-name\",\"version\":\"3.0.0\"},\"esutils-2.0.3.tgz\":{\"integrity\":\"kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea\",\"name\":\"esutils\",\"version\":\"2.0.3\"},\"eventemitter3-5.0.4.tgz\":{\"integrity\":\"mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9a5b1347219a3c18cf79d93a06fc3e6aa6ec5c3b680320339b930eec9814fb2551c8c4393bc6c3e0a71c8bb052f397fddef79e81e08f90bf11e062c29678cb17\",\"name\":\"eventemitter3\",\"version\":\"5.0.4\"},\"execa-4.1.0.tgz\":{\"integrity\":\"j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8f95b4fff5bb7fc531027f215d59f01bcb4bc1d894cb81492dc4aea4283a99a058643a7206f4c0a4aecacae2386ca8fc28e875af6607fbab9cb98b49bf56d364\",\"name\":\"execa\",\"version\":\"4.1.0\"},\"execa-8.0.1.tgz\":{\"integrity\":\"VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57286779b5dc8855760c449cfa9e81fb2d0b8d29b492b5383a024de38a85021058d1327ed55eb5b580f6fb01eeb19e85f67e4afaf97c934b13cbb3c47d5e2aa6\",\"name\":\"execa\",\"version\":\"8.0.1\"},\"exenv-1.2.2.tgz\":{\"integrity\":\"Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"67e92d4f14f0bfd20b7e0282937d8e5f79ff7687be39c2d346da8af6970bf89b0fdc9d7f556f14be5e198cb94aa9e5b8af32b8a1eb03386304311219aad3f823\",\"name\":\"exenv\",\"version\":\"1.2.2\"},\"exponential-backoff-3.1.3.tgz\":{\"integrity\":\"ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708\",\"name\":\"exponential-backoff\",\"version\":\"3.1.3\"},\"extend-3.0.2.tgz\":{\"integrity\":\"fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7e3aae0b9f5c0fb0b25babab3572b4141b9f9197288861bcd304ee3ee8d7e7dd1c0794ed967db4136501e12fd601156a8577df665d8b3604be81074f2088a6fe\",\"name\":\"extend\",\"version\":\"3.0.2\"},\"extract-zip-2.0.1.tgz\":{\"integrity\":\"GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"183854f67b70b8ac865dd6415204c87bebd79d68f47e9a5412d3032f4fa275de52b5af131a91ecb27fdebac03d9ab3ebf6a343ca6e92c406198cdbc29fff5106\",\"name\":\"extract-zip\",\"version\":\"2.0.1\"},\"extsprintf-1.4.1.tgz\":{\"integrity\":\"Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5ab937e5ef327422838ff02b0a5a3556b3d598df33a61e55e00b47c08b8786f317b0a7fbdd44f704e0fe6b30485bedf0389e058441fbcf2689085bc286362f30\",\"name\":\"extsprintf\",\"version\":\"1.4.1\"},\"fast-content-type-parse-2.0.1.tgz\":{\"integrity\":\"nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c6aadbcbae3e70d27691ead0cf7c1e1c526602aa8bb3c908b3e82e72fcbb5c0e594976b71ce966965ba897c8820e12b4dafd74726e3dbc69ab1d9f82e4564e9\",\"name\":\"fast-content-type-parse\",\"version\":\"2.0.1\"},\"fast-copy-4.0.3.tgz\":{\"integrity\":\"58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7c6a95abd065220c533cfb769facee9e6302419fd6408433b31b72feffd96569bfe16820114b65087df7e63aead82f06e00d1b3c9f4adfafaa8000f100b8043\",\"name\":\"fast-copy\",\"version\":\"4.0.3\"},\"fast-deep-equal-3.1.3.tgz\":{\"integrity\":\"f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\",\"name\":\"fast-deep-equal\",\"version\":\"3.1.3\"},\"fast-glob-3.3.3.tgz\":{\"integrity\":\"7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e\",\"name\":\"fast-glob\",\"version\":\"3.3.3\"},\"fast-json-parse-1.0.3.tgz\":{\"integrity\":\"FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1515ac699456109d4449535b0d69ac025a8393dea03d07b3ccb82169fa792781942a36c2cf73a4007b99b394ee3c4b646d5404472b0ba7dc6fe9cdb87c19bc03\",\"name\":\"fast-json-parse\",\"version\":\"1.0.3\"},\"fast-json-stable-stringify-2.1.0.tgz\":{\"integrity\":\"lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f\",\"name\":\"fast-json-stable-stringify\",\"version\":\"2.1.0\"},\"fast-levenshtein-2.0.6.tgz\":{\"integrity\":\"DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77\",\"name\":\"fast-levenshtein\",\"version\":\"2.0.6\"},\"fast-safe-stringify-2.1.1.tgz\":{\"integrity\":\"W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5be28973676620b94fa650ff1f82bd97d2dc00701f3ed3fa058f38b952d743a12f733f4b720df7636cf52156e54fac5d639e0f5d854712ffb45a9abc228eb390\",\"name\":\"fast-safe-stringify\",\"version\":\"2.1.1\"},\"fast-uri-3.1.0.tgz\":{\"integrity\":\"iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"88f79e0ca25259fe0810e6ac555ae49d7a5a055d08029cff829ed2d9b6fb6782e58db976306251a889d9894ad0c15d7a729cf0fc3dd2e63e49ba58ff813e7600\",\"name\":\"fast-uri\",\"version\":\"3.1.0\"},\"fastq-1.20.1.tgz\":{\"integrity\":\"GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1864e8c49ff0d71df6b3f0f610a343ee44e29789fc39593ff66c9c4dce150f36b5de53afa54653197de61520ad57d92c746055cefb320152ccea61c54e1c57c7\",\"name\":\"fastq\",\"version\":\"1.20.1\"},\"fd-slicer-1.1.0.tgz\":{\"integrity\":\"cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"704d6ab01fd5c32428cd9faad5d1b147c2c160d65ea1f84475434648c6d00f71b0da50335fd65bdee214e846dcfc59b28e8f405967e79f4014087aad7afb3ff2\",\"name\":\"fd-slicer\",\"version\":\"1.1.0\"},\"fdir-6.5.0.tgz\":{\"integrity\":\"tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e\",\"name\":\"fdir\",\"version\":\"6.5.0\"},\"fflate-0.8.2.tgz\":{\"integrity\":\"cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"70f254e3b39a02809b834a41bf3b20a533e19a1a88e5e26387f248bbcb4f8f9abe4fb88bbd6fc901852a984eca381e11d59c8487305a210a50a5aadd045e73f0\",\"name\":\"fflate\",\"version\":\"0.8.2\"},\"file-entry-cache-8.0.0.tgz\":{\"integrity\":\"XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d\",\"name\":\"file-entry-cache\",\"version\":\"8.0.0\"},\"file-uri-to-path-1.0.0.tgz\":{\"integrity\":\"0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d19b7eb372fb55fd5b8b0599dbd6804625582f1ee23069c4525f71df77db07f8f78d1f35bbf3b62dba8af819b508348d0ca56d27f623c18ed351de5291e2d02f\",\"name\":\"file-uri-to-path\",\"version\":\"1.0.0\"},\"filelist-1.0.6.tgz\":{\"integrity\":\"5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e608b2d8f90b618d5c3f7f69d7b11c87edb19694d12fd1cbb2939f1209b42fa0b005705382c2b9a2ed09b7362e7a9c64690fedbe1085209e6e5e8d0eaccd83c4\",\"name\":\"filelist\",\"version\":\"1.0.6\"},\"fill-range-7.1.1.tgz\":{\"integrity\":\"YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"62c1a97b75872caf19622e2d583836272dde6d1cf6ad7a300f19e57786e4401d3471cff5670f405a70b48bdced0c98ad8afb50bda23d29a2f22ab73e8415b4ca\",\"name\":\"fill-range\",\"version\":\"7.1.1\"},\"find-babel-config-2.1.2.tgz\":{\"integrity\":\"ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65f669d6b432a78832bb1aadd59aa314655e541be6a5444ca9d2165db3d17c1f7b05fe81cdd2bfc5221bca5108373434901e6d94341f9fd1e43575d6b2a4ea2e\",\"name\":\"find-babel-config\",\"version\":\"2.1.2\"},\"find-up-3.0.0.tgz\":{\"integrity\":\"1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d720fa4662c8d5705fc6e82f391c25724e9fef9b582fe891d23ab0b0eacec4c672198a94b83849d25e005dd3b5897fc54ecf5c040304935816484c759126f296\",\"name\":\"find-up\",\"version\":\"3.0.0\"},\"find-up-5.0.0.tgz\":{\"integrity\":\"78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e\",\"name\":\"find-up\",\"version\":\"5.0.0\"},\"flat-cache-4.0.1.tgz\":{\"integrity\":\"f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb\",\"name\":\"flat-cache\",\"version\":\"4.0.1\"},\"flatbuffers-1.12.0.tgz\":{\"integrity\":\"c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"73b0990038d1725ea3d0f96f172d19a9743aeea48465fad53f29e69cbfb6ccf73e36d32fac5f18d1071e328ed0aa748f73bfae5a350801bbc24395882a531575\",\"name\":\"flatbuffers\",\"version\":\"1.12.0\"},\"flatbuffers-22.10.26.tgz\":{\"integrity\":\"sdO3emf/BlLfOogW6KwHuXg16APR/E86jNacDXfSInPzt8SSEzxlHcqDekfM/IJ1CGC5bvDksfNufNhS8h1FRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1d3b77a67ff0652df3a8816e8ac07b97835e803d1fc4f3a8cd69c0d77d22273f3b7c492133c651dca837a47ccfc82750860b96ef0e4b1f36e7cd852f21d4544\",\"name\":\"flatbuffers\",\"version\":\"22.10.26\"},\"flatted-3.4.2.tgz\":{\"integrity\":\"PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3e30ec7bb47385c3e4209c32e6deca3d641267d7006f341771a7ec7ad4280fbb0e2514251a290d6f1ef2669d8ea2d0e7272ac371bc91ab74ed6f5f2260eaa4c4\",\"name\":\"flatted\",\"version\":\"3.4.2\"},\"for-each-0.3.5.tgz\":{\"integrity\":\"dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74ac75d9e442548cea0b1146a65c8528930fbcb11682636d52ba53889211e6ef7bcc48511bcc92aed6e83c7657c7b75a2f1415ae5eb8ddc4f36da6f6b64423c6\",\"name\":\"for-each\",\"version\":\"0.3.5\"},\"foreground-child-3.3.1.tgz\":{\"integrity\":\"gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8085e32aab45b96120cc544903d58241e4892d90e380950e302333c6dbc5abfdfb2a88ccd41146b9faac0b2d2be2a4909982ec65831ec91ab321638cba9d37b3\",\"name\":\"foreground-child\",\"version\":\"3.3.1\"},\"form-data-4.0.5.tgz\":{\"integrity\":\"8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f118a944ba25dfb6cdb366e1a15ebb7e24c4bdd4eb6cc5187054e2cb7fb0bae3a75288364011c26565c34628d641f0248418f651fe549d56a25b0039bdd77cdb\",\"name\":\"form-data\",\"version\":\"4.0.5\"},\"form-data-encoder-2.1.4.tgz\":{\"integrity\":\"yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c8361280d32b6aabe7c621173b8862f3cf986716870ba40acdbe4df388910930de44eed900ba62aff95599ffee5d4867c14af63b81d4f2cfe7eb1fb23634241f\",\"name\":\"form-data-encoder\",\"version\":\"2.1.4\"},\"fraction.js-5.3.4.tgz\":{\"integrity\":\"1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d57d4d4ed889a61af29ffb8b433df086d63a8caddf4eaa04de884ab34b53f948ebd56e7da28a719a8121ecbbb9a7abc168f6e0a0cd1bcef7805b8422e51c960d\",\"name\":\"fraction.js\",\"version\":\"5.3.4\"},\"fs-extra-10.1.0.tgz\":{\"integrity\":\"oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d\",\"name\":\"fs-extra\",\"version\":\"10.1.0\"},\"fs-extra-11.3.4.tgz\":{\"integrity\":\"CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0935ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc\",\"name\":\"fs-extra\",\"version\":\"11.3.4\"},\"fs-extra-7.0.1.tgz\":{\"integrity\":\"YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b\",\"name\":\"fs-extra\",\"version\":\"7.0.1\"},\"fs-extra-8.1.0.tgz\":{\"integrity\":\"yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ca1950800ea69ce25428eb11505b2025d402be42a1733f2d9591b91c141f45e619cb8e8ec0b718f9989ad26b5d1ec3a8f72fe13fe0b130dd1353d431a0eb46e2\",\"name\":\"fs-extra\",\"version\":\"8.1.0\"},\"fs-extra-9.1.0.tgz\":{\"integrity\":\"hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539\",\"name\":\"fs-extra\",\"version\":\"9.1.0\"},\"fs-minipass-3.0.3.tgz\":{\"integrity\":\"XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f\",\"name\":\"fs-minipass\",\"version\":\"3.0.3\"},\"fs.realpath-1.0.0.tgz\":{\"integrity\":\"OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38ed291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f\",\"name\":\"fs.realpath\",\"version\":\"1.0.0\"},\"fsevents-2.3.3.tgz\":{\"integrity\":\"5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43\",\"name\":\"fsevents\",\"version\":\"2.3.3\"},\"function-bind-1.1.2.tgz\":{\"integrity\":\"7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648\",\"name\":\"function-bind\",\"version\":\"1.1.2\"},\"function.prototype.name-1.1.8.tgz\":{\"integrity\":\"e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b98b0ca874e1e16ccaffc8dadcedf0d81b8aa56c8bc8e606a3cb33e76f94c2c32863029ce7421d41305a2ef5bdf449ebd8e3780224a5f27280818cc6ecb96d1\",\"name\":\"function.prototype.name\",\"version\":\"1.1.8\"},\"functions-have-names-1.2.3.tgz\":{\"integrity\":\"xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5c901517c9322a4fdeedab6c7600c6fe835eb76f9245cac624d31e2ac4d1706df42498d6688911dbeac3f323dfd0577dd67aebd5601508883e0dccd232a9a45\",\"name\":\"functions-have-names\",\"version\":\"1.2.3\"},\"generator-function-2.0.1.tgz\":{\"integrity\":\"SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"485745988262fb26c2d2f8e51cdd191951877379601340f13c04f47638d583e9233a74aa725aa68f4290ef291338b3fa631a2a3afb8038319d707267fb8deade\",\"name\":\"generator-function\",\"version\":\"2.0.1\"},\"gensync-1.0.0-beta.2.tgz\":{\"integrity\":\"3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"de137b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce\",\"name\":\"gensync\",\"version\":\"1.0.0-beta.2\"},\"get-caller-file-2.0.5.tgz\":{\"integrity\":\"DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616\",\"name\":\"get-caller-file\",\"version\":\"2.0.5\"},\"get-east-asian-width-1.5.0.tgz\":{\"integrity\":\"CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"090f9b10ef93bdafea966c36e1d09e8ee94ae6933356750e14e8a356881ddca42cd3b1e7448829f131a2a6f082453d3ac5e6046e96e0c1a0b18251728ae21c98\",\"name\":\"get-east-asian-width\",\"version\":\"1.5.0\"},\"get-intrinsic-1.3.0.tgz\":{\"integrity\":\"9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f5f4a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09\",\"name\":\"get-intrinsic\",\"version\":\"1.3.0\"},\"get-proto-1.0.1.tgz\":{\"integrity\":\"sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2\",\"name\":\"get-proto\",\"version\":\"1.0.1\"},\"get-stream-5.2.0.tgz\":{\"integrity\":\"nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c117e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4\",\"name\":\"get-stream\",\"version\":\"5.2.0\"},\"get-stream-6.0.1.tgz\":{\"integrity\":\"ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b6ce968beda3de3423aa2ef4c3902537c0c59e44b00be32a9b113374400b076a976585775ff6f50937e03cb18934c7805b174f7d4f053b59acdcd51f68708f62\",\"name\":\"get-stream\",\"version\":\"6.0.1\"},\"get-stream-8.0.1.tgz\":{\"integrity\":\"VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"55a509b2905f7e7fcb302255a0cbd201d9ac709c92d5aba3e59ba59e7e54a18718e77d545a67708515a47062a7194f779b91d25cff4b3f6bac3abcab06d428c0\",\"name\":\"get-stream\",\"version\":\"8.0.1\"},\"get-symbol-description-1.1.0.tgz\":{\"integrity\":\"w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3d50ca96c09c4734ebe8373489da83c5e70bd872f3fb8d4bd8ce1a7aef21214e2d7b6430410b5cfda53746bb38c3f84148a8b4984707998ea7e23f3434e846e\",\"name\":\"get-symbol-description\",\"version\":\"1.1.0\"},\"get-tsconfig-4.14.0.tgz\":{\"integrity\":\"yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c936fef035f30d113382f62687ab3dbc7b125421de0b41b73c8e5b1173411ed9ac84f9cef92e4eeea80b10e9f423942f332ea4a5937c2b534a1b28a52dbf77c0\",\"name\":\"get-tsconfig\",\"version\":\"4.14.0\"},\"glob-10.5.0.tgz\":{\"integrity\":\"DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0df5cdf037e127b347dce7bb7059aedcd0aed7029b911789f13a2bcd20056d22ab94d69048a7c8cea62a558f3395bb3634b05b5a9462539d865f63db68154d92\",\"name\":\"glob\",\"version\":\"10.5.0\"},\"glob-13.0.6.tgz\":{\"integrity\":\"Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5a3972ae89669bcb83a66fe8806c976576f567e09ad81f0d6c9c2a0558346b12bd19b05ea12ef2195eaf8d79d87469ba5f9de27a112ec716f288aa7c42637857\",\"name\":\"glob\",\"version\":\"13.0.6\"},\"glob-7.2.3.tgz\":{\"integrity\":\"nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c5474ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5\",\"name\":\"glob\",\"version\":\"7.2.3\"},\"glob-9.3.5.tgz\":{\"integrity\":\"e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b52e5783ca4533d88bbe31361d912b2e597f25bc08c072cd1779fd25348bb44b6c0e033b93c4226d71df52ddc8a3970605d7c12c537af36fc8cf5686f10e1f5\",\"name\":\"glob\",\"version\":\"9.3.5\"},\"glob-parent-5.1.2.tgz\":{\"integrity\":\"AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"00e22049009ea62258c0fdc04671b1fb95674eed870587736c63f8e5e2f0d6faf7cc1def64b7b279dd6c0bd8676dc39cf7f4ab33233944f42b906cf8692f59a3\",\"name\":\"glob-parent\",\"version\":\"5.1.2\"},\"glob-parent-6.0.2.tgz\":{\"integrity\":\"XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0\",\"name\":\"glob-parent\",\"version\":\"6.0.2\"},\"global-agent-3.0.0.tgz\":{\"integrity\":\"PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1\",\"name\":\"global-agent\",\"version\":\"3.0.0\"},\"globals-14.0.0.tgz\":{\"integrity\":\"oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5\",\"name\":\"globals\",\"version\":\"14.0.0\"},\"globals-15.15.0.tgz\":{\"integrity\":\"7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ec00b24f7c26ca9dc8eb54b87c6ebcd8bd150364460fda2d92a189230354305d52594a266c8224f9a7f5ba7b83620326d3cd9a1d8c03fa6cc9beff48bbc76c82\",\"name\":\"globals\",\"version\":\"15.15.0\"},\"globalthis-1.0.4.tgz\":{\"integrity\":\"DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e92ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d\",\"name\":\"globalthis\",\"version\":\"1.0.4\"},\"gopd-1.2.0.tgz\":{\"integrity\":\"ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65429187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46\",\"name\":\"gopd\",\"version\":\"1.2.0\"},\"got-11.8.6.tgz\":{\"integrity\":\"6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ead7d9f756ceafb6ce5e72bb3d10c21812dad47e14d3cd181cd6804362ac30694b13345b938e27b1917613521e45cdefb491cf55b2826207456da18eda58ddf2\",\"name\":\"got\",\"version\":\"11.8.6\"},\"got-12.6.1.tgz\":{\"integrity\":\"mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9938416e5be5005d5de0ee68ab2bcdf99c4b018c0824aedba4cc6062a3c3f68916d02dea9b91459fb93cd7542b72e101c1aa204779e0385a027ecea646feed79\",\"name\":\"got\",\"version\":\"12.6.1\"},\"got-fetch-5.1.10.tgz\":{\"integrity\":\"Gwj/A2htjvLEcY07PKDItv0WCPEs3dV2vWeZ+9TVBSKSTuWEZ4oXaMD0ZAOsajwx2orahQWN4HI0MfRyWSZsbg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1b08ff03686d8ef2c4718d3b3ca0c8b6fd1608f12cddd576bd6799fbd4d50522924ee584678a1768c0f46403ac6a3c31da8ada85058de0723431f47259266c6e\",\"name\":\"got-fetch\",\"version\":\"5.1.10\"},\"graceful-fs-4.2.11.tgz\":{\"integrity\":\"RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd\",\"name\":\"graceful-fs\",\"version\":\"4.2.11\"},\"has-bigints-1.1.0.tgz\":{\"integrity\":\"R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"477a5ba64708aafd8f9b7754c208dc943455996a53256d8370ccdc221117131d6887f08430e6cc9b728b99124e76f84cee8e2e4019f0afca7344adac25622a7e\",\"name\":\"has-bigints\",\"version\":\"1.1.0\"},\"has-flag-4.0.0.tgz\":{\"integrity\":\"EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d\",\"name\":\"has-flag\",\"version\":\"4.0.0\"},\"has-property-descriptors-1.0.2.tgz\":{\"integrity\":\"55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7924d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae\",\"name\":\"has-property-descriptors\",\"version\":\"1.0.2\"},\"has-proto-1.2.0.tgz\":{\"integrity\":\"KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2882fb7903df1d0442f3e5e5b9a230ec11d4c30a8bd7d6d09f887336076bfb5c17a14d0a2a3eabb9fbb8ee5858eca6c94760ba4faf8f7f237411aef09124bea9\",\"name\":\"has-proto\",\"version\":\"1.2.0\"},\"has-symbols-1.1.0.tgz\":{\"integrity\":\"1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d5c0cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d\",\"name\":\"has-symbols\",\"version\":\"1.1.0\"},\"has-tostringtag-1.0.2.tgz\":{\"integrity\":\"NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397\",\"name\":\"has-tostringtag\",\"version\":\"1.0.2\"},\"hasown-2.0.2.tgz\":{\"integrity\":\"0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d21254f5208fbe633320175916a34f5d66ba76a87b59d1f470823dcbe0b24bcac6de72f8f01725adaf4798a8555541f23d6347e58ef10f0001edb7e04a391431\",\"name\":\"hasown\",\"version\":\"2.0.2\"},\"hast-util-to-jsx-runtime-2.3.6.tgz\":{\"integrity\":\"zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ce5eacf0bc0dca8d4ff6ec3e5c91af66d74517519d0243a0f2e8cec3ee0fc9befaf3be1f2e9b38b9e1d70e15d6764e981d0e8e814b629e5886ed1b18bc26db06\",\"name\":\"hast-util-to-jsx-runtime\",\"version\":\"2.3.6\"},\"hast-util-whitespace-3.0.0.tgz\":{\"integrity\":\"88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f3c254374ea2a4bc2c9eff9d567f8e2183af02ebc1332fd0a22e8eee6407c5d3d7a63cbe09deb14645b0bb1ec328efb8b1820bb4b05120a82c7694b681073bab\",\"name\":\"hast-util-whitespace\",\"version\":\"3.0.0\"},\"help-me-5.0.0.tgz\":{\"integrity\":\"7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ef18289945fa00399c6331629341f303187fef7625291f5b985cdfe75099c11f9be98b735369b4bb8f61402a95e92be5a88aac6b1a2f7f076f6e7b30ddbff3a6\",\"name\":\"help-me\",\"version\":\"5.0.0\"},\"hermes-estree-0.25.1.tgz\":{\"integrity\":\"0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d3052809c2e9fb912fe690d6d8eae21c2d8c2426f02f0b91c7e800a8c4ce9062892620422e3b6bbf2e0f5941a7e8c21579f79c469ce8399fd457a88674eafe0b\",\"name\":\"hermes-estree\",\"version\":\"0.25.1\"},\"hermes-parser-0.25.1.tgz\":{\"integrity\":\"6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ea9123aae1f7aea688e9c6005d83dccfd312e2b63a4789e0460ae07c3b21469b54648737970d0c0882481838fdfbe99fc923ae3d31c1e27ad25bdf410af38f20\",\"name\":\"hermes-parser\",\"version\":\"0.25.1\"},\"highlight.js-10.7.3.tgz\":{\"integrity\":\"tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b7371415aba2b1628d1da4643785a397f640d3b8043408c597727f738f34769ae4193839110b2d81a345a817d4a82ab9e2465120472b793b00805fe6daab83ec\",\"name\":\"highlight.js\",\"version\":\"10.7.3\"},\"hoist-non-react-statics-3.3.2.tgz\":{\"integrity\":\"/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fe01a2bf18bc24f296366fd6d234a6cdc30fa5fa4f2dcddd63fe86c615f6850f621a3dda0df925578113ecd8caa528a72e9279bda7daf62886204660d7449f07\",\"name\":\"hoist-non-react-statics\",\"version\":\"3.3.2\"},\"hosted-git-info-4.1.0.tgz\":{\"integrity\":\"kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9320ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20\",\"name\":\"hosted-git-info\",\"version\":\"4.1.0\"},\"html-url-attributes-3.0.1.tgz\":{\"integrity\":\"ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a25e943f2056aacacee8427248fcf63bb652afce7a583ac4ccce7332aa7e14924b18c5b7e5c2d89a6667974bf3b40671454a0d6491530a885f8ee209f08e1005\",\"name\":\"html-url-attributes\",\"version\":\"3.0.1\"},\"http-cache-semantics-4.2.0.tgz\":{\"integrity\":\"dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"753c5cbcf5ea3ef5c1429ab9754afa9843095f8a08105bfa6f0a26dc50f02910ecb888e324600daa106ea009fd73545024874029abf7dc40fae44db2b3ef3b41\",\"name\":\"http-cache-semantics\",\"version\":\"4.2.0\"},\"http-proxy-agent-7.0.2.tgz\":{\"integrity\":\"T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f58240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a\",\"name\":\"http-proxy-agent\",\"version\":\"7.0.2\"},\"http2-client-1.3.5.tgz\":{\"integrity\":\"EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"102daeb53a1697844a7ece73777e8cc6aee7cc71c1ba89996e8234c982fa6344660604fb4a092ae2b4347b315362822c4aced39bd4897bea3615c020e8606118\",\"name\":\"http2-client\",\"version\":\"1.3.5\"},\"http2-wrapper-1.0.3.tgz\":{\"integrity\":\"V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57edb7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6\",\"name\":\"http2-wrapper\",\"version\":\"1.0.3\"},\"http2-wrapper-2.2.1.tgz\":{\"integrity\":\"V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5799d5c353c03a07c8dcb99e6a3d84c667a0edf7a78e1454833d653d27b3cb50ae84f61b810b5b423e2365f10010c95a2febeea6cbe18ea0b28f3a1bd32c6c99\",\"name\":\"http2-wrapper\",\"version\":\"2.2.1\"},\"https-proxy-agent-5.0.1.tgz\":{\"integrity\":\"dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7457008e94d0160a0b3330b657053e0bf09b4bbb912f49569b10c84e6aa6ec2fbb17439d9a3eacf65e9a95973a0042d786b9e080cd827964971c639d5f662dc0\",\"name\":\"https-proxy-agent\",\"version\":\"5.0.1\"},\"https-proxy-agent-7.0.6.tgz\":{\"integrity\":\"vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b\",\"name\":\"https-proxy-agent\",\"version\":\"7.0.6\"},\"human-signals-1.1.1.tgz\":{\"integrity\":\"SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"48442eeef97c2a334bd9ea0604b177fb0023a6c35f03d5cc9570188ffdc475a35f025c4ab610f5c631107c6394865942186255358df86d1afa94f20d84d8f267\",\"name\":\"human-signals\",\"version\":\"1.1.1\"},\"human-signals-5.0.0.tgz\":{\"integrity\":\"AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0177196fabf3ceb140504eb51e73789a92ea77f7122303508ed3564747ae3e6eb2d22ab1dc6e203976880ddb5d0f06668707bcd8b03afb38a7996e1405655e3d\",\"name\":\"human-signals\",\"version\":\"5.0.0\"},\"husky-9.1.7.tgz\":{\"integrity\":\"5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e60b39cad68d8c1ae1e4ec37cebbdd51463ed15c48b9654be22f62aede9fae257e06a7427e6575d4241358c8816161db5e1728f89d641df4ce52478f8420ef30\",\"name\":\"husky\",\"version\":\"9.1.7\"},\"hyphenate-style-name-1.1.0.tgz\":{\"integrity\":\"WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5830bfba2d95551af3de33958be5ed8ea9038e25634ed15a006896dfb93a6fea21c90e7060338692f0996bcf87d27c77832befd3e0524fdc6e3a0232190d3483\",\"name\":\"hyphenate-style-name\",\"version\":\"1.1.0\"},\"iconv-corefoundation-1.1.7.tgz\":{\"integrity\":\"T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5\",\"name\":\"iconv-corefoundation\",\"version\":\"1.1.7\"},\"iconv-lite-0.6.3.tgz\":{\"integrity\":\"4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33\",\"name\":\"iconv-lite\",\"version\":\"0.6.3\"},\"ieee754-1.2.1.tgz\":{\"integrity\":\"dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"75ccaa843bd7d42e3a95765c56a0a92be16d31141574830debf0dfe63b36ce8b94b2a1bb23ab05c62b480beeca60adbd29d5ce2c776ef732f8b059e85509ea68\",\"name\":\"ieee754\",\"version\":\"1.2.1\"},\"ignore-5.3.2.tgz\":{\"integrity\":\"hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa\",\"name\":\"ignore\",\"version\":\"5.3.2\"},\"ignore-7.0.5.tgz\":{\"integrity\":\"Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1ece7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a\",\"name\":\"ignore\",\"version\":\"7.0.5\"},\"immutable-5.1.5.tgz\":{\"integrity\":\"t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b7bc5c9b6b22c3e86550cebc23e50438afb3f3847398de7d6acf4367b3f5974f7de03294595ed45c1310655c5aa0c49143e3c165b1c23a806dedadb0c4e32df8\",\"name\":\"immutable\",\"version\":\"5.1.5\"},\"import-fresh-3.3.1.tgz\":{\"integrity\":\"TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9\",\"name\":\"import-fresh\",\"version\":\"3.3.1\"},\"imurmurhash-0.1.4.tgz\":{\"integrity\":\"JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c\",\"name\":\"imurmurhash\",\"version\":\"0.1.4\"},\"inflight-1.0.6.tgz\":{\"integrity\":\"k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93dd88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224\",\"name\":\"inflight\",\"version\":\"1.0.6\"},\"inherits-2.0.4.tgz\":{\"integrity\":\"k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93fbc6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1\",\"name\":\"inherits\",\"version\":\"2.0.4\"},\"inline-style-parser-0.2.7.tgz\":{\"integrity\":\"Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"35bd9cb4ec8d47c0ea4284743b0446f79b8d5880b40b594281fe4d6b3e47e898bbd8a67c39c1592f3d8fe6c360c25ca827c6227f5d6832e62ce690506bce9cb0\",\"name\":\"inline-style-parser\",\"version\":\"0.2.7\"},\"internal-slot-1.1.0.tgz\":{\"integrity\":\"4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e2077b56958d40d07850a28214555ca75015bfe14c3a0b3d34ace31cabac73c8d332177978bd4da90a8ea44d0accc76cf34e3fc87960969deec6096e3aa00f2f\",\"name\":\"internal-slot\",\"version\":\"1.1.0\"},\"intl-pluralrules-2.0.1.tgz\":{\"integrity\":\"astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6acb714cbcc87573de3742bd46e9a2e8b7cca66debbcd3b488913e87f93c2abfe2b3ec0f6d17b88a4c838e52ebe954e1fe611f36ff118cdfa0bb72b00e2ba1aa\",\"name\":\"intl-pluralrules\",\"version\":\"2.0.1\"},\"ip-address-10.1.0.tgz\":{\"integrity\":\"XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d70031f15e6bd3f7e091c615e0e7a2c9a2f13e6e65a711607bf0b07cdd5653a6b29399a0b941faee5e8731cd36762a5d033702ae05d9488632fc2de63c49ff1\",\"name\":\"ip-address\",\"version\":\"10.1.0\"},\"ip-num-1.5.2.tgz\":{\"integrity\":\"CUxHEJuJk74GIQA75LD9RDkpK/3NJv8yRnseOh79AlRmFwT1HgYPKDOiVkd0QVR5MNwMj9EnOnS1yJn9CaYNZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"094c47109b8993be0621003be4b0fd4439292bfdcd26ff32467b1e3a1efd0254661704f51e060f2833a256477441547930dc0c8fd1273a74b5c899fd09a60d64\",\"name\":\"ip-num\",\"version\":\"1.5.2\"},\"is-alphabetical-2.0.1.tgz\":{\"integrity\":\"FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"156cb263ad0c79337279246990cd88af2d06f61a6befff640f8d260ff706404ba295c6584b8a24cfc48dd90eab2c227c81b0ade9f37eac2fbab4c192f7d2dac5\",\"name\":\"is-alphabetical\",\"version\":\"2.0.1\"},\"is-alphanumerical-2.0.1.tgz\":{\"integrity\":\"hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8666d8857ffd314305e6e87bb4e5f22bf9f466f5a969de5c681035ec6b02eafcae0aa696962446e4ad6a4bd8a799484431a381216effc210274b0bde5bf2ed67\",\"name\":\"is-alphanumerical\",\"version\":\"2.0.1\"},\"is-arguments-1.2.0.tgz\":{\"integrity\":\"7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"edb55b8b486e8ffc2b2003b36fc5356acce0f64762dca37f0b2535f424c8eed028658119a0bf720835e96d737eb8fb2e5a73f4d9ccae8358257aaabe4d4f9808\",\"name\":\"is-arguments\",\"version\":\"1.2.0\"},\"is-array-buffer-3.0.5.tgz\":{\"integrity\":\"DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0c37c03548a21b6c02d6a6b03faeaa953ba025e2f91f2ccca5fafc94b2be8cc422ac6ccda1dd01d7670507ff6af37f11bb6eec0707f0efcfeb76853b444473e8\",\"name\":\"is-array-buffer\",\"version\":\"3.0.5\"},\"is-async-function-2.1.1.tgz\":{\"integrity\":\"9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f5d80cfdc6419cdbe3cda3181d5a31c5f3e3d905eddb612fed2bae3ebb3ec5abf4ba4181d12e9de3275974488ce3c90bc7990357e4013eba559c5c9e7cbf2491\",\"name\":\"is-async-function\",\"version\":\"2.1.1\"},\"is-bigint-1.1.0.tgz\":{\"integrity\":\"n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9f8653dfbc06efc8b3d37c4f44a26b1d37596dedc889ccae704b5d46c579ca09707371b251f6c07e949e0f4149e3535b50d4ade706e1a9fa757d2f81827bc315\",\"name\":\"is-bigint\",\"version\":\"1.1.0\"},\"is-binary-path-2.1.0.tgz\":{\"integrity\":\"ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"64c11161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f\",\"name\":\"is-binary-path\",\"version\":\"2.1.0\"},\"is-boolean-object-1.2.2.tgz\":{\"integrity\":\"wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c1ae7aa36fc4949318aa30a31a45eb8bb8ade456de6d6e6eb0bc3f9cf98232ce43799edece24986614a63d19f4b71a9e5b82e702641053b160a8ba6c10528ce0\",\"name\":\"is-boolean-object\",\"version\":\"1.2.2\"},\"is-bun-module-2.0.0.tgz\":{\"integrity\":\"gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"80d0866e79e79c501418a799f4f75bc9e19826a7b0a6673668a1d410c3b99d03d653d94e9afee3726408bfea870fc7d75ba5bba9fb82c17e2b63d2cd4635eb91\",\"name\":\"is-bun-module\",\"version\":\"2.0.0\"},\"is-callable-1.2.7.tgz\":{\"integrity\":\"1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d410b40551614bfa74aadc3a7a7a7c7bef0e0f452b2b4a052f3b528cdce170a037583b89c7100f5f33ee3ed2a48c463d514a045a55fff1f80a7aed92f22f494c\",\"name\":\"is-callable\",\"version\":\"1.2.7\"},\"is-core-module-2.16.1.tgz\":{\"integrity\":\"UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51fa1e300e9f209f304d81445237a59da188ebbbfaf8deea5c912f42e2066bdf65e31b02aee498395490d2e3c0367e1d0339bc96460f68a2ebae28cbabbc76df\",\"name\":\"is-core-module\",\"version\":\"2.16.1\"},\"is-data-view-1.0.2.tgz\":{\"integrity\":\"RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"44ab5617ca46992f3b8b60fa82a42efe5ec461195575fcde98224dfcfdd43acfffc75404ee67e1bf31c802905345fedac6f4fa0cc1b04b00576024f49df07dc7\",\"name\":\"is-data-view\",\"version\":\"1.0.2\"},\"is-date-object-1.1.0.tgz\":{\"integrity\":\"PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3f0c2111a90754a4dd44d54ec3efc6ca1d3e33394297847aa8abe486ebcbb4f320808d56007b7db0ec19c502d21a951a0e7addc83b289a846036709f28d4975e\",\"name\":\"is-date-object\",\"version\":\"1.1.0\"},\"is-decimal-2.0.1.tgz\":{\"integrity\":\"AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"00007d862a2642ce435d6711075aeab31194b2d6d1ae814e3cf540a26364ff75c74792721190a13b24d67b6a1ac8a9ec4acaff91c1aa17ecfacae1fa1c7a4dd0\",\"name\":\"is-decimal\",\"version\":\"2.0.1\"},\"is-docker-2.2.1.tgz\":{\"integrity\":\"F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17e8b604ab05ac7eba89a505734c280fcb0bcbc81eb64c13c2d3818efb39e82c780a024378a41ea9fcfcc0062249bf093a9ad68471f9a7becf6e6602bef52e5d\",\"name\":\"is-docker\",\"version\":\"2.2.1\"},\"is-docker-3.0.0.tgz\":{\"integrity\":\"eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7a58dc8040e5127b3fec05c5a2c0792bfda708ce0fec540f90673f0d62f2e6b985116bd96b21ab8a4d5df7f4086399c9e1ff58b15bc1900ea42691e7f6b21275\",\"name\":\"is-docker\",\"version\":\"3.0.0\"},\"is-extglob-2.1.1.tgz\":{\"integrity\":\"SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1\",\"name\":\"is-extglob\",\"version\":\"2.1.1\"},\"is-finalizationregistry-1.1.1.tgz\":{\"integrity\":\"1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d690ba37ca9625b5a83ed12381c2f6c7285038fe3dd44423794a37a9329c995f184830c9ace7a97c6f29702ee1fd0827407612bf4989dd9fd95b199ab55af2b2\",\"name\":\"is-finalizationregistry\",\"version\":\"1.1.1\"},\"is-fullwidth-code-point-3.0.0.tgz\":{\"integrity\":\"zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742\",\"name\":\"is-fullwidth-code-point\",\"version\":\"3.0.0\"},\"is-fullwidth-code-point-4.0.0.tgz\":{\"integrity\":\"O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3b82f4f78376fdd67bc6a55dad7861f6bd4a3833c9a459acf01e6c19d24b3f2ebae0082f5ecade654c82410348b59443958ba0e314ad2e3369feccf71ef068c1\",\"name\":\"is-fullwidth-code-point\",\"version\":\"4.0.0\"},\"is-fullwidth-code-point-5.1.0.tgz\":{\"integrity\":\"5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e571d8692ca2a800dbe119d9d4175a77a70fa7c4e88ac7b84f312370e6031d991309b2a089497b593502a4d587bb1983b7dd709ec64173dc629cdce8a6fdc931\",\"name\":\"is-fullwidth-code-point\",\"version\":\"5.1.0\"},\"is-generator-function-1.1.2.tgz\":{\"integrity\":\"upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ba9aadd5290690e0d6f6db06346e66b574d7b440a2cf0b52da4035eb533e8093dcd7175bfc0c7adbd69fe98ad3c1c39e4076dec2b3cd944e43c7b933bd74e2cc\",\"name\":\"is-generator-function\",\"version\":\"1.1.2\"},\"is-glob-4.0.3.tgz\":{\"integrity\":\"xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a\",\"name\":\"is-glob\",\"version\":\"4.0.3\"},\"is-hexadecimal-2.0.1.tgz\":{\"integrity\":\"DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e0650a76e3573ca0ee9c03549b4c45a25dea31578daf95c271807f81de18b5022aaa2abb9947764617c227ddf8f8fbfcbfeeb1ef94e64b66d809ff8b6d60666\",\"name\":\"is-hexadecimal\",\"version\":\"2.0.1\"},\"is-in-ssh-1.0.0.tgz\":{\"integrity\":\"jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8d86ba43dac7f74911d6f281e8d33baaa7759a07b7171e03870e535652b531406a8443ae09a82b10731ebcdb8271b1029976744e15e4466f989abe751f010f03\",\"name\":\"is-in-ssh\",\"version\":\"1.0.0\"},\"is-inside-container-1.0.0.tgz\":{\"integrity\":\"KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"28860b08226085f1d9c6a8d8044eeb132d0e06e4dde710874bbb47560bc22e4c7b4ad2286b1c0d5b784200b80452315f79193e306fd0c66a7fbed113105ded44\",\"name\":\"is-inside-container\",\"version\":\"1.0.0\"},\"is-interactive-1.0.0.tgz\":{\"integrity\":\"2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d87bc810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb\",\"name\":\"is-interactive\",\"version\":\"1.0.0\"},\"is-map-2.0.3.tgz\":{\"integrity\":\"1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d5079dd3f1ebda6f98ab19ccd3d0a303677f8ba61935f17a476a1100e8f7e9e51d4baa8857f86e3c935212929bba97b016cf99b09971b238cf6dcd3f69f5ba2f\",\"name\":\"is-map\",\"version\":\"2.0.3\"},\"is-negative-zero-2.0.3.tgz\":{\"integrity\":\"5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e4aa08bb6360a727a4ef98d7a1d16f9da7c1e83260af7bbcbae2b42c46498eb535f43acc0f7115111691f2c8f3f0208682966fc4f97d4ae13518c54f147c759b\",\"name\":\"is-negative-zero\",\"version\":\"2.0.3\"},\"is-number-7.0.0.tgz\":{\"integrity\":\"41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e350a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e\",\"name\":\"is-number\",\"version\":\"7.0.0\"},\"is-number-object-1.1.1.tgz\":{\"integrity\":\"lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"95985c96e984d46e95603f151dedf9c0568889ff824f2e522488b9fb7cb8a6c0e05aee303c3a01845f0dc543a29c473ba478224ec4fa31a05bf76aca8610fe5f\",\"name\":\"is-number-object\",\"version\":\"1.1.1\"},\"is-plain-obj-4.1.0.tgz\":{\"integrity\":\"+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f8f822faf32e50d909c84c62301b792251683322a7af9ce127852ca73e7c58e841179428219905c8d1c86c102d1f0cd502093946d9dd54db0344deb5fe6983aa\",\"name\":\"is-plain-obj\",\"version\":\"4.1.0\"},\"is-regex-1.2.1.tgz\":{\"integrity\":\"MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"32362c2873b93bb982b26446c5670b5a1785a8df4327fd939a782f8ca5e285ee9e7d588fa9cdbbe3e171ff87d88ffaf4dfe112bc17535cad15ead037ae07b3d6\",\"name\":\"is-regex\",\"version\":\"1.2.1\"},\"is-set-2.0.3.tgz\":{\"integrity\":\"iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"88f0237abaec7b6effca018bc70f84051f5a82ff58eae2de61524cbbe40d0a8a2e275ff5ae2d261ab716a5f0aa159bb3cf1dd68edc311b4f7c5fe9f83ae4643e\",\"name\":\"is-set\",\"version\":\"2.0.3\"},\"is-shared-array-buffer-1.0.4.tgz\":{\"integrity\":\"ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"21259a73c76bbf86467f02a5e6c9691c6f4ec0f36dcb88ce58f448841a713a80fe86a2138b0ba2a4e4366cdb61033c00dc1e1f2233b83659fbe0dd12f5bcaaf0\",\"name\":\"is-shared-array-buffer\",\"version\":\"1.0.4\"},\"is-stream-2.0.1.tgz\":{\"integrity\":\"hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"845a222624e5eb79e7fa4b2d1c606d7b05922a740ba726f5e7928785e035977f6ebed3bd9d6228a75a77b9da8f71477fc5b17554b30ee27ece23aa7b45b9e00e\",\"name\":\"is-stream\",\"version\":\"2.0.1\"},\"is-stream-3.0.0.tgz\":{\"integrity\":\"LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2e7411e1b67d2000c345292fa6a306bedfed10959c9739253604b0e3c57910068078377aa86bcdf1e8ba939a74b6fc52475ef55661b21ee4e200e7f101bafc90\",\"name\":\"is-stream\",\"version\":\"3.0.0\"},\"is-string-1.1.1.tgz\":{\"integrity\":\"BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06d11e4aca1a4239523c17a631022b635318d2e33abe74b58397e6b9f60eb67c4b19464cdb5efc3ca6e1b24ec57efe7c217f99b5cbe81b071c62c8743e096400\",\"name\":\"is-string\",\"version\":\"1.1.1\"},\"is-symbol-1.1.1.tgz\":{\"integrity\":\"9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f601b1e864ed09033bdc18261d05df0e62ed7e38d35034b2a314c26e9e56b688b10217e0b038ab58871543f207a6f2395607798bf27917b07d70dfd69556c2ff\",\"name\":\"is-symbol\",\"version\":\"1.1.1\"},\"is-typed-array-1.1.15.tgz\":{\"integrity\":\"p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a7711cb227178e2b7b49ab245c7b35840f75431813c38e85bfa10528a192e434452c3f322a7a218c5de1c688eef786ff39c319a10ba4ce93e9044f6e2d52b381\",\"name\":\"is-typed-array\",\"version\":\"1.1.15\"},\"is-unicode-supported-0.1.0.tgz\":{\"integrity\":\"knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"927c46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f\",\"name\":\"is-unicode-supported\",\"version\":\"0.1.0\"},\"is-weakmap-2.0.2.tgz\":{\"integrity\":\"K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2b9a5760e9bdc2a6354608e92f7613905dfdb678b55da8d42246b04cb528f446445541606b981240917c9cd4bb670250d36cbed5808d61c321f8721fd59a84fb\",\"name\":\"is-weakmap\",\"version\":\"2.0.2\"},\"is-weakref-1.1.1.tgz\":{\"integrity\":\"6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ea2f661964a5ab334c12aa42a7ddcac114b5b943a8764d8e27a6feb2aed93c34b2d96b88e4d148c69ff6e784f2b51f1fb5e7dec645a7e713621d43693ce7d27b\",\"name\":\"is-weakref\",\"version\":\"1.1.1\"},\"is-weakset-2.0.4.tgz\":{\"integrity\":\"mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"99f7306fa23343238a4ecf3809032b3b05b881071a4ce016274cf32429765923c3ad693f3b30da2265851f77635e16f6e20e1eb9d65f2d1a3302f3c6c3877d85\",\"name\":\"is-weakset\",\"version\":\"2.0.4\"},\"is-wsl-2.2.0.tgz\":{\"integrity\":\"fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7cacc0adad2b18951407018180d90766e4e865c9fe4ed5c7a5e0a09a430930c631d6c40361a092ca32414826b69c7d431a6eecde7d68067a21a154c168decbc3\",\"name\":\"is-wsl\",\"version\":\"2.2.0\"},\"is-wsl-3.1.1.tgz\":{\"integrity\":\"e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7baaef7540a240202eba666c971449591fc3a2ae15a4f47cda4a9c96f712d1e7e0b78df44a5188934e6f742379f3e56bce0b4871f34e0e3a335627a5c9c0f84b\",\"name\":\"is-wsl\",\"version\":\"3.1.1\"},\"isarray-2.0.5.tgz\":{\"integrity\":\"xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c478e10ebddc3412b40737542523d7667b50531fe6c0c4b9470e00ee53c9f745c600ee8848ffde3c336ea34be1a8e654f940f9268a1dc02000a1941ddc57802b\",\"name\":\"isarray\",\"version\":\"2.0.5\"},\"isbinaryfile-4.0.10.tgz\":{\"integrity\":\"iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"887aea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb\",\"name\":\"isbinaryfile\",\"version\":\"4.0.10\"},\"isbinaryfile-5.0.7.tgz\":{\"integrity\":\"gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"827583d78261dc5cd2dc23e117403134e27c0b1a9e6e53d3003cc8dfcaf4c2df19c9097979da72ef99b2b74f041b6a0abe9ca2a92aacc7e5a4cfdbed91b4ea61\",\"name\":\"isbinaryfile\",\"version\":\"5.0.7\"},\"isexe-2.0.0.tgz\":{\"integrity\":\"RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23\",\"name\":\"isexe\",\"version\":\"2.0.0\"},\"isexe-3.1.5.tgz\":{\"integrity\":\"6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e81ded2ed16ab504b87a46abbcb54c67e5fe565bd07a46dee2d69491ffeb8553b777f874336adf0119bfa572dc3c4b238ccb0582b1604ab85023171256b073f3\",\"name\":\"isexe\",\"version\":\"3.1.5\"},\"iterator.prototype-1.1.5.tgz\":{\"integrity\":\"H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1f476442809addbd9511e29004ec45a61f8901b72b41d13b282d1492ac292e6bf6102e0fe354173feaeaa3dc18a1d002886e7f58ce6cf680c0a5353cbadc23f6\",\"name\":\"iterator.prototype\",\"version\":\"1.1.5\"},\"jackspeak-3.4.3.tgz\":{\"integrity\":\"OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"386959429cf6c9f6a103f45dd58f0277d48812caaf5e42d5a12c3f720c219e114c0dbb1015e658a0927b6c86414bd05c6a6516f7a6acabf9e93d6ba033e45007\",\"name\":\"jackspeak\",\"version\":\"3.4.3\"},\"jake-10.9.4.tgz\":{\"integrity\":\"wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c\",\"name\":\"jake\",\"version\":\"10.9.4\"},\"jiti-1.21.7.tgz\":{\"integrity\":\"/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fe298a346e046d636b563a0d0bfd47e7ff46172fadaa31811c2692b0df8fd919cfaa3b0b9afe940f7123f8a8fc9c159a440c3293b90ae5951cf8e11ab674d1dc\",\"name\":\"jiti\",\"version\":\"1.21.7\"},\"jiti-2.6.1.tgz\":{\"integrity\":\"ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7a48a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85\",\"name\":\"jiti\",\"version\":\"2.6.1\"},\"jotai-2.19.1.tgz\":{\"integrity\":\"sqm9lVZiqBHZH8aSRk32DSiZDHY3yUIlulXYn9GQj7/LvoUdYXSMti7ZPJGo+6zjzKFt5a25k/I6iBCi43PJcw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b2a9bd955662a811d91fc692464df60d28990c7637c94225ba55d89fd1908fbfcbbe851d61748cb62ed93c91a8fbace3cca16de5adb993f23a8810a2e373c973\",\"name\":\"jotai\",\"version\":\"2.19.1\"},\"joycon-3.1.1.tgz\":{\"integrity\":\"34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"df8c01fd8ecc5bb6f38ca46350a4dae3a23667b795eb646486f6be2a4a295bb42fbff392581aaf91263bbeeb0e3eb36e65c506ded029bdd560341f0f3a3dd23f\",\"name\":\"joycon\",\"version\":\"3.1.1\"},\"js-tokens-4.0.0.tgz\":{\"integrity\":\"RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29\",\"name\":\"js-tokens\",\"version\":\"4.0.0\"},\"js-yaml-4.1.1.tgz\":{\"integrity\":\"qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a90293e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0\",\"name\":\"js-yaml\",\"version\":\"4.1.1\"},\"jsesc-3.1.0.tgz\":{\"integrity\":\"/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868\",\"name\":\"jsesc\",\"version\":\"3.1.0\"},\"json-buffer-3.0.1.tgz\":{\"integrity\":\"4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49\",\"name\":\"json-buffer\",\"version\":\"3.0.1\"},\"json-schema-traverse-0.4.1.tgz\":{\"integrity\":\"xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756\",\"name\":\"json-schema-traverse\",\"version\":\"0.4.1\"},\"json-schema-traverse-1.0.0.tgz\":{\"integrity\":\"NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba\",\"name\":\"json-schema-traverse\",\"version\":\"1.0.0\"},\"json-stable-stringify-without-jsonify-1.0.1.tgz\":{\"integrity\":\"Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f\",\"name\":\"json-stable-stringify-without-jsonify\",\"version\":\"1.0.1\"},\"json-stringify-safe-5.0.1.tgz\":{\"integrity\":\"ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"642960e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44\",\"name\":\"json-stringify-safe\",\"version\":\"5.0.1\"},\"json5-1.0.2.tgz\":{\"integrity\":\"g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"83531630b062cfc14a8b57b8c3453254bdf0fa225c7960050406819e718a3a935ae5ff132e4b646eb7b5facea8202c9d5809be1d15064e623efffc6fda1bd760\",\"name\":\"json5\",\"version\":\"1.0.2\"},\"json5-2.2.3.tgz\":{\"integrity\":\"XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5e63967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca\",\"name\":\"json5\",\"version\":\"2.2.3\"},\"jsonfile-4.0.0.tgz\":{\"integrity\":\"m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9ba175477cfc8e395fda29901d2d907b3e6c8ca590cdbbae86e27f14a605459bcf1373ee1dc48c559cdfb0b84654e91f776d286cbe5258405ec394a196ab8dc6\",\"name\":\"jsonfile\",\"version\":\"4.0.0\"},\"jsonfile-6.2.0.tgz\":{\"integrity\":\"FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"146b8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502\",\"name\":\"jsonfile\",\"version\":\"6.2.0\"},\"jsx-ast-utils-3.3.5.tgz\":{\"integrity\":\"ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"659a30f47048e4ee843e04892d46fc9f634a8265564f00af1c6c05b8994c8ef2c5aa5186ea98e2acf86d76cb1e68b6634a26c3f1e7a0ce6629519c282258f671\",\"name\":\"jsx-ast-utils\",\"version\":\"3.3.5\"},\"keyv-4.5.4.tgz\":{\"integrity\":\"oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7\",\"name\":\"keyv\",\"version\":\"4.5.4\"},\"kleur-3.0.3.tgz\":{\"integrity\":\"eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"793233955392511f89c5d0c57a911870132d67d42a75e7feae7cd675166e31b3b2c2ee6d3b6c3637baea8e800d67993dbf2c212fa06bd55463508813431e04f3\",\"name\":\"kleur\",\"version\":\"3.0.3\"},\"language-subtag-registry-0.3.23.tgz\":{\"integrity\":\"0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d0aeb92de6bcf35a47a2da0611ae600e5331b77a5cb4b8b64699416fb133878ad174b10eb608bb9f81302bd95a9a750290a06a69e29155e6d3aba040c529295d\",\"name\":\"language-subtag-registry\",\"version\":\"0.3.23\"},\"language-tags-1.0.9.tgz\":{\"integrity\":\"MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"31b8cde34f1f12775f8905db150d6f9ddfb53682c3b27416e35e35d284015e2c970cc607e73e74e63b966b82941352eac510bb0e03a06436ca2f11c8c26dbb84\",\"name\":\"language-tags\",\"version\":\"1.0.9\"},\"lazy-val-1.0.5.tgz\":{\"integrity\":\"0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d3f06718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9\",\"name\":\"lazy-val\",\"version\":\"1.0.5\"},\"levn-0.4.1.tgz\":{\"integrity\":\"+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029\",\"name\":\"levn\",\"version\":\"0.4.1\"},\"lilconfig-3.1.3.tgz\":{\"integrity\":\"/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fef945280a07e4282ddc87be24b8516f03ac09078f001894ded2757a01afc90fb7dd1fef730336665d9047f2f38ec05e22d3edde84955daa67fa6e27403be9cf\",\"name\":\"lilconfig\",\"version\":\"3.1.3\"},\"lines-and-columns-1.2.4.tgz\":{\"integrity\":\"7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406\",\"name\":\"lines-and-columns\",\"version\":\"1.2.4\"},\"lint-staged-15.5.2.tgz\":{\"integrity\":\"YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"61448e2eaf55791340a3f0936959a1183286f8b06d03c285d57e0ae7eca4312c16493d6f0f125107692fd823a02dbd5fbe90a8f80ff2f40d06d339cd566771e3\",\"name\":\"lint-staged\",\"version\":\"15.5.2\"},\"listr2-8.3.3.tgz\":{\"integrity\":\"LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2d6cd7d8ab2a701d70a90e001e061be11b035dab908aa8632e4fba8636da7871b8ce98e354007ac02fe0cfa5f497e0eed5c377a54079665aef4db84648d9d441\",\"name\":\"listr2\",\"version\":\"8.3.3\"},\"locate-path-3.0.0.tgz\":{\"integrity\":\"7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ec03bbe3cc169c884da80b9ab72d995879101d148d7cf548b0f21fc043963b6d8099aa15ad66af94e70c4799f34cb358be9dfa5f6db4fe669a46cade7351bae4\",\"name\":\"locate-path\",\"version\":\"3.0.0\"},\"locate-path-6.0.0.tgz\":{\"integrity\":\"iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553\",\"name\":\"locate-path\",\"version\":\"6.0.0\"},\"lodash-4.18.1.tgz\":{\"integrity\":\"dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74c22789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1\",\"name\":\"lodash\",\"version\":\"4.18.1\"},\"lodash.merge-4.6.2.tgz\":{\"integrity\":\"0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321\",\"name\":\"lodash.merge\",\"version\":\"4.6.2\"},\"log-symbols-4.1.0.tgz\":{\"integrity\":\"8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f173efa4003cbb285fb5ebbca48bd0c69259ed2618769522bd9a46cbab05b01b8a458ffbad019abde75e07c68af99932ababa930554bffd016eaf398cdf4722e\",\"name\":\"log-symbols\",\"version\":\"4.1.0\"},\"log-update-6.1.0.tgz\":{\"integrity\":\"9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f627bc22d3d1ead8d8e6e60987c2bf66bbff44c67954e94e5afb597441d849314a65f2013d06bdb4e0047805a177e02722778b276db0e5f8ce62da2eb695aae7\",\"name\":\"log-update\",\"version\":\"6.1.0\"},\"longest-streak-3.1.0.tgz\":{\"integrity\":\"9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f518bea3425881e8536950410e832a225f065ed6d683bd753b7b2b7ed707859d1daa7113a8b6a820ad31d7b7d4c3dac54a52bfd0d96c29ed00861ca5e695c4da\",\"name\":\"longest-streak\",\"version\":\"3.1.0\"},\"loose-envify-1.4.0.tgz\":{\"integrity\":\"lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add\",\"name\":\"loose-envify\",\"version\":\"1.4.0\"},\"lowercase-keys-2.0.0.tgz\":{\"integrity\":\"tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b6a357ad2efca0c384ef734cc4ae0430b42c428c167fc8caa281fd83bc4f6af453ef4e91e9b91027a0d8d937bb42e91a66cba5c5adf4c10edb934a66e1788798\",\"name\":\"lowercase-keys\",\"version\":\"2.0.0\"},\"lowercase-keys-3.0.0.tgz\":{\"integrity\":\"ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a33082ea0750fa0957390b2f78a0f462c0f2f034901630d3cf8cf2cc41cd579f893f90fad8b99f0d9ea8d5cc9c171f68b86f78d0ce5d13c0bc0937b0763d9859\",\"name\":\"lowercase-keys\",\"version\":\"3.0.0\"},\"lru-cache-10.4.3.tgz\":{\"integrity\":\"JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49\",\"name\":\"lru-cache\",\"version\":\"10.4.3\"},\"lru-cache-11.3.5.tgz\":{\"integrity\":\"NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"371545c0b027addf62eca501c42e03ad4866823cceb3ed509b9d03de8175fe82feaf5369678800ef1bc6d3fcc9f1ebd1ef320a9f8bcb7fba9335db9616d0ab47\",\"name\":\"lru-cache\",\"version\":\"11.3.5\"},\"lru-cache-5.1.1.tgz\":{\"integrity\":\"KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2a9340450037230bfe8d3034bad51555bae1f8996baf516fd1ee7a186cc014e5cdedd93f16f89a0d6f0b1e62b9d8395c1f858fda7ea023cbcdd5a7ac045828f7\",\"name\":\"lru-cache\",\"version\":\"5.1.1\"},\"lru-cache-6.0.0.tgz\":{\"integrity\":\"Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"268e9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88\",\"name\":\"lru-cache\",\"version\":\"6.0.0\"},\"magic-bytes.js-1.13.0.tgz\":{\"integrity\":\"afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"69f3b69a7c56ec60d35cc9b9fc0a0dd56b8e71da0a86d8178c8bc79a86ea4c3d60acda6584676fdcf14eca30959ab9ce641213fe00ff9280caa581bed26bc772\",\"name\":\"magic-bytes.js\",\"version\":\"1.13.0\"},\"magic-string-0.30.21.tgz\":{\"integrity\":\"vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609\",\"name\":\"magic-string\",\"version\":\"0.30.21\"},\"magic-string-0.30.8.tgz\":{\"integrity\":\"ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2124137b9e53d9aa3b5ed9404adb9deaac183d98c4e062b54bf05e54fbace23aeae89b8e9d0d3460a402e7cd515a1475db65bb9ac655dbadcacd578ba2a89dc9\",\"name\":\"magic-string\",\"version\":\"0.30.8\"},\"make-error-1.3.6.tgz\":{\"integrity\":\"s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b3c52194d7bbbcf2a8990842d6a15e94ca24aff49cdc080d6eca379fbe2654f0392d3670901f4d9577f85cf6a62f1244f21d2087bdeb33de31bf0453d825489f\",\"name\":\"make-error\",\"version\":\"1.3.6\"},\"make-fetch-happen-14.0.3.tgz\":{\"integrity\":\"QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40c8c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5\",\"name\":\"make-fetch-happen\",\"version\":\"14.0.3\"},\"markdown-table-3.0.4.tgz\":{\"integrity\":\"wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c22633e3e26b2f26ff0ea5b6864149c4fed577b26e4c39bbedfbdb33c55f11076648ca9c22659e7916c7c198c18c81648bf55a30ad818458bba1451978ce5bab\",\"name\":\"markdown-table\",\"version\":\"3.0.4\"},\"matcher-3.0.0.tgz\":{\"integrity\":\"OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3a478368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e\",\"name\":\"matcher\",\"version\":\"3.0.0\"},\"matchmediaquery-0.4.2.tgz\":{\"integrity\":\"wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c2b669a13e747a160eb9d8438edfd8bd425ce9e53371d14f7666e2cdf82fb3008a3470f5fce04e1d82691e27be1d7a6ee9b4a410689e14c624e95baeb5a8917c\",\"name\":\"matchmediaquery\",\"version\":\"0.4.2\"},\"math-intrinsics-1.1.0.tgz\":{\"integrity\":\"/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fc85ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6\",\"name\":\"math-intrinsics\",\"version\":\"1.1.0\"},\"mdast-util-find-and-replace-3.0.2.tgz\":{\"integrity\":\"Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4e6775560fe6dd7cf8dda7de3710c885646d15980cd952f269fe2f493630b9d4f27ae4e77a82f7aad58c0398de2f2cff3b5bc3266995e10b92705080dad04fc2\",\"name\":\"mdast-util-find-and-replace\",\"version\":\"3.0.2\"},\"mdast-util-from-markdown-2.0.3.tgz\":{\"integrity\":\"W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5b8980593bd294abdff0be89f9537dc8b4aa43d00e000bc7ba80c098f933e1d1dfe79de6e60563d9e8da747261a0999c9b11273afe8f6bc5c9869c44f7791bf1\",\"name\":\"mdast-util-from-markdown\",\"version\":\"2.0.3\"},\"mdast-util-gfm-3.1.0.tgz\":{\"integrity\":\"0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d2e95f75038cdf2b07842275a74ea5d1bd152a5854d30b90b37b61c5941a8237233eb94546a636d79b991871c96a7f461005ddf4c6df3e3149cfea8c91547acd\",\"name\":\"mdast-util-gfm\",\"version\":\"3.1.0\"},\"mdast-util-gfm-autolink-literal-2.0.1.tgz\":{\"integrity\":\"5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e4754fd8c29a3fa2fe1ba61ac4f363b8bd013ebabda2b1b74ecad9f585db037bc3c3f002238304b27a03a67e99366ec69d982d01c38d2723e138ff2d34941abd\",\"name\":\"mdast-util-gfm-autolink-literal\",\"version\":\"2.0.1\"},\"mdast-util-gfm-footnote-2.1.0.tgz\":{\"integrity\":\"sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b2aa435a5b079fb01cf4635940c794ccf41233347a5afd1629136f4118342aa1e1d367e94f3ebd41cd504ac78d5f6f5b873d51388c8dcb11317dac152939b519\",\"name\":\"mdast-util-gfm-footnote\",\"version\":\"2.1.0\"},\"mdast-util-gfm-strikethrough-2.0.0.tgz\":{\"integrity\":\"mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"98a29bf75e5317e382e69b63e5b27b58544f758b6e1efd324d1c4adad26f8be043a9b9221bb87bbbff5223cf6744061c99aa76c4740bf43f901bfeb04ab4ed5e\",\"name\":\"mdast-util-gfm-strikethrough\",\"version\":\"2.0.0\"},\"mdast-util-gfm-table-2.0.0.tgz\":{\"integrity\":\"78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efc504bde6f3cffac92312ef13b66d0ddfef210d111effb7321e4347dea9edc4bb1ec0616082020c10aef1cb1335634eead0567ea5cf59e911ba3d8534e18e66\",\"name\":\"mdast-util-gfm-table\",\"version\":\"2.0.0\"},\"mdast-util-gfm-task-list-item-2.0.0.tgz\":{\"integrity\":\"IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"22bb6f36f8f10b5a34ead6810152739c49e4887c4b153ce0a2751dcbc873155783ba7d2e4e3c71ad119568d16a914d70251dd104f11fb31994ea30d63e87eb4d\",\"name\":\"mdast-util-gfm-task-list-item\",\"version\":\"2.0.0\"},\"mdast-util-mdx-expression-2.0.1.tgz\":{\"integrity\":\"J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"27a7fef61529fa575366a2914a0ed5c3957a32a8c04dcfb713881fdc214d72e64d583f1777223acd0f06a87edff35ebd30ce8fee13014435469e7ee81c1f645d\",\"name\":\"mdast-util-mdx-expression\",\"version\":\"2.0.1\"},\"mdast-util-mdx-jsx-3.2.0.tgz\":{\"integrity\":\"lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"963ff3f2fd2be99b6c37f70634db5e9a699fa0b0056678cc6cdc8bcc169f8f38a438cfa096b8cd1cf95fea540339371c8fd9f96f43cf8a11016e19de3321acd5\",\"name\":\"mdast-util-mdx-jsx\",\"version\":\"3.2.0\"},\"mdast-util-mdxjs-esm-2.0.1.tgz\":{\"integrity\":\"EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"11c98ea71b19f7a0af94fd3736086d1f512c2edaf49fd4e6e253d425405c715f51c143a77aa4b2720d7d9f91c6cc27fed742e8ccc45239bb55af779ed56a07b6\",\"name\":\"mdast-util-mdxjs-esm\",\"version\":\"2.0.1\"},\"mdast-util-phrasing-4.1.0.tgz\":{\"integrity\":\"TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4ea202c32bc9269070bc600c6638f82769f45fc416a76d5bf65d28ede5f2549db960d5986c90d52320f56d95c4e96b55e9198a2556264002966b4cd6380073db\",\"name\":\"mdast-util-phrasing\",\"version\":\"4.1.0\"},\"mdast-util-to-hast-13.2.1.tgz\":{\"integrity\":\"cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71cb6cab6c29e6f4ec2c871aca66e552b8a24dc65dd02c16b426cbbeb3b36020d9a16c8c355f2c67b92b8f4f454a7b22262dd656c1cb33893a0eaff268fc825c\",\"name\":\"mdast-util-to-hast\",\"version\":\"13.2.1\"},\"mdast-util-to-markdown-2.1.2.tgz\":{\"integrity\":\"xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c63ebcc0c4ef19754e2a89e6a20e8bc3224aad85d93ef97069b6abc938cb87d2eebe8bc1fca007fa4be2f068e3fbbac98ec162db79e4531450bf52aa4aba0ca8\",\"name\":\"mdast-util-to-markdown\",\"version\":\"2.1.2\"},\"mdast-util-to-string-4.0.0.tgz\":{\"integrity\":\"0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d07e38bc38a69f9d45d18c2fc522529b47820ce25346598dd11d72061e072e3f70895d439f44285c66ef1405a3da1488b554e50a6045d61a8a948c9405514b3e\",\"name\":\"mdast-util-to-string\",\"version\":\"4.0.0\"},\"merge-stream-2.0.0.tgz\":{\"integrity\":\"abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"69bbffa8e72e3df9375113df0f39995352ca9aec3c913fb49c81ef2ab2a016bc227e897f76859c740e19aac590f0436b14a91debb31fa68fcba2f6c852c6eddf\",\"name\":\"merge-stream\",\"version\":\"2.0.0\"},\"merge2-1.4.1.tgz\":{\"integrity\":\"8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f2aed51203095b827cb5c7d53f2f20d3d35c43065d6f0144aa17bf5999282338e7ff74c60f0b4e098b571b10373bcb4fce97330820e0bfe3f63f9cb4d1924e3a\",\"name\":\"merge2\",\"version\":\"1.4.1\"},\"meshoptimizer-0.18.1.tgz\":{\"integrity\":\"ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"661a08a0bed3355e2ce41ebeaf1e660bffdfc3cfcf386c8dc52fc36720897a2675d9270b7d5c1113f19fb31c224e4318603e4398adbf2579c4557a8be2b17e4b\",\"name\":\"meshoptimizer\",\"version\":\"0.18.1\"},\"micromark-4.0.2.tgz\":{\"integrity\":\"zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ce97bdf10ea4bdabe90abd4d3d548231e6c229f0fb080d8da99fabca478d84e348241a5cd6d14ab7d86e70b1b085ade3353348f251e972d5895a88a6545e0f7c\",\"name\":\"micromark\",\"version\":\"4.0.2\"},\"micromark-core-commonmark-2.0.3.tgz\":{\"integrity\":\"RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"44306b1c4312c5514b83ac6f9d799bd40cabd96ccb0168de4804c0a31c0a60957de1378d6af82821d0346bdcadcc3495cc1cb660a14af9e9823ce1226cb782ae\",\"name\":\"micromark-core-commonmark\",\"version\":\"2.0.3\"},\"micromark-extension-gfm-3.0.0.tgz\":{\"integrity\":\"vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bec280ad0b22726eedd33d86ba09022ad65e86a526df5a1e18157f2954a8ad64b2f1994d02fef2b63161bdaaf2522094258aacf8da04e80161a50bc14cce90e3\",\"name\":\"micromark-extension-gfm\",\"version\":\"3.0.0\"},\"micromark-extension-gfm-autolink-literal-2.1.0.tgz\":{\"integrity\":\"oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0e83b927ce189c810dede100a309681399f361bd06c30e725e56ef6ff35afb365b4d0959a13f2d5f2515f6ee921269f7632fe495738777978f066faa5b472a7\",\"name\":\"micromark-extension-gfm-autolink-literal\",\"version\":\"2.1.0\"},\"micromark-extension-gfm-footnote-2.1.0.tgz\":{\"integrity\":\"/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ff23e1c48d67b670cdb221edccb2989c4def7fd259e9c022b2a5436ae869e02107c656f8ba8393c4e089fbdb39d5b201f14d4dd4527545738a4c8943e41fe0ab\",\"name\":\"micromark-extension-gfm-footnote\",\"version\":\"2.1.0\"},\"micromark-extension-gfm-strikethrough-2.1.0.tgz\":{\"integrity\":\"ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"003563a4e3a48f3d6186464b94189803d711d809dff05e07a9950ee9ee5e0dc3d07744f1c397f12f3cf19c491291f9c3d30ce24868afeec62193f92dbdb7f5bb\",\"name\":\"micromark-extension-gfm-strikethrough\",\"version\":\"2.1.0\"},\"micromark-extension-gfm-table-2.1.1.tgz\":{\"integrity\":\"t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b76394fdd5d78a8011ac2eb259f27886a07badcb75e1ef1fee6d1c6c8e615260f2c88970bf9bc4b68a29b47f083646cbcce6adccab956d098061c6d6a32cfa0e\",\"name\":\"micromark-extension-gfm-table\",\"version\":\"2.1.1\"},\"micromark-extension-gfm-tagfilter-2.0.0.tgz\":{\"integrity\":\"xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c479533a6b824a8b4803c4d6d660c833a5f63b54a25f93fd22e0eda86a2716110ad2a811238c9e0babccc44576760cabd93883fb63d0d74a3e70e85d5407307e\",\"name\":\"micromark-extension-gfm-tagfilter\",\"version\":\"2.0.0\"},\"micromark-extension-gfm-task-list-item-2.1.0.tgz\":{\"integrity\":\"qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a8805986ac6a23a7e32c36054c121ae1e8af0cc9cff8e66ab0dc26437c4d2c4e02c7073ecdf4047dbb3ab73028d878eaf9b87aab917e67cfdc92cacb15859043\",\"name\":\"micromark-extension-gfm-task-list-item\",\"version\":\"2.1.0\"},\"micromark-factory-destination-2.0.1.tgz\":{\"integrity\":\"Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5deeab0dd2659266c5444c694ce9918fd37731a5a66c081da52ac142f085aa17b3527e001ea2476da1277db5586227b1552b3ffeda8e758fc3c618dd0a226720\",\"name\":\"micromark-factory-destination\",\"version\":\"2.0.1\"},\"micromark-factory-label-2.0.1.tgz\":{\"integrity\":\"VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"54531e932404c6a216ef120285c5e7e28936f58137ae7bb2bde5b7c194165aa17836ff56939ae027df4accfbc78e498f5c5f7715721b069e98756dedef5ffb56\",\"name\":\"micromark-factory-label\",\"version\":\"2.0.1\"},\"micromark-factory-space-2.0.1.tgz\":{\"integrity\":\"zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cd19318ed071c4b77649cd1df9f6e712e9ec4e3e3a4965e05dc899987ab49036069dc93f6521a3f7fc142d357de6ea1e6222b98515cfda627df14a3872afcb42\",\"name\":\"micromark-factory-space\",\"version\":\"2.0.1\"},\"micromark-factory-title-2.0.1.tgz\":{\"integrity\":\"5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e5b67edc28e101df5e0a16131ec8f2e931b1a4e1522a028a24f271af6f778d36dfaf2d8a0e85a48416fa4dc3d5078366cda3e132cd45ae6f40647ece0f80a3cf\",\"name\":\"micromark-factory-title\",\"version\":\"2.0.1\"},\"micromark-factory-whitespace-2.0.1.tgz\":{\"integrity\":\"Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"39bd27b99dcf2adfe7d213911f2be80fdb9986bf996bcb05a0ff8e9cc72758ae659e04b300b81060a32bf512553962ea418bb29faba5a865925ddc1fe85f3495\",\"name\":\"micromark-factory-whitespace\",\"version\":\"2.0.1\"},\"micromark-util-character-2.1.1.tgz\":{\"integrity\":\"wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c2ff2d7544c9ded8521451492ada5828e62218fdbebfde87be4e13bbc2a9080b1332ceb28be9d5986875b32bd20ac6b1cf8e49e896f0fbd0c3ea0f7bf8d57aed\",\"name\":\"micromark-util-character\",\"version\":\"2.1.1\"},\"micromark-util-chunked-2.0.1.tgz\":{\"integrity\":\"QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"41434510e3c42df9afbfee3188d836b1161e4bf3fce294d6d130a03f9cdcf45a577ad1d8d1a6fb4b12b201008d09cd5e2b4e39f6ea0b235cb9a0ee5573575b84\",\"name\":\"micromark-util-chunked\",\"version\":\"2.0.1\"},\"micromark-util-classify-character-2.0.1.tgz\":{\"integrity\":\"K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2b4907ccce9a7d6fcc6de59858b8e81d0bf5b2083643d11c707103cd293188ffc469a80dcc29bb4ff58c299deb8cc6ef229bc189983047774a33282d038986d5\",\"name\":\"micromark-util-classify-character\",\"version\":\"2.0.1\"},\"micromark-util-combine-extensions-2.0.1.tgz\":{\"integrity\":\"OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3a70271fc5239b2e7d25cc99c3c2526caf5c1a9755638e0d2a048cec4f4487b0e22d2d84f513507f474e35a183cc41bdca3125e6172a788b23e217d190b1ff06\",\"name\":\"micromark-util-combine-extensions\",\"version\":\"2.0.1\"},\"micromark-util-decode-numeric-character-reference-2.0.2.tgz\":{\"integrity\":\"ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71c51b624e82c1576498240ccabeb8757cf8d847c71a43d09418f9a7b6151b3abc23b0ad8d7649aee6c061ecdfed1a7e6e33ec7a244ea9eec6e9fa0577e944bb\",\"name\":\"micromark-util-decode-numeric-character-reference\",\"version\":\"2.0.2\"},\"micromark-util-decode-string-2.0.1.tgz\":{\"integrity\":\"nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c357fefb163e9e1f5ca7c2c7184ceb1b2bbad1fff523d1b65707025945f68b109d6218147a9087cd9a536a6aa25feb8f443f417735635d7898b4dde96594d51\",\"name\":\"micromark-util-decode-string\",\"version\":\"2.0.1\"},\"micromark-util-encode-2.0.1.tgz\":{\"integrity\":\"c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"737715c76cb82aa527c28a5c3bd6ff482768d8eebb2f0249fd4caa19f6e281a85f7a02fd9b2a041680d8660913edfdfa4f46cbaccf6165301a0321fe3c20178f\",\"name\":\"micromark-util-encode\",\"version\":\"2.0.1\"},\"micromark-util-html-tag-name-2.0.1.tgz\":{\"integrity\":\"2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d9c3448980e1096288f86b3d4f44e2cac935dfa4a7475de184ef325ba04637284e0b8a98167c05d6729f0f71c50085c0e5ce3946b206d6e6f5d46897798775c4\",\"name\":\"micromark-util-html-tag-name\",\"version\":\"2.0.1\"},\"micromark-util-normalize-identifier-2.0.1.tgz\":{\"integrity\":\"sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b313ea9a8ef42f201126cd30d947250023d4504aa5b42909e8f84a74c203b89de049ffd0fbf1887b758a9742236ff1b21fd94ea5491100edb0a7419590bbd2f5\",\"name\":\"micromark-util-normalize-identifier\",\"version\":\"2.0.1\"},\"micromark-util-resolve-all-2.0.1.tgz\":{\"integrity\":\"VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"55d432c455854f6fc51898304272586ded638d0a0d4d2e118e09664a34d496950c6bde47b71f4d1de616e2b1832736e3bc2b25f5e2e3310c0678496caa6cdc1e\",\"name\":\"micromark-util-resolve-all\",\"version\":\"2.0.1\"},\"micromark-util-sanitize-uri-2.0.1.tgz\":{\"integrity\":\"9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4df48a2667f62e18665999079cd4c6e0c6d960a2e8314e8755c03cf3128b8f2a8dea156bf29851d67270e2dafcd5d5f7fa91ab3db9c5bea37cb324af5807501\",\"name\":\"micromark-util-sanitize-uri\",\"version\":\"2.0.1\"},\"micromark-util-subtokenize-2.1.0.tgz\":{\"integrity\":\"XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d02eee79da249cb6f9c47205f0ebe4b1ef919f9403cd103d6ac7b78127ec327416f62826d165ef8dc2f20410c33cdee9a5d7ed96497a4101ca7d2140a009858\",\"name\":\"micromark-util-subtokenize\",\"version\":\"2.1.0\"},\"micromark-util-symbol-2.0.1.tgz\":{\"integrity\":\"vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bece6df00a5ab9df4ddbc9200ab45474479de1427ec1636f89c1cb3f109af4436562e018df5334113cb9cb5bc0df762834f0c54e08446e787a79f684f21e31d1\",\"name\":\"micromark-util-symbol\",\"version\":\"2.0.1\"},\"micromark-util-types-2.0.2.tgz\":{\"integrity\":\"Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"630d04092a49a15885d6a4d4e030ba370b42e1a586b75124cda401f0a3cfc82451f33f5359e5741db1051933be658d70076db39b19c9aa13f24e93950a97874c\",\"name\":\"micromark-util-types\",\"version\":\"2.0.2\"},\"micromatch-4.0.8.tgz\":{\"integrity\":\"PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3d7c1f06162ed210423f0f039f413e58361beda7f77522d558a8b71c6bfce08745e13c85a02d32b3115dd06a31c3b9d2bf84ff3f3109431b18b0488508aa3604\",\"name\":\"micromatch\",\"version\":\"4.0.8\"},\"mime-2.6.0.tgz\":{\"integrity\":\"USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242\",\"name\":\"mime\",\"version\":\"2.6.0\"},\"mime-db-1.52.0.tgz\":{\"integrity\":\"sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be\",\"name\":\"mime-db\",\"version\":\"1.52.0\"},\"mime-types-2.1.35.tgz\":{\"integrity\":\"ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b\",\"name\":\"mime-types\",\"version\":\"2.1.35\"},\"mimic-fn-2.1.0.tgz\":{\"integrity\":\"OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672\",\"name\":\"mimic-fn\",\"version\":\"2.1.0\"},\"mimic-fn-4.0.0.tgz\":{\"integrity\":\"vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bea882d3a0ae8414d47591fe45897cb05acbd3deaf038e4e9392123bab04fccaf58d16c61f80ac9e18bc7f7c0a565ef1f263b802eec8afd0f73b2bf555830527\",\"name\":\"mimic-fn\",\"version\":\"4.0.0\"},\"mimic-function-5.0.1.tgz\":{\"integrity\":\"VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"54fefd5d43f15760a28183f78d6c005054a4bb668aa811fbb9301aa4558206abadb1b983a3de8a639a3cba1e94fbf612227e4ec499d7a7bddb795929a8c20684\",\"name\":\"mimic-function\",\"version\":\"5.0.1\"},\"mimic-response-1.0.1.tgz\":{\"integrity\":\"j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8f911cb67907eda99f57fab91e09a86a5d60d901c5251ada3ad9b1d09a48aa4c6106123f9494a5d67329438e6155aaf03444cea161229a7759e102b4447c6ec5\",\"name\":\"mimic-response\",\"version\":\"1.0.1\"},\"mimic-response-3.1.0.tgz\":{\"integrity\":\"z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf4c9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19\",\"name\":\"mimic-response\",\"version\":\"3.1.0\"},\"mimic-response-4.0.0.tgz\":{\"integrity\":\"e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7b92121fdc4c614d03ceb4fe8e5f2adb37bd0fa79606da3e23c08da5ef9523e2b627f17f9373dd91d4ddcf8c2f1951f8353a68f8d4584d522e31010c31cb0baa\",\"name\":\"mimic-response\",\"version\":\"4.0.0\"},\"mini-svg-data-uri-1.4.4.tgz\":{\"integrity\":\"r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"afd75e0def69e452543d9024dc0e7dc061fb222f58ae38d6c348e6c3f96249b1e5d821e2c978fa15c0d70eed8add38d5017aa225d6b0df1c7095966bf44ea71e\",\"name\":\"mini-svg-data-uri\",\"version\":\"1.4.4\"},\"minimatch-10.2.5.tgz\":{\"integrity\":\"MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3142e454b7ca1980c561e8cfd3b40ebab0cb2d0a5c8e4ec5c3eee35d2d91d9ccd1433479eb21d1bde5393432443af887fa111364a4a4224e5cf93db71a315432\",\"name\":\"minimatch\",\"version\":\"10.2.5\"},\"minimatch-3.1.5.tgz\":{\"integrity\":\"VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5608d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3\",\"name\":\"minimatch\",\"version\":\"3.1.5\"},\"minimatch-5.1.9.tgz\":{\"integrity\":\"7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ee8d70100d91c8c3fb22eec635b6bdbdcd11596180089382641257d862568a9d22915fb070eb2056e63db84f023e2c908641854a586e4a464f6af37bbb573617\",\"name\":\"minimatch\",\"version\":\"5.1.9\"},\"minimatch-8.0.7.tgz\":{\"integrity\":\"V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57ed6e40d773c9bc5ad787bfa74d0766740d35c4e39d12630f183657cc2d92315cb6ae0cee15c5c2ce287a4c933f425e6deabb418b6917239e0408dcf3ccef62\",\"name\":\"minimatch\",\"version\":\"8.0.7\"},\"minimatch-9.0.9.tgz\":{\"integrity\":\"OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"381c0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662\",\"name\":\"minimatch\",\"version\":\"9.0.9\"},\"minimist-1.2.8.tgz\":{\"integrity\":\"2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db2c8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308\",\"name\":\"minimist\",\"version\":\"1.2.8\"},\"minipass-3.3.6.tgz\":{\"integrity\":\"DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0f188d89dc5210afad1c6eb3388925bcd3b09b786f0ab6d4addb7363be14e87293271bc80df3942f95b93f61a17770d392184a3d81aa78d508879a9c3386017f\",\"name\":\"minipass\",\"version\":\"3.3.6\"},\"minipass-4.2.8.tgz\":{\"integrity\":\"fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7cdcee57289fa2548b14be0dce917ec04178aab82a69a297d216973d011d43b34a00df9679ca0a307574f5872e2ff0c7c6b52c61038adcc8ae0dfec8a763977d\",\"name\":\"minipass\",\"version\":\"4.2.8\"},\"minipass-7.1.3.tgz\":{\"integrity\":\"tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b44047a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0\",\"name\":\"minipass\",\"version\":\"7.1.3\"},\"minipass-collect-2.0.1.tgz\":{\"integrity\":\"D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b\",\"name\":\"minipass-collect\",\"version\":\"2.0.1\"},\"minipass-fetch-4.0.1.tgz\":{\"integrity\":\"j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8fb535d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81\",\"name\":\"minipass-fetch\",\"version\":\"4.0.1\"},\"minipass-flush-1.0.7.tgz\":{\"integrity\":\"TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4dba93cfd714c16c874b60f2f3d3f7a1c006506c4a8e32ee47dcfcc385944c60158048f5effe27860a360eee7a8b4166dcf9b7d20e2203c2dca9cb5cefa8c2cc\",\"name\":\"minipass-flush\",\"version\":\"1.0.7\"},\"minipass-pipeline-1.2.4.tgz\":{\"integrity\":\"xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c6e22aedc20eb74f513d1275f60762e1bf9188dbc31587b9247fa080dbc1a86aa941772bbb73dc466399b8704a58ad53c5ff7e710f8731537877acf8e8b64fec\",\"name\":\"minipass-pipeline\",\"version\":\"1.2.4\"},\"minipass-sized-1.0.3.tgz\":{\"integrity\":\"MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"31b9104360938813250360e6ff9718fbd49614437ca73cce5e2eab94ce57c6ad18a9b75ae59432f6c53be5aebbdc513d64ad19b1bafa63988feaef6792d7e0da\",\"name\":\"minipass-sized\",\"version\":\"1.0.3\"},\"minizlib-3.1.0.tgz\":{\"integrity\":\"KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397\",\"name\":\"minizlib\",\"version\":\"3.1.0\"},\"mkdirp-0.5.6.tgz\":{\"integrity\":\"FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"14ffa9f1107c396a45dd86410ab3f982d0039ad5c0a41e4030b9febddc80f8fcb10a3ac2b34d268f2528cecb0edf77300de4f7c0d19d2f127933ffd8aad1c027\",\"name\":\"mkdirp\",\"version\":\"0.5.6\"},\"ms-2.1.3.tgz\":{\"integrity\":\"6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394\",\"name\":\"ms\",\"version\":\"2.1.3\"},\"mz-2.7.0.tgz\":{\"integrity\":\"z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cfcd4634eee79d830486b1a1f4b7b29a8138f98af45a7e4c70721930ae5c7d00a5f8d0d7d3cb0266051cf7fe8c1e78bd216b852e6d59dc74c25eedb3f5f37ad9\",\"name\":\"mz\",\"version\":\"2.7.0\"},\"nanoid-3.3.11.tgz\":{\"integrity\":\"N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"37c4a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb\",\"name\":\"nanoid\",\"version\":\"3.3.11\"},\"napi-postinstall-0.3.4.tgz\":{\"integrity\":\"PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3c72397f53b410fe7127d81098518c4ba21972b56f4e3a578f3ecd6b8d604c4ede13684ad75960d3808408260412375cd7b115e033be7e4184b6ded3a5369389\",\"name\":\"napi-postinstall\",\"version\":\"0.3.4\"},\"natural-compare-1.4.0.tgz\":{\"integrity\":\"OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b\",\"name\":\"natural-compare\",\"version\":\"1.4.0\"},\"negotiator-1.0.0.tgz\":{\"integrity\":\"8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a\",\"name\":\"negotiator\",\"version\":\"1.0.0\"},\"node-abi-4.28.0.tgz\":{\"integrity\":\"Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"41fa795d92f57090ce69b393f07e609ea31398ce0d8ef6331e9e08fcab7f4a5efa39590e0411d11653eca46574858bcca2a42cca91634ff629eca9b46de5d6f6\",\"name\":\"node-abi\",\"version\":\"4.28.0\"},\"node-addon-api-1.7.2.tgz\":{\"integrity\":\"ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"89b3cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce\",\"name\":\"node-addon-api\",\"version\":\"1.7.2\"},\"node-addon-api-7.1.1.tgz\":{\"integrity\":\"5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e66ddbb32ae3156135c5fee7cfb61774de2e76756d5caebf61f827e6a9da84be9b0a47f6c8ab789379ee4ca02d4f8af7206f09351da772c20c759b80cc98c741\",\"name\":\"node-addon-api\",\"version\":\"7.1.1\"},\"node-api-version-0.2.1.tgz\":{\"integrity\":\"2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db13ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1\",\"name\":\"node-api-version\",\"version\":\"0.2.1\"},\"node-exports-info-1.6.0.tgz\":{\"integrity\":\"pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a72152eb7a6d8adfcfe56a9492df9451f7bee287af1fe6c578888f3dd7dbd2915e604bbfd442e726ee65fb911c4ca60be4cef36806bb4bc75dcb0817ca9a8a0b\",\"name\":\"node-exports-info\",\"version\":\"1.6.0\"},\"node-fetch-2.7.0.tgz\":{\"integrity\":\"c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7381517d49bf75b71667b53ed56ab40300b214bfb79edd9b130d39c1fc52cfe0d6a56b22b609928189b2d9d41d5b2282d7af7810b3ea32cfd8cd448da332edf0\",\"name\":\"node-fetch\",\"version\":\"2.7.0\"},\"node-fetch-h2-2.3.0.tgz\":{\"integrity\":\"ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a1f456f7801bd13e003a1e4593cb7487c3815ab9a36f4492076d318751fc6273d5f4427e7f900ca18494436ce027822ad8700ad08da5e7f35eaaef18cc54b71e\",\"name\":\"node-fetch-h2\",\"version\":\"2.3.0\"},\"node-gyp-11.5.0.tgz\":{\"integrity\":\"ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"adaecabe58719f957d4a5caeb34ca031ada1f94a84c4fa942247e4ecf73c4132d3f79e892d2cb9d6e585c07b48632d2f23c701e010e173f4b4dfef3cd0ccbf2d\",\"name\":\"node-gyp\",\"version\":\"11.5.0\"},\"node-readfiles-0.2.0.tgz\":{\"integrity\":\"SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"494d3465aadec4d944e118dd9bcdef825b7963dca243e5c8d57a5f95695beeaed44cdd49508b66ebdc4c7a24024f1b537e7cedfbcdd3f02c7ebc8d840fef950c\",\"name\":\"node-readfiles\",\"version\":\"0.2.0\"},\"node-releases-2.0.37.tgz\":{\"integrity\":\"1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d61e60299085fa93bfa3722ab79269ef073dac7dde249d3e9e1fc2228891c2347175efe1007c8b3d760de15dc2a8a01b8993d2789152587989b1b92272d6b412\",\"name\":\"node-releases\",\"version\":\"2.0.37\"},\"nopt-8.1.0.tgz\":{\"integrity\":\"ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec\",\"name\":\"nopt\",\"version\":\"8.1.0\"},\"normalize-path-3.0.0.tgz\":{\"integrity\":\"6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c\",\"name\":\"normalize-path\",\"version\":\"3.0.0\"},\"normalize-url-6.1.0.tgz\":{\"integrity\":\"DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e52fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec\",\"name\":\"normalize-url\",\"version\":\"6.1.0\"},\"normalize-url-8.1.1.tgz\":{\"integrity\":\"JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2587340cf969196078d241f9834ee0193ad8b8ca95eb9de4dee04a63ab884cf59db37334a2fdc66961a9f656c4dc1ce7831f3e5e47f382f0126fdbe4f490c55d\",\"name\":\"normalize-url\",\"version\":\"8.1.1\"},\"npm-run-path-4.0.1.tgz\":{\"integrity\":\"S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4b8f16cd95bbefbce1348ae7ee0c4e94848d02a8bd642fee4059d175b7881e1661080e94aa990e4fc4f51bb06f7dd80fe04afc805e2c51b692d22ed0bc87c25b\",\"name\":\"npm-run-path\",\"version\":\"4.0.1\"},\"npm-run-path-5.3.0.tgz\":{\"integrity\":\"ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a69c13b62259ab43bf6a2d33ef27ee76d069588a3133cc84ea71e2d57e3b785476116391a9f6eee829cf94db2378debcdde4f4a86e87fcfc9ff5f09cbe39e79d\",\"name\":\"npm-run-path\",\"version\":\"5.3.0\"},\"oas-kit-common-1.0.8.tgz\":{\"integrity\":\"pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a494d2dbe4f4a062308231a9c3bb08454f1140c714a0a0835852dd06a281d813661a96c1307dac76a01a397520f0ece89d91d4d0beef7c9bb59891448980d639\",\"name\":\"oas-kit-common\",\"version\":\"1.0.8\"},\"oas-linter-3.2.2.tgz\":{\"integrity\":\"KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2841a33c35685392bab30828f6125503fa981a5c1f6c5c7e2a0d9007f91deebcd5e4df0de4c83a3e5b2808ca21567426a3ea7325aa7f17ad74a93a1d2b379c19\",\"name\":\"oas-linter\",\"version\":\"3.2.2\"},\"oas-resolver-2.5.6.tgz\":{\"integrity\":\"Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"631e4f590359a267c484f3cea6115b64a8bd5bddc2a1c423d7c3650f63dae06599cdd669489bd8c288aebab448ee6dd2a5c0a1ae73b4f2192e4032f7146b1515\",\"name\":\"oas-resolver\",\"version\":\"2.5.6\"},\"oas-schema-walker-1.1.5.tgz\":{\"integrity\":\"2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db2b9c7a7ab56bd60f99e344c6851af50c2bb7d445923a9a3000355fe53bb1b6f402a05e4c874c1e4cbd49043a88df786cee4d5b45b84d16177ab1be05d02f01\",\"name\":\"oas-schema-walker\",\"version\":\"1.1.5\"},\"oas-validator-5.0.8.tgz\":{\"integrity\":\"cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"72edb4fc71393791caa95ca0b3776df7879825f062d13b19bcf5570e16d74078848adc8337e45139395e79fa0a44a289f5d1401762419031e0bd68f4b232869b\",\"name\":\"oas-validator\",\"version\":\"5.0.8\"},\"object-assign-4.1.1.tgz\":{\"integrity\":\"rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52\",\"name\":\"object-assign\",\"version\":\"4.1.1\"},\"object-hash-3.0.0.tgz\":{\"integrity\":\"RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4529fd17af0f8c7f47aad96db129ea602d575e859ef418eee7edb5dd1f7c70d1adb5a83dabdc80393cdd6ecaaf21aeda366e567df059169598af6696ae495603\",\"name\":\"object-hash\",\"version\":\"3.0.0\"},\"object-inspect-1.13.4.tgz\":{\"integrity\":\"W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5baee22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b\",\"name\":\"object-inspect\",\"version\":\"1.13.4\"},\"object-is-1.1.6.tgz\":{\"integrity\":\"F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17c719f8a7c69521a2d3d9494fbfcd77a28967dca0b6f602d3f51860b23d9e640a2cc9f276907dcaf6eff4ad6e4a412eec553dbd83e65702e0df6f2d5fea2ddd\",\"name\":\"object-is\",\"version\":\"1.1.6\"},\"object-keys-1.1.1.tgz\":{\"integrity\":\"NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c\",\"name\":\"object-keys\",\"version\":\"1.1.1\"},\"object.assign-4.1.7.tgz\":{\"integrity\":\"nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9cadbc58ea3e4088c190376e4c8344e09905fd42492b27f6109c6f24a7db943a7283443ea643873532f4430cba34fe85844fc49f357bdc1c71a9c25a5d8f5a9f\",\"name\":\"object.assign\",\"version\":\"4.1.7\"},\"object.entries-1.1.9.tgz\":{\"integrity\":\"8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f2efe17d7151043d4ed213d48e2a0b8685851d19adead280e3fbd93f272406bd7c975284f6e1eb15a15a522f0c0d14e98b8b9a936828c8f4d23492d75f69361f\",\"name\":\"object.entries\",\"version\":\"1.1.9\"},\"object.fromentries-2.0.8.tgz\":{\"integrity\":\"k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93a136d45cf24ac48ae5adb529100305dfcd1a77917a014ee692c77dd40ba510c44d4349b9e2d7b37582cf2437b454436206eadca1c65df4db8b66ecf1643aad\",\"name\":\"object.fromentries\",\"version\":\"2.0.8\"},\"object.groupby-1.0.3.tgz\":{\"integrity\":\"+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f8b872dd3413bb35c8e617af87cb011aa6e6bab1db6c88c08b46784bade7b6154b98bc5f6e3e13e786b809f66b5c8aedf623f899500f60ca3fbfdf6d6a3df08d\",\"name\":\"object.groupby\",\"version\":\"1.0.3\"},\"object.values-1.2.1.tgz\":{\"integrity\":\"gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8176a1e9a66b714c635a0db3476330a2e3f6787942073755e29ca0b9d7a168a5d2196e2fd80b114142be970c178628ba28565cba7127992528629e425e26f1b4\",\"name\":\"object.values\",\"version\":\"1.2.1\"},\"objectorarray-1.0.5.tgz\":{\"integrity\":\"eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7892436248491456c1040c5e87cc56fb0787964236f27d9975057f27f0cd7d67d22a51847f6c5c7c06d94efdeb8845c70212fd495393b36a519978924dfefcc6\",\"name\":\"objectorarray\",\"version\":\"1.0.5\"},\"on-exit-leak-free-2.1.2.tgz\":{\"integrity\":\"0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1e24963a8572c67f5b9d1f07cd7ed06a1fe83bdc4538079d389d978aa73d6c61129a7c0821c31109ba70763bbac36642f83c67ec3159d35d9d848e26dba9cb0\",\"name\":\"on-exit-leak-free\",\"version\":\"2.1.2\"},\"once-1.4.0.tgz\":{\"integrity\":\"lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb\",\"name\":\"once\",\"version\":\"1.4.0\"},\"onetime-5.1.2.tgz\":{\"integrity\":\"kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a\",\"name\":\"onetime\",\"version\":\"5.1.2\"},\"onetime-6.0.0.tgz\":{\"integrity\":\"1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d45951fa08d72bb5fe02c007b28df9327c8de4aa86c09462ff7d5fb7ac74335f7886ded2fab580bddecf1ecb3dc5228ccc4d1ab2fd69c881da258abe05b69c01\",\"name\":\"onetime\",\"version\":\"6.0.0\"},\"onetime-7.0.0.tgz\":{\"integrity\":\"VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"55726373cec549c17cf2e69f4b726594382f026f9cfd295fcf4ea5a2b8f6b80637e2b954bb436dfaff30ade88899cae00238c81e9d6b5e94c394b386c36f56c1\",\"name\":\"onetime\",\"version\":\"7.0.0\"},\"open-11.0.0.tgz\":{\"integrity\":\"smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b26b16bf62f31633f4df19af168277df5b2cea1fa38b17c0e14515fc1b22caebb86093df37e1484063888afe30f7ff8ca0791f909db650869059154545f1fa57\",\"name\":\"open\",\"version\":\"11.0.0\"},\"open-8.4.2.tgz\":{\"integrity\":\"7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ef1f353422fbd7da0d6ecabfde687e855ac05a616e11852aaeafc8c37914cc7f117b2a53f5043404ba094bbfc6f64e8df355e35b8a875ad8d6c1effd78bcb511\",\"name\":\"open\",\"version\":\"8.4.2\"},\"openapi3-ts-2.0.2.tgz\":{\"integrity\":\"TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f185804ca2ac7d7eb5f23a09d11ee7e341f3d7a264c81d82a148a27a8c77e3d77912f0e10886f984f024ee4322ad8e35adb408d7e433f1335be66a5129a3c43\",\"name\":\"openapi3-ts\",\"version\":\"2.0.2\"},\"optionator-0.9.4.tgz\":{\"integrity\":\"6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6\",\"name\":\"optionator\",\"version\":\"0.9.4\"},\"ora-5.4.1.tgz\":{\"integrity\":\"5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e5be98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9\",\"name\":\"ora\",\"version\":\"5.4.1\"},\"own-keys-1.0.1.tgz\":{\"integrity\":\"qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a853b22b93e389665df9040887ed6385d6fd2e9c53174aacecf9bca39407619d0cdef2aa4aacec65a101ea85a5c59faadac241308fcab607763796704284477e\",\"name\":\"own-keys\",\"version\":\"1.0.1\"},\"p-cancelable-2.1.1.tgz\":{\"integrity\":\"BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0593abde74501ce9ed5234eb1fcf8b879e2c98a1e81f2babf167b557c0d2315ae5e40da66a538ec2e2519ca4438d29e4a1e061e1ab7a0701276f923b265df5c2\",\"name\":\"p-cancelable\",\"version\":\"2.1.1\"},\"p-cancelable-3.0.0.tgz\":{\"integrity\":\"mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9a55604773c6bb3968d0c993764e1c5ea5d69704032e738d4c083ab26eb65e430912247137718bdd27df918beac289db90905cac8ed4befe5987dca3be7da253\",\"name\":\"p-cancelable\",\"version\":\"3.0.0\"},\"p-limit-2.3.0.tgz\":{\"integrity\":\"//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ffff3c985592271f25c42cf07400014c92f6332581d76f9e218ecc0cbd92a8b98091e294f6ac51bd6b92c938e6dc5526a4110cb857dc90022a11a546503c5beb\",\"name\":\"p-limit\",\"version\":\"2.3.0\"},\"p-limit-3.1.0.tgz\":{\"integrity\":\"TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945\",\"name\":\"p-limit\",\"version\":\"3.1.0\"},\"p-locate-3.0.0.tgz\":{\"integrity\":\"x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c7ed76c3f4e8fb81857e0261044a620dc2e8cd12467a063e122effcf4b522e4326c4664dc9b54c49f5a3f5a267f19e4573b74150d24e39580fbf61fb230ba549\",\"name\":\"p-locate\",\"version\":\"3.0.0\"},\"p-locate-5.0.0.tgz\":{\"integrity\":\"LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f\",\"name\":\"p-locate\",\"version\":\"5.0.0\"},\"p-map-7.0.4.tgz\":{\"integrity\":\"tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b64010130f32b0cce6921830f24fb553f88f856361ca42a74a4e11779ccba0f242b8968644fa3a629a2cad981ac472b30c774359666f13f4a4ee1b0bd97fc2a5\",\"name\":\"p-map\",\"version\":\"7.0.4\"},\"p-try-2.2.0.tgz\":{\"integrity\":\"R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4789cf0154c053407d0f7e7f1a4dee25fffb5d86d0732a2148a76f03121148d821165e1eef5855a069c1350cfd716697c4ed88d742930bede331dbefa0ac3a75\",\"name\":\"p-try\",\"version\":\"2.2.0\"},\"package-json-from-dist-1.0.1.tgz\":{\"integrity\":\"UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5046484b7fdbcb8382f2f2f73f67535d1113a5e6cb236362239bc8ae3683ff952dae4157fed35bc234d2440182ffeec2028da921c05a4605a670104772c68223\",\"name\":\"package-json-from-dist\",\"version\":\"1.0.1\"},\"parent-module-1.0.1.tgz\":{\"integrity\":\"GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa\",\"name\":\"parent-module\",\"version\":\"1.0.1\"},\"parse-entities-4.0.2.tgz\":{\"integrity\":\"GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"186d804185a82e02fcefb81020a7913c63b5c45f7e786d6e8c86f9b284b980fbcb435cb6a3c14bf74c3641635d7fd237eb5329a7bef6e9cfa58f7534a8ad6e1b\",\"name\":\"parse-entities\",\"version\":\"4.0.2\"},\"parse5-5.1.1.tgz\":{\"integrity\":\"ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ba0ab80c52343ed6fe5968c074e2b5ebebbf9c77e222b704fac87c91931a3345a595028b23dace52ae9cd9bedcc0f9177737d0112aafa2a2baba0ed4fd8cb3ba\",\"name\":\"parse5\",\"version\":\"5.1.1\"},\"parse5-6.0.1.tgz\":{\"integrity\":\"Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"39f9ff0931734464d3c70a4d12cf4f3fdde05d2847713ab6e799f345848a7bc024569658eded5fa664df3b2a08be33f91c6ed9d9933b552f4f3e14065b6a4ea7\",\"name\":\"parse5\",\"version\":\"6.0.1\"},\"parse5-htmlparser2-tree-adapter-6.0.1.tgz\":{\"integrity\":\"qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a8fb96bdb2e0bc31a294a73906889c468be54f832d613e897c9c8138c0ec2a8893f868ae3f9ab2acf0a747d1dc3c40882499998798d19ddc8d4e19e185bfef94\",\"name\":\"parse5-htmlparser2-tree-adapter\",\"version\":\"6.0.1\"},\"path-exists-3.0.0.tgz\":{\"integrity\":\"bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6e90bb198c220d8438c182def8503c96146385008c7101ae4a0186a83920fd07ab456c3d0a61914f4892395452649dbd34c2d9808cea6a58c9eb7a1a2f834825\",\"name\":\"path-exists\",\"version\":\"3.0.0\"},\"path-exists-4.0.0.tgz\":{\"integrity\":\"ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff\",\"name\":\"path-exists\",\"version\":\"4.0.0\"},\"path-is-absolute-1.0.1.tgz\":{\"integrity\":\"AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242\",\"name\":\"path-is-absolute\",\"version\":\"1.0.1\"},\"path-key-3.1.1.tgz\":{\"integrity\":\"ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9\",\"name\":\"path-key\",\"version\":\"3.1.1\"},\"path-key-4.0.0.tgz\":{\"integrity\":\"haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"85a444ca9abbc6433b12b7e0232034cfe063e0018a94c49d9501368ef268ea1b960f511d90a615f86fd3e27ab4604176be04d3f24a8c14aa35b879fde74af849\",\"name\":\"path-key\",\"version\":\"4.0.0\"},\"path-parse-1.0.7.tgz\":{\"integrity\":\"LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3\",\"name\":\"path-parse\",\"version\":\"1.0.7\"},\"path-scurry-1.11.1.tgz\":{\"integrity\":\"Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c\",\"name\":\"path-scurry\",\"version\":\"1.11.1\"},\"path-scurry-2.0.2.tgz\":{\"integrity\":\"3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dcefe2555b0900fb0e9e9c1621e0fe77acffecf9aa029c9078f52d0a77636ad8fff48e4bca51efb79aa5b856814f7239877af57a37d1d39e9cf850aff8d9cd5e\",\"name\":\"path-scurry\",\"version\":\"2.0.2\"},\"pe-library-0.4.1.tgz\":{\"integrity\":\"eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"791581e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67\",\"name\":\"pe-library\",\"version\":\"0.4.1\"},\"pegjs-0.10.0.tgz\":{\"integrity\":\"qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a88e7ea053441a2dcbe470310f03762c0e0683b8ab17bd19b36e5e7618e577d41e98e829d026ef32d6c570cbc5b44a353a2b723eb702ce440507c24ffe1c60a3\",\"name\":\"pegjs\",\"version\":\"0.10.0\"},\"pend-1.2.0.tgz\":{\"integrity\":\"F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1776acbf8d94b97721773b7ec57a9f5b538695505efa6c5ada6a88d29839c801d93ef16663763a76b49ffc643503ce9681610df4ace1fd6ae029aea219c1d72e\",\"name\":\"pend\",\"version\":\"1.2.0\"},\"picocolors-1.1.1.tgz\":{\"integrity\":\"xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\",\"name\":\"picocolors\",\"version\":\"1.1.1\"},\"picomatch-2.3.2.tgz\":{\"integrity\":\"V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57bfaf404274e99f9ce6d4b27bc4be9c751f239d71a172178c743df5c42d294910aaa3b590efca08951f657b81e3b87f60194385a8761f785d5065e7f227b4a0\",\"name\":\"picomatch\",\"version\":\"2.3.2\"},\"picomatch-4.0.4.tgz\":{\"integrity\":\"QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec\",\"name\":\"picomatch\",\"version\":\"4.0.4\"},\"pidtree-0.6.0.tgz\":{\"integrity\":\"eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"786d9d593570e5bcea191ced9c7131733371b79546b04e8ec137821b77dd51ff4a06c6733b7479388208cd647e89903436d67e44355d6a813674ad5c9fa8c7e2\",\"name\":\"pidtree\",\"version\":\"0.6.0\"},\"pify-2.3.0.tgz\":{\"integrity\":\"udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b9d82c018f9f4e7befee423b69ac5bab058d6f4007881d2a04ef3d3d928f9284e618e81d6eb1c3283fb40765f8b937c9fc54f5474f6bf604ec8d48cd268b6ea2\",\"name\":\"pify\",\"version\":\"2.3.0\"},\"pino-10.3.1.tgz\":{\"integrity\":\"r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"af7e321ff1a54292996d4d41bc516a3a3848491a3530dc75b5662c62f9a3e8a2111d23cc4f6fb21ce11bd521ba34cbd1a07445d1ad3b9023a8c7ff726a4975be\",\"name\":\"pino\",\"version\":\"10.3.1\"},\"pino-abstract-transport-3.0.0.tgz\":{\"integrity\":\"wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c257d473353e9fb1f2fc76b98fd6bf819372ed67b9f9c5e9f182fe5fe3c6f12d0a5f1c3b9ff257037738e98d334339c827cdd44498b0cbb2e1e7a58ba2436ec6\",\"name\":\"pino-abstract-transport\",\"version\":\"3.0.0\"},\"pino-pretty-13.1.3.tgz\":{\"integrity\":\"ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b6d5d19243b3e96582f7929e63dfb1c562fa02d226c1bc8c1eb2f5992c2ac16f6efaf2e9fd620496f1ef0920e0d313bf0f3ae0833d73bf7acde68bd3455a302a\",\"name\":\"pino-pretty\",\"version\":\"13.1.3\"},\"pino-roll-4.0.0.tgz\":{\"integrity\":\"axI1aQaIxXdw1F4OFFli1EDxIrdYNGLowkw/ZoZogX8oCSLHUghzwVVXUS8U+xD/Savwa5IXpiXmsSGKFX/7Sg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6b1235690688c57770d45e0e145962d440f122b7583462e8c24c3f668668817f280922c7520873c15557512f14fb10ff49abf06b9217a625e6b1218a157ffb4a\",\"name\":\"pino-roll\",\"version\":\"4.0.0\"},\"pino-std-serializers-7.1.0.tgz\":{\"integrity\":\"BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06774f1faeff271184c518225f5757d30d45bd9724e566b869a97dd7df12ad18598c7dc6c4a4142880676094dd8f61c3377510012d3a1e57dc49b423d8e1e66b\",\"name\":\"pino-std-serializers\",\"version\":\"7.1.0\"},\"pirates-4.0.7.tgz\":{\"integrity\":\"TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4dfc92aecff99e6f1f4090dc043b949e0dd53942ac77b4beceabdb3938865c77f15f8c0adf56ab77e86836ebe489c33fd981739690e000139ebca4ac0781bf14\",\"name\":\"pirates\",\"version\":\"4.0.7\"},\"pkg-up-3.1.0.tgz\":{\"integrity\":\"nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c3cb04e1164d62e0140ae2dc0f43a4c0e114fc6c363deb27ae0950562f778f0110a210a0d14ab3466c5220509a4ba7e5de211eb9bfcadaed6b89385501b6430\",\"name\":\"pkg-up\",\"version\":\"3.1.0\"},\"plist-3.1.0.tgz\":{\"integrity\":\"uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bb2b2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481\",\"name\":\"plist\",\"version\":\"3.1.0\"},\"pluralize-8.0.0.tgz\":{\"integrity\":\"Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"35cdc84f9c87cdf9537db8e0a967023e9a3b0da2b2e059e907497fcc2016d1373b8f1022baa4b11dab27b41dc3efcf3b2d2ac0f7790327d217a2fc49631c8b08\",\"name\":\"pluralize\",\"version\":\"8.0.0\"},\"possible-typed-array-names-1.1.0.tgz\":{\"integrity\":\"/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ffee55153721243a158f76e1a2a8ba51eca6703d340c0c1bd672706a6ccfbc712ccc9e05a45e9234d6d46ce4bcc88e7aa87cdd57c78ad2a11f3928a87644ddc6\",\"name\":\"possible-typed-array-names\",\"version\":\"1.1.0\"},\"postcss-8.5.10.tgz\":{\"integrity\":\"pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a4c307c4139928553a1e0019e1ec869f05c5fc4bcf186a94af4327679fbdf78f39c305b8d645bdd40e0b386c521e182e8199920a12f902512535dc253607272d\",\"name\":\"postcss\",\"version\":\"8.5.10\"},\"postcss-import-15.1.0.tgz\":{\"integrity\":\"hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"869afe274e41d855585005c778ad58c88dbaec9fdd0c384c53a07a722be6f21498d636099c15f1cca0ca0ecc33266b4b1ebcab8e19c38eaaa9ff8f6df0500b7b\",\"name\":\"postcss-import\",\"version\":\"15.1.0\"},\"postcss-js-4.1.0.tgz\":{\"integrity\":\"oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0800e4ea808a3bab610ec1b85bf146a561e3ccbd8a0879163660a9ed7691505cda2c4aedef2eb9e21a0987f4e2acfea0247e88f9a01de57bfee620d5b52c27f\",\"name\":\"postcss-js\",\"version\":\"4.1.0\"},\"postcss-load-config-6.0.1.tgz\":{\"integrity\":\"oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0fb53338a1eacbf945e6c7ef77cad65537cd91ae563fc0f515f08783c45af32235ce2c5d6937e12628f2dbb9bbca1d3d870b6d315ec0801f667e08a57a3b3fe\",\"name\":\"postcss-load-config\",\"version\":\"6.0.1\"},\"postcss-nested-6.2.0.tgz\":{\"integrity\":\"HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1d06eddbc2ae942e402731be719b63f64bca07ddc214274bbe88355852dfd43fb198cbcf1a506cb64a531197cae7e00df617c9a1cc81142362ab24b8f1ba60cd\",\"name\":\"postcss-nested\",\"version\":\"6.2.0\"},\"postcss-selector-parser-6.0.10.tgz\":{\"integrity\":\"IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"210ed365da1aa9b4fe2c2a52860e3a8e7655961583db0ea241801c6177c701167b5f5b7f50686171e403b395f4706a8abd894734ebafece6b5c666f4a10b80df\",\"name\":\"postcss-selector-parser\",\"version\":\"6.0.10\"},\"postcss-selector-parser-6.1.2.tgz\":{\"integrity\":\"Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"43ca907cf899f931ceff766b3ab3b470924a7e96026a0b4c5245db9c47e68148f05e0eb3fd605e3b24bd00f0413c24d288357eb384b0406bbcc85b2231122e76\",\"name\":\"postcss-selector-parser\",\"version\":\"6.1.2\"},\"postcss-value-parser-4.2.0.tgz\":{\"integrity\":\"1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779\",\"name\":\"postcss-value-parser\",\"version\":\"4.2.0\"},\"postject-1.0.0-alpha.6.tgz\":{\"integrity\":\"b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0\",\"name\":\"postject\",\"version\":\"1.0.0-alpha.6\"},\"powershell-utils-0.1.0.tgz\":{\"integrity\":\"dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74cd2356e5c93ec0cde83bd1a5e6b8f38b4251a3225d68ee0a7fbe1c64ea516cc60e3bf9b5990466574027f50c96a458185ac3fdeb41ca8e3fc4eb82fec9d7d8\",\"name\":\"powershell-utils\",\"version\":\"0.1.0\"},\"prelude-ls-1.2.1.tgz\":{\"integrity\":\"vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6\",\"name\":\"prelude-ls\",\"version\":\"1.2.1\"},\"prettier-3.8.3.tgz\":{\"integrity\":\"7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ee280f4cce777061cc5bcc56b954f2762d8a3b6df754589337217984b26aa629477e69fc0bc80f7fe3d2edd513eb861c5c56e23066714bda424b12ff0f19bf27\",\"name\":\"prettier\",\"version\":\"3.8.3\"},\"proc-log-5.0.0.tgz\":{\"integrity\":\"Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d\",\"name\":\"proc-log\",\"version\":\"5.0.0\"},\"process-warning-5.0.0.tgz\":{\"integrity\":\"a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6b7f6df40a47371d8be3e1c19d02aac711cdb35afb285f889ed77c43f8356d487aab4588a7dbe83d727fc748fe64be39285d6925df7eab68cb21131fbc4b2190\",\"name\":\"process-warning\",\"version\":\"5.0.0\"},\"progress-2.0.3.tgz\":{\"integrity\":\"7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ecf887b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0\",\"name\":\"progress\",\"version\":\"2.0.3\"},\"promise-retry-2.0.1.tgz\":{\"integrity\":\"y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cbe58a165051f011979ec3652071463d99b20dfdc314ca0b85a7e5027c99815eab1bac6ef89c1eb13a3643d47a5f0626b66c001429009377b7e6311da1e87fde\",\"name\":\"promise-retry\",\"version\":\"2.0.1\"},\"prompts-2.4.2.tgz\":{\"integrity\":\"NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"37136ffe42e0b8203ba778c4f282f668406cac95a001a901a609a02ba9693d657e5ae3a663aaf6ff36c05673fe4fc6d0940d27cc75d2252256d07abbca5683d9\",\"name\":\"prompts\",\"version\":\"2.4.2\"},\"prop-types-15.8.1.tgz\":{\"integrity\":\"oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972\",\"name\":\"prop-types\",\"version\":\"15.8.1\"},\"proper-lockfile-4.1.2.tgz\":{\"integrity\":\"TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4e334f6e537807001631753cb3d004cf82664319c3d4d34bedb34e63f00a533c9a99cdfbf4558049485cfcad692f69e855bf9799928b2faf1c8f32ec88e00c68\",\"name\":\"proper-lockfile\",\"version\":\"4.1.2\"},\"property-expr-2.0.6.tgz\":{\"integrity\":\"SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"495b66c61444fc21a49f77996354faa42f0d967e85aff96ed66292811b9dd1e0bbdf086319fa00a206e7efc2e40fc6852f4cf3ddb0057ab2929ce97b36512b04\",\"name\":\"property-expr\",\"version\":\"2.0.6\"},\"property-information-7.1.0.tgz\":{\"integrity\":\"TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f0119f97fb20899987cbed33d439cbc167841fa13e587a742226e5ffff4b61e770c4eb0d31c4b12d7cade2cabc9015d757baf908939d44120ac943458990e99\",\"name\":\"property-information\",\"version\":\"7.1.0\"},\"proxy-from-env-1.1.0.tgz\":{\"integrity\":\"D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0fece439109b03d7f5b5d5912b445a091dc63efe7470cc5caf3e17f24e4b4d2503d43930e3b98a24465036e9c8b514e45b082d6944a8d515454481bd65788562\",\"name\":\"proxy-from-env\",\"version\":\"1.1.0\"},\"pump-3.0.4.tgz\":{\"integrity\":\"VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"552eec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70\",\"name\":\"pump\",\"version\":\"3.0.4\"},\"punycode-2.3.1.tgz\":{\"integrity\":\"vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16\",\"name\":\"punycode\",\"version\":\"2.3.1\"},\"queue-microtask-1.2.3.tgz\":{\"integrity\":\"NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4\",\"name\":\"queue-microtask\",\"version\":\"1.2.3\"},\"quick-format-unescaped-4.0.4.tgz\":{\"integrity\":\"tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b580b5435860c91b87825a15fd85ecdb0d79ba73d587ca9fbbfa824df85361a99ac3b7f286e98a6b6c86a5d4a8f3bbd8df6ac87258fee1f59841750cb3d107be\",\"name\":\"quick-format-unescaped\",\"version\":\"4.0.4\"},\"quick-lru-5.1.1.tgz\":{\"integrity\":\"WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5aec802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848\",\"name\":\"quick-lru\",\"version\":\"5.1.1\"},\"react-18.3.1.tgz\":{\"integrity\":\"wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689\",\"name\":\"react\",\"version\":\"18.3.1\"},\"react-dom-18.3.1.tgz\":{\"integrity\":\"5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423\",\"name\":\"react-dom\",\"version\":\"18.3.1\"},\"react-error-boundary-4.1.2.tgz\":{\"integrity\":\"GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1900f167925df80abfa94c5b0a6d54b7398bfecfbe57bcca804f32324b498824170821599cc661f6783eebf35ee8f8cd4971f42fd0a378e11111f467aba0ee6a\",\"name\":\"react-error-boundary\",\"version\":\"4.1.2\"},\"react-fast-compare-3.2.2.tgz\":{\"integrity\":\"nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9ec3be292360a3549b26a24461113d111ce8ed8b586e8bbf3aa8d240ac55ee370aa31efebac8945593800be5e70ce0015e08104e7a346350a9567b9611cd5ba1\",\"name\":\"react-fast-compare\",\"version\":\"3.2.2\"},\"react-helmet-6.1.0.tgz\":{\"integrity\":\"4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e2e333118f67943960c6beb534bdd76ca472d611245e628d5e18db008395c39bdc16bb1d61b1f6144c1c3725af5a29e5d74de75e0cd83659ecf5c6bef241625b\",\"name\":\"react-helmet\",\"version\":\"6.1.0\"},\"react-hook-form-7.72.1.tgz\":{\"integrity\":\"RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"461c01a32db281e5598def82f9bc09f20d0d8d3741983949bc05074f14634e649428f62c29f3298644b6b2010ca2db18d376cfdf9f3211896751e672fff0fd22\",\"name\":\"react-hook-form\",\"version\":\"7.72.1\"},\"react-is-16.13.1.tgz\":{\"integrity\":\"24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d\",\"name\":\"react-is\",\"version\":\"16.13.1\"},\"react-lifecycles-compat-3.0.4.tgz\":{\"integrity\":\"fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7c10126c0e8b9ce53d74e536796eda43cc666014975085abf94985f5bd5e7d905acc634efab7174ff89c74a9d89b6a53c1c472955518c16ec7d4f1df2de915cc\",\"name\":\"react-lifecycles-compat\",\"version\":\"3.0.4\"},\"react-markdown-9.1.0.tgz\":{\"integrity\":\"xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5a8a3b890749331a251d1bb9dcd8c38c0d40c158fc8602366d52ba30f57c547ae6bc22a78ff959487c06776e986970b4e74995f3eb3f637150bf4c2c1b7e077\",\"name\":\"react-markdown\",\"version\":\"9.1.0\"},\"react-modal-3.16.3.tgz\":{\"integrity\":\"yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c82611241e5891e4034254edd7b586020149ee3af64187166b5487a99dcf96e0e69ca27fefeb5553e13ab8ac99d2738369e123fb10a92b82dc4a72972cc0b437\",\"name\":\"react-modal\",\"version\":\"3.16.3\"},\"react-refresh-0.17.0.tgz\":{\"integrity\":\"z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cfa17b2bd6d5f3911fb1e442a766f3ae9c90d06930d6e2e809e97d5c15563e0fd38d18fde12909cd44c67ce6b86ecee226f056b501b45aaef09c8d2ccb0dc405\",\"name\":\"react-refresh\",\"version\":\"0.17.0\"},\"react-responsive-10.0.1.tgz\":{\"integrity\":\"OM5/cRvbtUWEX8le8RCT8scA8y2OPtb0Q/IViEyCEM5FBN8lRrkUOZnu87I88A6njxDldvxG+rLBxWiA7/UM9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38ce7f711bdbb545845fc95ef11093f2c700f32d8e3ed6f443f215884c8210ce4504df2546b9143999eef3b23cf00ea78f10e576fc46fab2c1c56880eff50cf6\",\"name\":\"react-responsive\",\"version\":\"10.0.1\"},\"react-router-6.30.3.tgz\":{\"integrity\":\"XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d19e56ca3139a4b4192308b13cfd77191659c7bebd8bb5daf57895f889d2f9e7ff416ce473c9911a2240450e1146084581048b6c56b0f1c31de09e2b0c8ad77\",\"name\":\"react-router\",\"version\":\"6.30.3\"},\"react-router-dom-6.30.3.tgz\":{\"integrity\":\"pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a713dcbf501ccc3e2fb28ec6e19dd329cbe5c4aee0ed336ddff14d18c85fab29eda1cbd82a3f8609ab5f8a01838db2e8cc2e1b6a0b89d117828a0a032576f46a\",\"name\":\"react-router-dom\",\"version\":\"6.30.3\"},\"react-side-effect-2.1.2.tgz\":{\"integrity\":\"PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3d58ce72f54ec8820bad8a32184a43377be660d2ddcb509a8d214db784c3b15402e4aa538a30ef595a11fbfed1cf6c53f7bf03f3f66d15c797c73b0fc19103bf\",\"name\":\"react-side-effect\",\"version\":\"2.1.2\"},\"read-binary-file-arch-1.0.6.tgz\":{\"integrity\":\"BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04d83d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612\",\"name\":\"read-binary-file-arch\",\"version\":\"1.0.6\"},\"read-cache-1.0.0.tgz\":{\"integrity\":\"Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3b076ffc5b7b2233a09bf8b4c6f3436752eb4403517dec386f6a6b1773963102f12dfbb76d2f055610acad208c2b8951e7a63dc9af804e1a13a43093c429a944\",\"name\":\"read-cache\",\"version\":\"1.0.0\"},\"readable-stream-3.6.2.tgz\":{\"integrity\":\"9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0\",\"name\":\"readable-stream\",\"version\":\"3.6.2\"},\"readdirp-3.6.0.tgz\":{\"integrity\":\"hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"84e4b4f3da27f1176ea9d6e1bd0e59dfb0341128ecab3eaa9d171f7ec314df8f7916e4dda929beedb849dbd26f20eb010c41276a7e433eef6ddd3a3d55194ccc\",\"name\":\"readdirp\",\"version\":\"3.6.0\"},\"readdirp-4.1.2.tgz\":{\"integrity\":\"GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"18387090b7f2c162f6b3abc48f286b8be79799f1fa8f52fb244dbb5a1a8b798ce887f0370c16981848f61ff1c56429ff90c7e29bbdc55f11094f0d3a5adc50c2\",\"name\":\"readdirp\",\"version\":\"4.1.2\"},\"real-require-0.2.0.tgz\":{\"integrity\":\"57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7b7ebac633f3824cba8b3808749a1540f5504c1ddfbd53b65bd931cc19d054a1954eb466c9ce3c6c6060c9dc0f4061808fe219facb54d56da39fcd6b66e4616\",\"name\":\"real-require\",\"version\":\"0.2.0\"},\"reflect.getprototypeof-1.0.10.tgz\":{\"integrity\":\"00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d34a3823e0d5ade7e1bfe9d7d2e9728b76e248708f0defb22efe68fe9e9dfd45658ab8a307c135e85b5fc12022e20ded72aad0e25440a904a81446497a160473\",\"name\":\"reflect.getprototypeof\",\"version\":\"1.0.10\"},\"reftools-1.1.9.tgz\":{\"integrity\":\"OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"39579d7bf350135df1050fa86f908a7792b2789614d982276f56e65789d1a0e7eab993e4024c6e39789c49ed4fbea22e659e240f5dec3ca05b47b5050e6962eb\",\"name\":\"reftools\",\"version\":\"1.1.9\"},\"regexp.prototype.flags-1.5.4.tgz\":{\"integrity\":\"dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"758aa035265b0f091a27671e45df688c21a306afa63a6f4b9ad5e7027106c8784dff947b8835b64d1c3787ea3f8c2171bacdcfd8b7d62088b0a3002300d9bb20\",\"name\":\"regexp.prototype.flags\",\"version\":\"1.5.4\"},\"register-scheme-https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17.tgz\":{\"integrity\":\"q5WVbH3w0SUkANl6m2LHwugH9Bw4YpRx3A9Bcjqn/xc=\",\"integrity_algo\":\"sha256\",\"integrity_digest\":\"ab95956c7df0d1252400d97a9b62c7c2e807f41c38629471dc0f41723aa7ff17\",\"name\":\"register-scheme\",\"tarball_url\":\"https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17\",\"version\":\"https://codeload.github.com/devsnek/node-register-scheme/tar.gz/e7cc9a63a1f512565da44cb57316d9fb10750e17\"},\"remark-gfm-4.0.1.tgz\":{\"integrity\":\"1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d6aba87d9d9143d11675e377e12efdf8a131575efae3ec02506a29e423cbd5619d0f4a1c3e9bbdd65ccf19bc163040a9129778da4246430cd17f2a2ff63e3236\",\"name\":\"remark-gfm\",\"version\":\"4.0.1\"},\"remark-parse-11.0.0.tgz\":{\"integrity\":\"FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"142c6528b3469274b96daff5966a588a3314cd7d9eb315b9c50aa35b1c3678715f4b631275a1d520d166863a3ea8dd5685984d8a6ab475901337da47d080eba4\",\"name\":\"remark-parse\",\"version\":\"11.0.0\"},\"remark-rehype-11.1.2.tgz\":{\"integrity\":\"Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e1ee5e7b89a9da128229cdba743c2f542807424959250fc139469c3b1137db4e5dc5a9c38e82ae6ad8b54386018291a06fee9db82578a43ddbe18661ef28cb3\",\"name\":\"remark-rehype\",\"version\":\"11.1.2\"},\"remark-stringify-11.0.0.tgz\":{\"integrity\":\"1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d4e4a62ddddac01fedf2a76810e31acd990db1f553798e1f4ec83371015d5cdabc4e84cde191b0acc9e575ae0aeac99314a0fe19157a3b8f22e99e222a03cfa7\",\"name\":\"remark-stringify\",\"version\":\"11.0.0\"},\"require-directory-2.1.1.tgz\":{\"integrity\":\"fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7c6c4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9\",\"name\":\"require-directory\",\"version\":\"2.1.1\"},\"require-from-string-2.0.2.tgz\":{\"integrity\":\"Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13\",\"name\":\"require-from-string\",\"version\":\"2.0.2\"},\"resedit-1.7.2.tgz\":{\"integrity\":\"vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bc78dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410\",\"name\":\"resedit\",\"version\":\"1.7.2\"},\"reselect-4.1.8.tgz\":{\"integrity\":\"ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"69bf44991f3417fcd04cc35e9de52be1cbfe8d2c0f260225bc4995c0b7abc2b5956e92e506e96cf571f321e4c5cb871e814d8d1c1a77bdad0b28ecd4e6a14461\",\"name\":\"reselect\",\"version\":\"4.1.8\"},\"resolve-1.22.12.tgz\":{\"integrity\":\"TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f2789d7389fe7704f7c7a28b411b03d1613d5152dea8196b1a42bf14c995bf7809bd6caa228edbebb920c49991e6f760b04bd9e3eff7d6b6da8f0a0cdea7c08\",\"name\":\"resolve\",\"version\":\"1.22.12\"},\"resolve-2.0.0-next.6.tgz\":{\"integrity\":\"3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dc999597984c1ad27790c981df38b70cbdb929f902132cb74f0ec69b0ef3e70f0cf56970a0f16722fc02873bb5f9c17789a2b7b29d7c8613f3f0035e8a67497c\",\"name\":\"resolve\",\"version\":\"2.0.0-next.6\"},\"resolve-alpn-1.2.1.tgz\":{\"integrity\":\"0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1ad45e25ef7fd915939a9099d0dc5be4276fa0493416cffaf6284e4e7436344f13e6e61e0692a91659f338ed3ec7b1b9ceb5c255105e1ea42572eaeed0dcafa\",\"name\":\"resolve-alpn\",\"version\":\"1.2.1\"},\"resolve-from-4.0.0.tgz\":{\"integrity\":\"pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2\",\"name\":\"resolve-from\",\"version\":\"4.0.0\"},\"resolve-pkg-maps-1.0.0.tgz\":{\"integrity\":\"seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1e4b64e3dba4c154e0b6348736ace7b6cb664eede7f1213b4b65c1923a71c734e43b0a489405fc34230d9c93ac642213f02e128d2d2f013be844a6781096acf\",\"name\":\"resolve-pkg-maps\",\"version\":\"1.0.0\"},\"responselike-2.0.1.tgz\":{\"integrity\":\"4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e20974df09f7863d473f7cb381d23b777942905f79176d4fcf804f1af2878a7c90cc02d1e426a9c02f32222d11879f0310c43f4a0b82d37c058f693433f98787\",\"name\":\"responselike\",\"version\":\"2.0.1\"},\"responselike-3.0.0.tgz\":{\"integrity\":\"40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e34c87c5b35c976fabcd7bd9b9592b62885ab61b122653135caaf21b9cbcb9c887bf5fb10cb1d0a608c6eb82543bd9eb12ada318b1fa219f01719cb0df0af07a\",\"name\":\"responselike\",\"version\":\"3.0.0\"},\"restore-cursor-3.1.0.tgz\":{\"integrity\":\"l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"97eb1279fcc7a63e6a8a6845484e5af27b9f65800cdec05254c00fb589260bee041f66a7486684317483d22cd141bbbd9dfc90f72e49ad59a9ec4f2866b523bc\",\"name\":\"restore-cursor\",\"version\":\"3.1.0\"},\"restore-cursor-5.1.0.tgz\":{\"integrity\":\"oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0c03675caf0eaed187f12505e6df8d9b14a5ff138b06f6b6d3ccef69b54711fdef00df7707baf4ad8983b01fb7ecce4665675cffb5af400283e4d85e2a20e1c\",\"name\":\"restore-cursor\",\"version\":\"5.1.0\"},\"retry-0.12.0.tgz\":{\"integrity\":\"9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4b9224f08d487aad3e79e43b44f6b4d7f81281c8f7eb333100b67944b5d130af73647dfc228a1a9ed9b5800e0f8e4118edf6097a20276607f6450c2180b52a3\",\"name\":\"retry\",\"version\":\"0.12.0\"},\"reusify-1.1.0.tgz\":{\"integrity\":\"g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"83a4147dfd38a19a47b34786e69f37ac52e11de574d2e83f61ff6764ce9f2de52b3e0b814e44d039da40596b29321e794d97d54033da37735025f6d5440c5d23\",\"name\":\"reusify\",\"version\":\"1.1.0\"},\"rfdc-1.4.1.tgz\":{\"integrity\":\"q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ab56f737942445459497b8b2ca569a8f790ea484f43768bd32a2044173fbdc656c37d730ddf771f17eb77049968491a2d8f3c2176dc88e9ee4b66777f6b6b020\",\"name\":\"rfdc\",\"version\":\"1.4.1\"},\"rimraf-2.6.3.tgz\":{\"integrity\":\"mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9b0a9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88\",\"name\":\"rimraf\",\"version\":\"2.6.3\"},\"roarr-2.15.4.tgz\":{\"integrity\":\"CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8\",\"name\":\"roarr\",\"version\":\"2.15.4\"},\"rollup-4.60.1.tgz\":{\"integrity\":\"VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"566b41dab154fc6ae8678a0bf3e66a5e0480dfc3ba191f0a488bd698416feb7a50d06e8a6811fdb34ecf3bc5d35cfe2f23edd4254132a4e7e39067e6481051d3\",\"name\":\"rollup\",\"version\":\"4.60.1\"},\"rollup-plugin-visualizer-5.14.0.tgz\":{\"integrity\":\"VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5650d79de4c368ab07230f32cc90055adaf382ea09fcb9d0fa5329a157d82778c91782217b9a182c0a8b92520aff7e6581463ed721330a41f26758f8039c397c\",\"name\":\"rollup-plugin-visualizer\",\"version\":\"5.14.0\"},\"run-applescript-7.1.0.tgz\":{\"integrity\":\"DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0cf7b9a5515a02c8a749a57a42343a81d89e7560dc4426d4ba241f41adb099657bfb10bd6c6ba5188f3e4dd466a059003da05793c0ab01b9e56362129e2278ed\",\"name\":\"run-applescript\",\"version\":\"7.1.0\"},\"run-parallel-1.2.0.tgz\":{\"integrity\":\"5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e65e15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004\",\"name\":\"run-parallel\",\"version\":\"1.2.0\"},\"safe-array-concat-1.1.3.tgz\":{\"integrity\":\"AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"014466e5fd236043b27418fb550955bc3ae378582d8437441791f574ffba98da685ce328d6ab90a89e30bc90f2459f7ea4ede4196a0e766574f1c4afd9a255e9\",\"name\":\"safe-array-concat\",\"version\":\"1.1.3\"},\"safe-buffer-5.2.1.tgz\":{\"integrity\":\"rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ae9dd2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d\",\"name\":\"safe-buffer\",\"version\":\"5.2.1\"},\"safe-push-apply-1.0.0.tgz\":{\"integrity\":\"iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"88a13dc3f67bc42cd430866a741b29ea9110bf0b8479b1f8bdda637035a7cb3688eb297a3bd147bd5a6619e96f10736ca18eb019b964c51e99b72fe1d345a248\",\"name\":\"safe-push-apply\",\"version\":\"1.0.0\"},\"safe-regex-test-1.1.0.tgz\":{\"integrity\":\"x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c7ff82cf862b8a643141c7097f998a11b21ad4dcde091348e44725fde92695869a9a974d2cf6a557221c09934d1f732f9aa06e815e53318657bf4963b255256b\",\"name\":\"safe-regex-test\",\"version\":\"1.1.0\"},\"safe-stable-stringify-2.5.0.tgz\":{\"integrity\":\"b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6f7ae9a532a6f53f8fb1508110e511e3a19623b7dd3acd3454a675fbd7351160da0ccbe341cead530b85c88a6b806813716a151d22ab53c1f7d591c0d9ed111c\",\"name\":\"safe-stable-stringify\",\"version\":\"2.5.0\"},\"safer-buffer-2.1.2.tgz\":{\"integrity\":\"YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6\",\"name\":\"safer-buffer\",\"version\":\"2.1.2\"},\"sanitize-filename-1.6.4.tgz\":{\"integrity\":\"9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f59c88d3c3ecbdd425dabfdb0481ae6e955d477451f6c63a44389614fade036d42fc41654219a0a36d1466536364c31936e6eeb0b840428ce403439de49db512\",\"name\":\"sanitize-filename\",\"version\":\"1.6.4\"},\"sass-1.99.0.tgz\":{\"integrity\":\"kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9205b5dcce780d407b22c2113392ef264365a47f9684ca68a1471a5861404641754dcf36bfd9885a409b0987fe301be92140527923938a5a598c43ebd95604e9\",\"name\":\"sass\",\"version\":\"1.99.0\"},\"sax-1.6.0.tgz\":{\"integrity\":\"6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e91dc9e4ce0071bb4b51d66646fd92ca079568cec886b2d7bbd0669ce1a698009a93c7e252d3ac60d5944b8b8aeeea5b9872016cb05e15e23fff8efb04a2c1cc\",\"name\":\"sax\",\"version\":\"1.6.0\"},\"scheduler-0.23.2.tgz\":{\"integrity\":\"UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd\",\"name\":\"scheduler\",\"version\":\"0.23.2\"},\"secure-json-parse-4.1.0.tgz\":{\"integrity\":\"l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9782a761f132a982710f094d57245f3b61383531df30a016754b80f09d32bded83cff13f3dd05ea58d3746fc89a6cb08a51170268083e79c00fa6103b3a07258\",\"name\":\"secure-json-parse\",\"version\":\"4.1.0\"},\"semver-5.7.2.tgz\":{\"integrity\":\"cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"701ce79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2\",\"name\":\"semver\",\"version\":\"5.7.2\"},\"semver-6.3.1.tgz\":{\"integrity\":\"BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc\",\"name\":\"semver\",\"version\":\"6.3.1\"},\"semver-7.7.4.tgz\":{\"integrity\":\"vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bc5282d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894\",\"name\":\"semver\",\"version\":\"7.7.4\"},\"semver-compare-1.0.0.tgz\":{\"integrity\":\"YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"60cdff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3\",\"name\":\"semver-compare\",\"version\":\"1.0.0\"},\"serialize-error-7.0.1.tgz\":{\"integrity\":\"8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f08f138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf\",\"name\":\"serialize-error\",\"version\":\"7.0.1\"},\"set-function-length-1.2.2.tgz\":{\"integrity\":\"pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a6045ce21278fec363582492f409a74b8d31ddb34c0d39271e02f951a3014ccc899d4f741205a1d51cfe302f5e16ee01b8dfd4c198ca42e63fd6fdeb33b1cc7e\",\"name\":\"set-function-length\",\"version\":\"1.2.2\"},\"set-function-name-2.0.2.tgz\":{\"integrity\":\"7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ecf185966b70b040036f4598caf08c6b5b7eca47ba75a206e168ab69fbabe6471ff8c8549cf9acd54791d02290753643f35c844b03076ed9fe4d1f9d32f89a91\",\"name\":\"set-function-name\",\"version\":\"2.0.2\"},\"set-proto-1.0.0.tgz\":{\"integrity\":\"RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"44945dbc2a3a2009cf76cbcfffb9ba6ec42a3679f5142057e5936d14bf7c326145ff8c402094c883561b1d6e430b65b948a65a9eb0ba8b81ec26a95a8f0fdd67\",\"name\":\"set-proto\",\"version\":\"1.0.0\"},\"shallow-equal-3.1.0.tgz\":{\"integrity\":\"pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a5f54ec3c419217a4c6e1056bf30484a272f4e84e233958117511e0146430d26f90eddbdca5e0061bcb2c1b245484b1150cafb8096b1a8276be0bded41ff7056\",\"name\":\"shallow-equal\",\"version\":\"3.1.0\"},\"shebang-command-2.0.0.tgz\":{\"integrity\":\"kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c\",\"name\":\"shebang-command\",\"version\":\"2.0.0\"},\"shebang-regex-3.0.0.tgz\":{\"integrity\":\"7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4\",\"name\":\"shebang-regex\",\"version\":\"3.0.0\"},\"should-13.2.3.tgz\":{\"integrity\":\"ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8202deb0bb6edb1a7e67123ecac25398d8e1d94d13b02fab43fa5f103f5b5196780ca79f3f6ec3fbb6095554ef2ac9a32e9222f6301aee2b700c69030e6b7519\",\"name\":\"should\",\"version\":\"13.2.3\"},\"should-equal-2.0.0.tgz\":{\"integrity\":\"ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"64fdfa4ccacaf5eb84b9641806283d5b9e563c2eeea37eeacc01266e31f3e207f2b97ac452017c714bd054efb0f9ddce31f3ef491409db69529bc310278dcb4c\",\"name\":\"should-equal\",\"version\":\"2.0.0\"},\"should-format-3.0.3.tgz\":{\"integrity\":\"hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"859e7c69db6e94093480ab6e6bb4317af8146974d35f1222f2de352f7ce8f401ef8d73b5ffbb1d2c40ae1de20dd9246d617a4d92686850fda975e5a0ae2710f9\",\"name\":\"should-format\",\"version\":\"3.0.3\"},\"should-type-1.4.0.tgz\":{\"integrity\":\"MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"31d02c4eede7db9c836c87b535e37af46e27ea6527246b52247ca05f7fa837465b3b70d38804e77fb5e76097464f8d89097bab4dbd49234a8e051eb9b21be13d\",\"name\":\"should-type\",\"version\":\"1.4.0\"},\"should-type-adaptors-1.1.0.tgz\":{\"integrity\":\"JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"240e217682e737e91e6c4a7656cf1e05ef60eeecb4cdb468f9131c53412c372f91fa4d38f4a8be379b53e496a0b2dda0ec40236be7ae16ea171426bcbc89257c\",\"name\":\"should-type-adaptors\",\"version\":\"1.1.0\"},\"should-util-1.0.1.tgz\":{\"integrity\":\"oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a1717cb5fc71e5c0e4f2bda462a964509cd9a4306a558fc82365a1bd4d27f58dd762f01846679a7f53efbc8bd380f9efe0a27e112e4cd0fc83ab9269f98832da\",\"name\":\"should-util\",\"version\":\"1.0.1\"},\"side-channel-1.1.0.tgz\":{\"integrity\":\"ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"657f7d7bab51c1ea145ea47e541aec96175ae75361e4c4d0c28bb9b6750381bb723347418268440ed5863ffc5b2a7ea1a9f3d11ee8d4370cf97f2ff06db867a7\",\"name\":\"side-channel\",\"version\":\"1.1.0\"},\"side-channel-list-1.0.1.tgz\":{\"integrity\":\"mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9a39ffd1b8bfa145118dce5797b21a5a2fce24926e9aea0915025f0c3c8ee3afa1056b1f69533ae53047ab67a864187397d11c8713a28e991b442f12541414d3\",\"name\":\"side-channel-list\",\"version\":\"1.0.1\"},\"side-channel-map-1.0.1.tgz\":{\"integrity\":\"VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5428c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744\",\"name\":\"side-channel-map\",\"version\":\"1.0.1\"},\"side-channel-weakmap-1.0.2.tgz\":{\"integrity\":\"WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"58f4bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8\",\"name\":\"side-channel-weakmap\",\"version\":\"1.0.2\"},\"signal-exit-3.0.7.tgz\":{\"integrity\":\"wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19\",\"name\":\"signal-exit\",\"version\":\"3.0.7\"},\"signal-exit-4.1.0.tgz\":{\"integrity\":\"bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af\",\"name\":\"signal-exit\",\"version\":\"4.1.0\"},\"simple-update-notifier-2.0.0.tgz\":{\"integrity\":\"a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6b607d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb\",\"name\":\"simple-update-notifier\",\"version\":\"2.0.0\"},\"sisteransi-1.0.5.tgz\":{\"integrity\":\"bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6cb186951d50c417329e7d9de589835f83068e566fcb631104344d1cb27c548ea5ebef45522c9314d27422f78e48fd1b7178150cf45c7c6a80d298daa94a5f56\",\"name\":\"sisteransi\",\"version\":\"1.0.5\"},\"slash-4.0.0.tgz\":{\"integrity\":\"3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ddd3ac0075d7524413a4e61ca00c4b228acc4e9e20210af9216de255bec0ee5148a74547867ca79bd8b3c7a4ecb1dac87152044809558ed9ced8af1b83e0a87b\",\"name\":\"slash\",\"version\":\"4.0.0\"},\"slice-ansi-3.0.0.tgz\":{\"integrity\":\"pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a52cafedb4930bb8a0f437206f0f40b913546f993957aa03b9d8d9a0c052af5deaa4b046eed07ece00a40118eaef121481dcf93f541ef2efab486768b8e388c9\",\"name\":\"slice-ansi\",\"version\":\"3.0.0\"},\"slice-ansi-5.0.0.tgz\":{\"integrity\":\"FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"142fa5822cd53df89ed24921a9449cc11bb53bf945e8d3a026694280afbf2d8c4309393cb067a561a1c384570337e4a7dc2bfedd549ae01c9ea3e20c0b3a4c81\",\"name\":\"slice-ansi\",\"version\":\"5.0.0\"},\"slice-ansi-7.1.2.tgz\":{\"integrity\":\"iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"88e056160517edc688662baeb480b15605f549dc700151452b0b7512f31861e73f3563b999e389e8ae6e43186b6017502677b82b18aa65cf8aa6d14e585488f7\",\"name\":\"slice-ansi\",\"version\":\"7.1.2\"},\"smart-buffer-4.2.0.tgz\":{\"integrity\":\"94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f7884ad0787cacfa90976c577371ec681a0e5ca576d0c4e83e4717bf06c84962c4b3eeb8b01ab9905827da42431dbd4faf2f72acfd1dc6b088f5145c8bb4572a\",\"name\":\"smart-buffer\",\"version\":\"4.2.0\"},\"socks-2.8.7.tgz\":{\"integrity\":\"HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1cba6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0\",\"name\":\"socks\",\"version\":\"2.8.7\"},\"socks-proxy-agent-8.0.5.tgz\":{\"integrity\":\"HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1de84212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327\",\"name\":\"socks-proxy-agent\",\"version\":\"8.0.5\"},\"sonic-boom-4.2.1.tgz\":{\"integrity\":\"w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3a031b6e6d76b6c135c052c64c316111aec21101dacad1273e154cad5af60084124bcae238965acc202d43b65352748f7d108f3a299ba6d8c32adc4019945f5\",\"name\":\"sonic-boom\",\"version\":\"4.2.1\"},\"source-map-0.6.1.tgz\":{\"integrity\":\"UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee\",\"name\":\"source-map\",\"version\":\"0.6.1\"},\"source-map-0.7.6.tgz\":{\"integrity\":\"i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8b9bafb7c0b78a489678d65255935671f64f22d1503ac6135003a47143c677c0ea0f2d6e3948a48ede5d1beb91970caf475d3c15bf4339de06bd77d3d0ddbfb9\",\"name\":\"source-map\",\"version\":\"0.7.6\"},\"source-map-js-1.2.1.tgz\":{\"integrity\":\"UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40\",\"name\":\"source-map-js\",\"version\":\"1.2.1\"},\"source-map-support-0.5.21.tgz\":{\"integrity\":\"uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b811d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7\",\"name\":\"source-map-support\",\"version\":\"0.5.21\"},\"space-separated-tokens-2.0.2.tgz\":{\"integrity\":\"PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3c41a5030ac6f325c65d18d6df67c66e0eba24094e0306ce6eea95a09a6ffe6460a160d07e01f5c033efb735b25123405c119293c87be796036db704cb7487d9\",\"name\":\"space-separated-tokens\",\"version\":\"2.0.2\"},\"spdx-compare-1.0.0.tgz\":{\"integrity\":\"C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b598364e5f4867bb47a9f5d7e6ba88b4dfe78e743a33db2bcaefd4716dcad5106d4d3b53e1df9c96d74d831d628de2993cd27c0281e326498e4bdb9544e03f4\",\"name\":\"spdx-compare\",\"version\":\"1.0.0\"},\"spdx-exceptions-2.5.0.tgz\":{\"integrity\":\"PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3e2538dabfb13b851b512d5bba8dcb3c992394eef8df45e7e5254085da73cec3c7b236d855f9679c57404e069b9cbb9d7be0aabb6e69e8dfa0da5c3f3c5b1ae3\",\"name\":\"spdx-exceptions\",\"version\":\"2.5.0\"},\"spdx-expression-parse-3.0.1.tgz\":{\"integrity\":\"cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71ba87ba7b105a724d13a2a155232c31e1f91ff2fd129ca66f3a93437b8bc0d08b675438f35a166a87ea1fb9cee95d3bc655f063a3e141d43621e756c7f64ae1\",\"name\":\"spdx-expression-parse\",\"version\":\"3.0.1\"},\"spdx-license-ids-3.0.23.tgz\":{\"integrity\":\"CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0962dc0821fb54bbb5dd380e1feafca753bf667c21aaffdd6dbea5a96cbaec6fa94f590799e0fff95dfa0156ffbeaf10308430552849e92b25e453e1d1fb9277\",\"name\":\"spdx-license-ids\",\"version\":\"3.0.23\"},\"spdx-ranges-2.1.1.tgz\":{\"integrity\":\"mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"99c76940557b5030202e95c413f8ce32abcae0b0683b4b93420d2ebd751ec26105869899c79c894992131c1f30d596a129d85f66a3f918f10e28bc84ab9a7c5c\",\"name\":\"spdx-ranges\",\"version\":\"2.1.1\"},\"spdx-satisfies-5.0.1.tgz\":{\"integrity\":\"Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"370a2be96ea0cc5a7c5d7e2779a290ec2855e309a94a1dac4837a63054b31f1a53c38eb48f115878e9fe8eae326e7492c3fe6c737a6391af4c40fa2e92c40da7\",\"name\":\"spdx-satisfies\",\"version\":\"5.0.1\"},\"split2-4.2.0.tgz\":{\"integrity\":\"UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51c8dc24e5a49eb36417a3cb5fcdea70733a28781528d915eb663c6b9b980d5bfdc9d19057000730aa877498ded554d6a658c6d1662908386b09d00e607e135a\",\"name\":\"split2\",\"version\":\"4.2.0\"},\"sprintf-js-1.1.3.tgz\":{\"integrity\":\"Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3a8fb4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68\",\"name\":\"sprintf-js\",\"version\":\"1.1.3\"},\"ssri-12.0.0.tgz\":{\"integrity\":\"S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4bb886368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01\",\"name\":\"ssri\",\"version\":\"12.0.0\"},\"stable-hash-0.0.5.tgz\":{\"integrity\":\"+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f8bddc729ce26e8bc65c52be029fdff0b392d1a84cac74dfdf1bbb98c2d2a44194d043bdb9c6b2b12ca52a8f5e44314d856bdeff2dbbe623e6219e33dfd6bd88\",\"name\":\"stable-hash\",\"version\":\"0.0.5\"},\"stat-mode-1.0.0.tgz\":{\"integrity\":\"jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8c7f4486d2888ee5d9d9c5b19974bc64ff345f20b789ab10c4c0d5f23ce1349a5f0dbed56d02d55b85afb31cfd419bf357e1b862849f05454a0cecb12f38bfb2\",\"name\":\"stat-mode\",\"version\":\"1.0.0\"},\"stop-iteration-iterator-1.1.0.tgz\":{\"integrity\":\"eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"78ba175bf0c7ca5eb6cf1638482688827461b8cafaae2e23b84600452f04eac084ab32a93a2139db551ca1f771f8a9c3665e719af19869a2829391443b1242a1\",\"name\":\"stop-iteration-iterator\",\"version\":\"1.1.0\"},\"string-argv-0.3.2.tgz\":{\"integrity\":\"aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6aa0f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9\",\"name\":\"string-argv\",\"version\":\"0.3.2\"},\"string-width-4.2.3.tgz\":{\"integrity\":\"wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe\",\"name\":\"string-width\",\"version\":\"4.2.3\"},\"string-width-5.1.2.tgz\":{\"integrity\":\"HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8\",\"name\":\"string-width\",\"version\":\"5.1.2\"},\"string-width-7.2.0.tgz\":{\"integrity\":\"tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b6c693224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691\",\"name\":\"string-width\",\"version\":\"7.2.0\"},\"string.prototype.includes-2.0.1.tgz\":{\"integrity\":\"o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a3bf9cf5b5bace901d2474edba379e3ce0c0864ba271d02bc85b1f54ac00fb01b0f3dc09e064d8e3ce164ee70cf612ed0c43a93af23e6879f3aa70b9947a7846\",\"name\":\"string.prototype.includes\",\"version\":\"2.0.1\"},\"string.prototype.matchall-4.0.12.tgz\":{\"integrity\":\"6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e820bdbb204bfbfe3c7588b345fec7ed501808c08d4c178cefcc7f55351ef5b1446b105ea4f2436b53b0f7d2ea23fd7217b92ecbb437710b1832b72319472c90\",\"name\":\"string.prototype.matchall\",\"version\":\"4.0.12\"},\"string.prototype.repeat-1.0.0.tgz\":{\"integrity\":\"0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d2efd395d0db283f1b14243fe1fe7e98d46b5f067c860db0ed947cc1ad7a7bccfd5e978f5a5dde1847140f4397a441ff5491ffd86de08d4b51dd93a205ed92ff\",\"name\":\"string.prototype.repeat\",\"version\":\"1.0.0\"},\"string.prototype.trim-1.2.10.tgz\":{\"integrity\":\"Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"46ceba1743ffd6479d9399726321fdb81cee888fe43519b024047daae2ba54eb48a59d86fa131977e1d06dbbf6e4c80203a8047dfa0c658c654e877859c76b28\",\"name\":\"string.prototype.trim\",\"version\":\"1.2.10\"},\"string.prototype.trimend-1.0.9.tgz\":{\"integrity\":\"G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1bb3a4e42e84fe3e1219fc8b0a5a174eb9e0408414dcf5ad5c6b2ddf233b05e6bd1515117f54b8d991e5659b6c36ab9ed853763e85217d95d82cd5b012be1d2d\",\"name\":\"string.prototype.trimend\",\"version\":\"1.0.9\"},\"string.prototype.trimstart-1.0.8.tgz\":{\"integrity\":\"UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"517487dbad82499635b5fbb71b749e72beae18b08554f32122a1e3960094b4209c82285873fc4ab3d76331331439bda3d66552794f0453a35673f890294e867e\",\"name\":\"string.prototype.trimstart\",\"version\":\"1.0.8\"},\"string_decoder-1.3.0.tgz\":{\"integrity\":\"hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"864457f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78\",\"name\":\"string_decoder\",\"version\":\"1.3.0\"},\"stringify-entities-4.0.4.tgz\":{\"integrity\":\"IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2307c1a6d6ad94ef90089528d7d02abeb3cdaa554ca56f5810bd8b21563e469bf6aac8c21b16832cd460786b1058985f22d79bb8986c1922e36816cd490fa27a\",\"name\":\"stringify-entities\",\"version\":\"4.0.4\"},\"strip-ansi-6.0.1.tgz\":{\"integrity\":\"Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4\",\"name\":\"strip-ansi\",\"version\":\"6.0.1\"},\"strip-ansi-7.2.0.tgz\":{\"integrity\":\"yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef\",\"name\":\"strip-ansi\",\"version\":\"7.2.0\"},\"strip-bom-3.0.0.tgz\":{\"integrity\":\"vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bdabc03115ce80154d17a9f210498bdc304ad7d891a437282305beb3043e09b1a2bbb963bbab7e264940d4c1f07a85ad69d82de0849552c5cbc83ab7e1d75cc0\",\"name\":\"strip-bom\",\"version\":\"3.0.0\"},\"strip-final-newline-2.0.0.tgz\":{\"integrity\":\"BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06ba6f7cd004ddd72fabb965df156e9b38ca8d9439b48d6c11420aaf752892cd17525e394addc595ab55a9e7fda6b9388d10f3856e96660fb76e4f77cbaa4b8c\",\"name\":\"strip-final-newline\",\"version\":\"2.0.0\"},\"strip-final-newline-3.0.0.tgz\":{\"integrity\":\"dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74e112aa362bf7a89663294639bcdddfd12e3536b9549c72bd50049b926787b286a3be55e371e4d6874f424343c97366511ea4fa01220d55e78c1f0727772b5f\",\"name\":\"strip-final-newline\",\"version\":\"3.0.0\"},\"strip-json-comments-3.1.1.tgz\":{\"integrity\":\"6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a\",\"name\":\"strip-json-comments\",\"version\":\"3.1.1\"},\"strip-json-comments-5.0.3.tgz\":{\"integrity\":\"1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d6d0799a1568ed4f844c128d7fddb14f886b41ade99b4319d0f42fb839d68000061c3b1fa7894f4a9892ea9b2b4a27adf3bc3218f87d7edeb09a138c4348438b\",\"name\":\"strip-json-comments\",\"version\":\"5.0.3\"},\"style-to-js-1.1.21.tgz\":{\"integrity\":\"RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"46341eb7126bad424b40f1db2e4bba53fa1c1adcf28db24c3fd94234aec083408d87af749d21fcc28a961fdbb5ea732360102893e8bb24ed4d3f6a4ecbc22c3d\",\"name\":\"style-to-js\",\"version\":\"1.1.21\"},\"style-to-object-1.0.14.tgz\":{\"integrity\":\"LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2c837bad42c8d2306c716418692b30a6dc9d7ab95aac592343eb7bf67cedcbcb5c20071e5689845652f31f954fe029acbfa32d2a1b3ba9a022c25729f8c81ac7\",\"name\":\"style-to-object\",\"version\":\"1.0.14\"},\"sucrase-3.35.1.tgz\":{\"integrity\":\"DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e1b939af656bb1e07d543a758c077b24d2c6da0953a84198eff2ed6b0e84d5d074dd19e9bd864019b65e09672f0fdb3e018349d3f9831e385c95af8cdc1b94f\",\"name\":\"sucrase\",\"version\":\"3.35.1\"},\"sumchecker-3.0.1.tgz\":{\"integrity\":\"MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"32f8d7ce4cff04e7f2543906d2814eb41c475f6bb780a6cc1c817f7576e566c803dc158e14b987a2f229658ec1ca425d02372a442062d5660135d102f7223bbe\",\"name\":\"sumchecker\",\"version\":\"3.0.1\"},\"supports-color-7.2.0.tgz\":{\"integrity\":\"qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047\",\"name\":\"supports-color\",\"version\":\"7.2.0\"},\"supports-preserve-symlinks-flag-1.0.0.tgz\":{\"integrity\":\"ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3\",\"name\":\"supports-preserve-symlinks-flag\",\"version\":\"1.0.0\"},\"swagger2openapi-7.0.8.tgz\":{\"integrity\":\"upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ba98bfd191a462011c2de1a27a8cfc813ef8a161c0d04ec98af5fb68df6601ff9373b050a1106f9c8187a0f0f0f9ff535d35b8b3a906602649b5ab8fe8e629ee\",\"name\":\"swagger2openapi\",\"version\":\"7.0.8\"},\"tailwind-gradient-mask-image-1.2.0.tgz\":{\"integrity\":\"tUJaGhvqbJFiVKJu6EU5n//KvGdVvY3L3VOFNqjztk13+ifAk00pcSNHBTgHfUiBGOEzDn0gFRbSmsftUV1lXA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b5425a1a1bea6c916254a26ee845399fffcabc6755bd8dcbdd538536a8f3b64d77fa27c0934d297123470538077d488118e1330e7d201516d29ac7ed515d655c\",\"name\":\"tailwind-gradient-mask-image\",\"version\":\"1.2.0\"},\"tailwindcss-3.4.19.tgz\":{\"integrity\":\"3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"de87e9f8b2fc13ea4afc9b8f2cf82054021a12e86f233e2a35c7f79c0d579f6a3fedf6fbb3f4d8a47870183bf5654dcf90196e515685f0fc821dc9b8f1c28b59\",\"name\":\"tailwindcss\",\"version\":\"3.4.19\"},\"tar-7.5.13.tgz\":{\"integrity\":\"tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b4e1bfec6c97a457af857561f2338f26b9ad469393b18a9422455d568a196094bfcfc5a17d0517f112482e67ae24d8a7180312bb5bde06be1ab121c5b79fe19e\",\"name\":\"tar\",\"version\":\"7.5.13\"},\"temp-0.9.4.tgz\":{\"integrity\":\"yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c98aebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418\",\"name\":\"temp\",\"version\":\"0.9.4\"},\"temp-file-3.4.0.tgz\":{\"integrity\":\"C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b9b63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6\",\"name\":\"temp-file\",\"version\":\"3.4.0\"},\"thenify-3.3.1.tgz\":{\"integrity\":\"RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"455652215e481b5d079377a7a2dae1bf3d13f5e9ba7321c12e41ff60066e2aa77c85190a8527c218870fd8a518d043f19ddcc034198d965cd63f06a4f9b85e4b\",\"name\":\"thenify\",\"version\":\"3.3.1\"},\"thenify-all-1.6.0.tgz\":{\"integrity\":\"RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"44dc501ffa88f3fb77b615c90f072cb543b8cdeaa8eb8f94cbffac355441c785e7d8e5fe399f683fe8899cd16aa6516b6b665455e28249ada85568b74f8b9598\",\"name\":\"thenify-all\",\"version\":\"1.6.0\"},\"thread-stream-4.0.0.tgz\":{\"integrity\":\"4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e223152fa1c020d5d67f564a66320f733e7061a39d3e1b4ef004ef67e5eaa7705375aaad03042436628e46a708a3962442a197ab97307ecc03c0caaa40dae924\",\"name\":\"thread-stream\",\"version\":\"4.0.0\"},\"three-0.163.0.tgz\":{\"integrity\":\"HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1e532009bd9317f7532d1b649c19e3513b11f05b03a81638de2b58a29dbe660f36d88f8a77451adafb3c0af7c155e7d790174d0eb2cca114c60882297c2b837b\",\"name\":\"three\",\"version\":\"0.163.0\"},\"tiny-async-pool-1.3.0.tgz\":{\"integrity\":\"01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8\",\"name\":\"tiny-async-pool\",\"version\":\"1.3.0\"},\"tiny-case-1.0.3.tgz\":{\"integrity\":\"Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"11eb7f79e32190ee935fc9a752d792f7380f6d43106b823a2a4a793918810f9e3bebf9be3c8462ba63f9b668798a82691fb939d4a7a16b0cb65037ec9f1c58f1\",\"name\":\"tiny-case\",\"version\":\"1.0.3\"},\"tinycolor2-1.6.0.tgz\":{\"integrity\":\"XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5cf68191640976c7f7a4b28957da78a8dfd2f9f9b63a3f0020fa35053521839a3192f9bdf92544185761c8ecfbb537544dfbf132202ce2ca7afde64ed84c3ea7\",\"name\":\"tinycolor2\",\"version\":\"1.6.0\"},\"tinyglobby-0.2.16.tgz\":{\"integrity\":\"pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a67f7d561a0009847c9c51e1c6a8b1faebec6d78a77806ac5a6e688d7a0df311302b929ddff4eb84d9f5c01cae0f9d94c5644bcbca6efa444c9e2122e84abd66\",\"name\":\"tinyglobby\",\"version\":\"0.2.16\"},\"tmp-0.2.5.tgz\":{\"integrity\":\"voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"be8cb3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3\",\"name\":\"tmp\",\"version\":\"0.2.5\"},\"tmp-promise-3.0.3.tgz\":{\"integrity\":\"RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1\",\"name\":\"tmp-promise\",\"version\":\"3.0.3\"},\"to-regex-range-5.0.1.tgz\":{\"integrity\":\"65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eb93fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1\",\"name\":\"to-regex-range\",\"version\":\"5.0.1\"},\"toposort-2.0.2.tgz\":{\"integrity\":\"0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1ae443a4014a7c0f89a8322d96f1917c8dc81aec181977dd4eff269b242158f1acfe5d2cde1b24cab34028a3cf7b895d4d8fa82e16af28ad60d2f7acfdd681a\",\"name\":\"toposort\",\"version\":\"2.0.2\"},\"tr46-0.0.3.tgz\":{\"integrity\":\"N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"37758cb2ea95eba953df40ab5cd6c48f1e06130968c37bfaaebe2609cbfaa6b9dfc214b4d6b920c857633cd05877d6ebecba57575f849a1d357c79ead86760af\",\"name\":\"tr46\",\"version\":\"0.0.3\"},\"trim-lines-3.0.1.tgz\":{\"integrity\":\"kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9118fc07e60764273d91061d59f241dbfa1497dac0f7da9ba3061806daf8ba2e26672010d89a6f54177fe94d989680137ea06105348c853a60047b54d0c7f746\",\"name\":\"trim-lines\",\"version\":\"3.0.1\"},\"trough-2.2.0.tgz\":{\"integrity\":\"tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b663292b4d018d9894c95cafac12bb9277ab3609a0bdc57f28b572ba66bf482f9340dd7aec6acc45c880353cf4f7e937cd6f0bf2deb48d63b51a97e465d8d36b\",\"name\":\"trough\",\"version\":\"2.2.0\"},\"truncate-utf8-bytes-1.0.2.tgz\":{\"integrity\":\"95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f793eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899\",\"name\":\"truncate-utf8-bytes\",\"version\":\"1.0.2\"},\"ts-api-utils-2.5.0.tgz\":{\"integrity\":\"OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"389fe26f184f96aacc33452234727fd02290928285db8dff0049a996ddeaa518245bc546ec87ce4b8d61ed5f138c84ea741c87ceb8dc4bfdac8becb894887c34\",\"name\":\"ts-api-utils\",\"version\":\"2.5.0\"},\"ts-interface-checker-0.1.13.tgz\":{\"integrity\":\"Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63f6abbdb9feaebcf72422a5f42e2454d7d37d29b6fe6129e454b3e44b194803463d2950ae9448e4ce0f285fa6267139da338ef743e73d273752bddb4d0c3480\",\"name\":\"ts-interface-checker\",\"version\":\"0.1.13\"},\"ts-node-9.1.1.tgz\":{\"integrity\":\"hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"84f96ded90021114067f4dccdb9df2b4b6377476c6346ac0abda881d6518f571d8975cfbc189e04abdce439c66ba2f28d806b1b0e3712338da7cb522581a3516\",\"name\":\"ts-node\",\"version\":\"9.1.1\"},\"ts-pattern-5.9.0.tgz\":{\"integrity\":\"6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eace55ef5997f2a0549a581badf2f7df10d4c0ed1fab8f2bc40bb62c1135d5605e19da423ceb1792c41b6491ef1f086b77742352eb1dde600e3391a0d261412e\",\"name\":\"ts-pattern\",\"version\":\"5.9.0\"},\"tsconfig-paths-3.15.0.tgz\":{\"integrity\":\"2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d80736460cc37bf727e3c1af39edccfa8f36a4415ec03dd43dbca85071dd29ab07c092a376ce1f2d759ffd4c799004c128ddb4a1a146bbe8db125a75a68b349a\",\"name\":\"tsconfig-paths\",\"version\":\"3.15.0\"},\"tslib-1.14.1.tgz\":{\"integrity\":\"Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5e78b7e4d2b38e032bc1ebf2b074c202bb4b0e93efc9ef3357fd04e04c989f8dcfeffeeabd0c0f87d0469077b06ccba5567b5b8a099c4fbadd5f704da3dc1126\",\"name\":\"tslib\",\"version\":\"1.14.1\"},\"tslib-2.8.1.tgz\":{\"integrity\":\"oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb\",\"name\":\"tslib\",\"version\":\"2.8.1\"},\"tsutils-3.21.0.tgz\":{\"integrity\":\"mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"98728ade25172fedd417ac4be64d0f12129150128f042bfff919043a98d15b1c71dbb28a4419a603ad00f6980e52f322f062a144c3c49a30513f3b365bb3b538\",\"name\":\"tsutils\",\"version\":\"3.21.0\"},\"typanion-3.14.0.tgz\":{\"integrity\":\"ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"656fe554c45a6c44ee60277d3bd66f321021f06b254aa6948f198afc92cf0a1ea5ef70af2c18ae5ecc23ffeecb76758e818b10d77d05a8bcc5cf96864f823752\",\"name\":\"typanion\",\"version\":\"3.14.0\"},\"type-check-0.4.0.tgz\":{\"integrity\":\"XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b\",\"name\":\"type-check\",\"version\":\"0.4.0\"},\"type-fest-0.13.1.tgz\":{\"integrity\":\"34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"df847b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732\",\"name\":\"type-fest\",\"version\":\"0.13.1\"},\"type-fest-2.19.0.tgz\":{\"integrity\":\"RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4401fcdb6a4074181c34c01f5a708153708565c7d9fe2d5e663c0553f76c2caba6caeb8fde78ae7a0d9402e917605d04d8002873cd994927fd2745900629f31c\",\"name\":\"type-fest\",\"version\":\"2.19.0\"},\"typed-array-buffer-1.0.3.tgz\":{\"integrity\":\"nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c0618c1f637aa7cd7df422403a01066355bb4ae9db86a27b5c426d56486d4c0fde182ea2b4e75e46340a57928c4a39632eb15b2c00758b87d49e6a879f6051b\",\"name\":\"typed-array-buffer\",\"version\":\"1.0.3\"},\"typed-array-byte-length-1.0.3.tgz\":{\"integrity\":\"BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"05a5e03ae231cfc9fca48ab77bb02d83feecf83a6262bc67e2f768b77c3d29b9c185c450abaa37c5e9907487f29ea49e5de0eb177db1f96bdfce63a33e263d96\",\"name\":\"typed-array-byte-length\",\"version\":\"1.0.3\"},\"typed-array-byte-offset-1.0.4.tgz\":{\"integrity\":\"bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d3940141fc505831cb97f3581b2f839ca47e4f9a5147aa5082a4097c025133333e64e77a0d0ef37ca753cd3962c4988db1e28ae9deb68e141e75b6ff57f8c15\",\"name\":\"typed-array-byte-offset\",\"version\":\"1.0.4\"},\"typed-array-length-1.0.7.tgz\":{\"integrity\":\"3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dca4b66fe90bedfb2e93f78967b1107671264286a1a3fafa29479fee1c6f96d340e4347c34050cfbcc0931b2726781bdffb8b7bf9ccf04830de5ac9b021dbf26\",\"name\":\"typed-array-length\",\"version\":\"1.0.7\"},\"typescript-4.8.2.tgz\":{\"integrity\":\"C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b423552caeb0c7a367d8239a1a0866d27a3c17e1c87ef58e634d010bbe8bdf98590adc71d264907c31225c58b982501cd005c842ad9f6b31157a1ae36bbc6b7\",\"name\":\"typescript\",\"version\":\"4.8.2\"},\"typescript-4.8.4.tgz\":{\"integrity\":\"QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40287ef39982cbe8742067dff2be575b339549b04ef8a7de62b31087b349e7c42e8f0704db6bbe3544a6531a85fae9fbd0ff465cac5ad8708d8934cc2649f28d\",\"name\":\"typescript\",\"version\":\"4.8.4\"},\"typescript-5.7.3.tgz\":{\"integrity\":\"84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f383154a33041cff854113f2de95fdb13555fc83487b1ef5b3d4cbd869b9146fd61b54aa5de2b267493bfdb958ff815d3b3235d82072d6f19ce2883f7aeb347f\",\"name\":\"typescript\",\"version\":\"5.7.3\"},\"typescript-5.9.3.tgz\":{\"integrity\":\"jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b\",\"name\":\"typescript\",\"version\":\"5.9.3\"},\"typescript-eslint-8.58.2.tgz\":{\"integrity\":\"V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57c8929e0f6645b7598e5e78549f4d2abe9907e756d09dd3cd15d119c49b2c87a3f6357ce9946d95879328347f40bc57ca4a1c27989c3736ec976fb94f322f71\",\"name\":\"typescript-eslint\",\"version\":\"8.58.2\"},\"unbox-primitive-1.1.0.tgz\":{\"integrity\":\"nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9d627dd438de3a47a3fd303ca574379b2aee2a9284620aafa70f65cf838f1e3fcd585365b98ae36f3f63d35089f322907768388c5a0e9083424d6d88e4b104cb\",\"name\":\"unbox-primitive\",\"version\":\"1.1.0\"},\"undici-6.24.1.tgz\":{\"integrity\":\"sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b02f9bd2d075c21382cdbb65c76d1fc775a0097c245badbba78100f6e33efed34d3e4492f9e48495dea902cf670efed66d8d545258c13183edbbd0423ab09628\",\"name\":\"undici\",\"version\":\"6.24.1\"},\"undici-types-7.16.0.tgz\":{\"integrity\":\"Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"673f9a6564a3f0b13ace8c43fb1ae387855f9081bc61ae8bbd8919aad5101893d98d8979df2a42694c16aa8ede234c7ae8a046791a3e9a504490c49e499dfc37\",\"name\":\"undici-types\",\"version\":\"7.16.0\"},\"unified-11.0.5.tgz\":{\"integrity\":\"xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c4abc684f5b0de4f3842387c6c8dd97898ea9f269d2be18416d6b349f66ffeb29e4e44e3389868ea616a87648cf7a888719a24c623a983bf066b34d283cf8a1c\",\"name\":\"unified\",\"version\":\"11.0.5\"},\"unique-filename-4.0.0.tgz\":{\"integrity\":\"XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d29c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535\",\"name\":\"unique-filename\",\"version\":\"4.0.0\"},\"unique-slug-5.0.0.tgz\":{\"integrity\":\"9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4e75aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e\",\"name\":\"unique-slug\",\"version\":\"5.0.0\"},\"unist-util-is-6.0.1.tgz\":{\"integrity\":\"LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2ec8882dbb41113903cfc23da75750d2ec91516b9a43377f72e11e4b5868452c96e44e571a64f39706353ab373cda906a3023d0ebfc8f0755ac38853b67c72f2\",\"name\":\"unist-util-is\",\"version\":\"6.0.1\"},\"unist-util-position-5.0.0.tgz\":{\"integrity\":\"fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7ee72c0bb1e35ef901e51de44c23bb9148d176b4b4049b7733f14fc661cc04e9bc2508b606c1c01c5b32dbb13412894ff2ba743735ec27e8cd3f20d6bce2593c\",\"name\":\"unist-util-position\",\"version\":\"5.0.0\"},\"unist-util-stringify-position-4.0.0.tgz\":{\"integrity\":\"0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d00495d3a000a0a083912dbec70e515c9cb0aeebaba5b0b82594a6ee7afb30eb75a23033bf2c9a3be53165fd7c8fc14217a926cc264a70080dff2bb6826d9781\",\"name\":\"unist-util-stringify-position\",\"version\":\"4.0.0\"},\"unist-util-visit-5.1.0.tgz\":{\"integrity\":\"m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9bebc87727823a976bfd07900aed84cf15ffa21812f0a6e73c38059e2e1d42c7d20ada73f14a83c98e468d1aeef0f0cab989fb16ad7d8f5090fa7252b0628ece\",\"name\":\"unist-util-visit\",\"version\":\"5.1.0\"},\"unist-util-visit-parents-6.0.2.tgz\":{\"integrity\":\"goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"828875b354c1aea4aaba449cf30ae3c1684bd21889c6003c9b8905c46950fbc1584370bf9b5d45713b386187a6ed5ebae0084756f82840b93cf744ac76caf621\",\"name\":\"unist-util-visit-parents\",\"version\":\"6.0.2\"},\"universal-user-agent-7.0.3.tgz\":{\"integrity\":\"TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4e69c400402c04955933f0000c42ec2bbea5967c1c7fdbcc2ae3f3f097e53b57eb3bc2dc862b6bd1f35a37d77e029d018cab6a5aa77f275eea7839d787c08bd8\",\"name\":\"universal-user-agent\",\"version\":\"7.0.3\"},\"universalify-0.1.2.tgz\":{\"integrity\":\"rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492\",\"name\":\"universalify\",\"version\":\"0.1.2\"},\"universalify-2.0.1.tgz\":{\"integrity\":\"gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"829b4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b\",\"name\":\"universalify\",\"version\":\"2.0.1\"},\"unplugin-1.0.1.tgz\":{\"integrity\":\"aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6aaac76950565b52552811e61a8df74f94f178bd2a5b37ef8d6a2439b1c0f5b62637b78d0e4c0ec662e3862a0797df3bf2a0c5300693e755cdae8472bb3ed6c4\",\"name\":\"unplugin\",\"version\":\"1.0.1\"},\"unrs-resolver-1.11.1.tgz\":{\"integrity\":\"bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d28edf698da1019cd88681cf6b5221c62afe65e3f4c6cc3998c374619e4246b4b85b9e703fe6a263ef1ddd343091c7f3c9c6eefbe0b947f2508e941e2111f2a\",\"name\":\"unrs-resolver\",\"version\":\"1.11.1\"},\"update-browserslist-db-1.2.3.tgz\":{\"integrity\":\"Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"26cd26f5cc7ea8e803c68d1e32214612e796cedcfe778f8cdeb1a598a3d3f93e084bf8cfe32970dcdc29bba7294d33fc4753000b5905e156dd2eddc045fdb4f7\",\"name\":\"update-browserslist-db\",\"version\":\"1.2.3\"},\"uri-js-4.4.1.tgz\":{\"integrity\":\"7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06\",\"name\":\"uri-js\",\"version\":\"4.4.1\"},\"use-double-tap-1.3.7.tgz\":{\"integrity\":\"OOgpAtT1U96D8jX6w/ODWhLMDpS92wVYIQyQQ0hDnOgLrPHNrkYSjTnkoPT41GaO30xF5OBJ7mAxF34sHxnLng==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38e82902d4f553de83f235fac3f3835a12cc0e94bddb0558210c904348439ce80bacf1cdae46128d39e4a0f4f8d4668edf4c45e4e049ee6031177e2c1f19cb9e\",\"name\":\"use-double-tap\",\"version\":\"1.3.7\"},\"utf8-byte-length-1.0.5.tgz\":{\"integrity\":\"Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5e7d30dccb6243ace8cf6bc5c9456bb9a08be773bf0f052f90478ebe3faeba5326d019141985a6058572125a996922e163a643d2e95f537681adad9a553e317c\",\"name\":\"utf8-byte-length\",\"version\":\"1.0.5\"},\"util-deprecate-1.0.2.tgz\":{\"integrity\":\"EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73\",\"name\":\"util-deprecate\",\"version\":\"1.0.2\"},\"uuid-13.0.0.tgz\":{\"integrity\":\"XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5d07a021a0535548d21e588aa9c9c5a98ca901de12f96098b79348791b3ac3f500af2ef3f18f63e59c1144be24ceaf54dec0fabfef397abf45be411a0698e2db\",\"name\":\"uuid\",\"version\":\"13.0.0\"},\"verror-1.10.1.tgz\":{\"integrity\":\"veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e\",\"name\":\"verror\",\"version\":\"1.10.1\"},\"vfile-6.0.3.tgz\":{\"integrity\":\"KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2b321b1fff6d5dab76bb7d237feb26330142b27a38c0755d366cc5c8bf93fcbdd41aaaa4e8929f56a3853991296521c00c7d64e3469be8d5085d9ab8db6a2fdd\",\"name\":\"vfile\",\"version\":\"6.0.3\"},\"vfile-message-4.0.3.tgz\":{\"integrity\":\"QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4131f3b067751216d9b3802c436d095f5ac2ddc3a5b7f21626bba4f3ddc37cb46be7b95c9ce78c6961b82b426b46d6b89882592ad87602ede6337bb4dff2562b\",\"name\":\"vfile-message\",\"version\":\"4.0.3\"},\"vite-5.4.21.tgz\":{\"integrity\":\"o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a396bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b\",\"name\":\"vite\",\"version\":\"5.4.21\"},\"warning-4.0.3.tgz\":{\"integrity\":\"rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ae9272376db629622f1c9fc5e775d266fd1997f69c72a1d1f1eb7592968c4c3fdf2c2471b55f225fc73333363bb1566ea53237cdc51383c7b2712da4345f65eb\",\"name\":\"warning\",\"version\":\"4.0.3\"},\"wcwidth-1.0.1.tgz\":{\"integrity\":\"XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5c73c4c12d2ae936b172f1bce7ef046246e20aec765ed586da691ce3b360d80efb050bbdf83a8838995d493e0780f92e79aeddbca4a3e55817dcfd5de2b5bc4e\",\"name\":\"wcwidth\",\"version\":\"1.0.1\"},\"webidl-conversions-3.0.1.tgz\":{\"integrity\":\"2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d89027df3f0047aae32bc4a6f28ad10b487f6dc97f0ea2fbb513dd199e08d428dd17e11a30b998c411f25ee28bf38f5eb9c3c586f068c4cb1f95f39bf24c5a79\",\"name\":\"webidl-conversions\",\"version\":\"3.0.1\"},\"webpack-sources-3.3.4.tgz\":{\"integrity\":\"7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eed3f53dd578bc5fa560f9e4311d23318e7f95adae6f915cffc550aeb53e95792233a0b84e355f1b0ee229fca19d340eb03fba43f88ac34785722ce24600f9f1\",\"name\":\"webpack-sources\",\"version\":\"3.3.4\"},\"webpack-virtual-modules-0.5.0.tgz\":{\"integrity\":\"kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9320e2bc567b64cd0154e52d7956c3161951b7b021fc248fc09762f2106990aed02ee994a9d2ed55f9bf3d7fe191c9ebbebd22efb7cee7e4e367de0f7be0bd8b\",\"name\":\"webpack-virtual-modules\",\"version\":\"0.5.0\"},\"whatwg-url-5.0.0.tgz\":{\"integrity\":\"saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1a139ee7ba9c64eafdc7637e7e8f307061ad2b292cb45d1f094b164fc202ebef2b34201ce11af880d7f4d41892e6495aacf296fd027bc809712e3872e9ad84f\",\"name\":\"whatwg-url\",\"version\":\"5.0.0\"},\"which-2.0.2.tgz\":{\"integrity\":\"BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c\",\"name\":\"which\",\"version\":\"2.0.2\"},\"which-5.0.0.tgz\":{\"integrity\":\"JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd\",\"name\":\"which\",\"version\":\"5.0.0\"},\"which-boxed-primitive-1.1.1.tgz\":{\"integrity\":\"TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4db5f79a3f27d2874204556563c03192a707012c372fad2322e17c8c53fbf1acf70b6621986bea6c70690234d11f6ff1a98ba7ac9f60d634b28c28e9a16cc800\",\"name\":\"which-boxed-primitive\",\"version\":\"1.1.1\"},\"which-builtin-type-1.2.1.tgz\":{\"integrity\":\"6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ea205cce85fe90343b6b7f982419e1dd3f8a651c4cfe260d3d789caa4ebafd07e6d5bf778aefb23889a4834cc76e3e4b34e70dbf54c4003899d316b7e01e2ae9\",\"name\":\"which-builtin-type\",\"version\":\"1.2.1\"},\"which-collection-1.0.2.tgz\":{\"integrity\":\"K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2b88d5ca39c1760bdcf3a63a06468b64437ddf74b060eb8116476606ef597e47006dd55ba484e70e68ef67f6908d15d0aefe443e44e70f5b37f468a2a9b9e00b\",\"name\":\"which-collection\",\"version\":\"1.0.2\"},\"which-typed-array-1.1.20.tgz\":{\"integrity\":\"LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2d87e95249aac25d21f40d872f4f4c9ace36ed0d51656b8e1ecba47d570a46af6af79890c5dc348b1d4942ba9b70347d3c7d500f07f9428f0e65be6592c67c5e\",\"name\":\"which-typed-array\",\"version\":\"1.1.20\"},\"word-wrap-1.2.5.tgz\":{\"integrity\":\"BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970\",\"name\":\"word-wrap\",\"version\":\"1.2.5\"},\"wrap-ansi-7.0.0.tgz\":{\"integrity\":\"YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9\",\"name\":\"wrap-ansi\",\"version\":\"7.0.0\"},\"wrap-ansi-8.1.0.tgz\":{\"integrity\":\"si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09\",\"name\":\"wrap-ansi\",\"version\":\"8.1.0\"},\"wrap-ansi-9.0.2.tgz\":{\"integrity\":\"42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e3602d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3\",\"name\":\"wrap-ansi\",\"version\":\"9.0.2\"},\"wrappy-1.0.2.tgz\":{\"integrity\":\"l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71\",\"name\":\"wrappy\",\"version\":\"1.0.2\"},\"ws-7.5.10.tgz\":{\"integrity\":\"+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f9d6c5d6d1f06695dc6ce25d54e9332c3c593f56a296f4b133a6707974de83294f9f2f34ddb16103ebea058c38b37d4d4809384b6433f802972bd6b8c2476371\",\"name\":\"ws\",\"version\":\"7.5.10\"},\"ws-8.20.0.tgz\":{\"integrity\":\"sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b00b7c06180d6f30ad8066edd8ec66a6eaf23badd9a0393fb2a681ff39d09bde13e1f084b32ff257eec2742d64261394f656e800453b47792abaec9c0e889b54\",\"name\":\"ws\",\"version\":\"8.20.0\"},\"wsl-utils-0.3.1.tgz\":{\"integrity\":\"g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"83f7b38a24943414ac74326d08b07c6dd60450c8f88d1ec019e528f7aa7fddd4da7e08c78691784620853e24482f08d0a035f1e4caa406be1fc16b51dcacb85a\",\"name\":\"wsl-utils\",\"version\":\"0.3.1\"},\"xmlbuilder-15.1.1.tgz\":{\"integrity\":\"yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c8ca8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12\",\"name\":\"xmlbuilder\",\"version\":\"15.1.1\"},\"y18n-5.0.8.tgz\":{\"integrity\":\"0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c\",\"name\":\"y18n\",\"version\":\"5.0.8\"},\"yallist-3.1.1.tgz\":{\"integrity\":\"a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6b850641a58f1f9f663975189c01b67b09dc412e22e05e374efdc9a0033eb365430264bd36c2bc1a90cc2eb0873e4b054fb8772ba4cea14367da96fb4685f1e2\",\"name\":\"yallist\",\"version\":\"3.1.1\"},\"yallist-4.0.0.tgz\":{\"integrity\":\"3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"df074689d672ab93c1d3ce172c44b94e9392440df08d7025216321ba6da445cbffe354a7d9e990d1dc9c416e2e6572de8f02af83a12cbdb76554bf8560472dec\",\"name\":\"yallist\",\"version\":\"4.0.0\"},\"yallist-5.0.0.tgz\":{\"integrity\":\"YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f\",\"name\":\"yallist\",\"version\":\"5.0.0\"},\"yaml-1.10.3.tgz\":{\"integrity\":\"vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bc861e175bb70a39610057a43cf024da1fcabf84f798090ca31e4eca6462250074b290cfd742c7bedf8aec6f4dcba36eb8c01bdb9ffa9f5ab252301c18d7ff00\",\"name\":\"yaml\",\"version\":\"1.10.3\"},\"yaml-2.8.3.tgz\":{\"integrity\":\"AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02f6da08b38ed8eb70fe55b96e687d77f58475c0c5750a766766541f7a57f54da2872518d27bcbbfb27a4eb5a8c2495118f61b07f22e20c7d88316823e0e41a6\",\"name\":\"yaml\",\"version\":\"2.8.3\"},\"yargs-16.2.0.tgz\":{\"integrity\":\"D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0f59afbed0c6d0be5fb7f8c65a42e91b5fa6d1e43139f681bd33442eb6968f6db049550c5b1654bd880961c2a1ea3186224245847e0864f4214784caa5cf2607\",\"name\":\"yargs\",\"version\":\"16.2.0\"},\"yargs-17.7.2.tgz\":{\"integrity\":\"7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"edd4b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb\",\"name\":\"yargs\",\"version\":\"17.7.2\"},\"yargs-parser-20.2.9.tgz\":{\"integrity\":\"y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cb5d67184953215f824f766ff6ded52a5f90de14d0a13f5ad50cdece1865e91a76d6027f2154d6ed9df2f4459786e5010b64a19dff835f46a7b5e72903048ff3\",\"name\":\"yargs-parser\",\"version\":\"20.2.9\"},\"yargs-parser-21.1.1.tgz\":{\"integrity\":\"tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b55a6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07\",\"name\":\"yargs-parser\",\"version\":\"21.1.1\"},\"yauzl-2.10.0.tgz\":{\"integrity\":\"p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a786bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde\",\"name\":\"yauzl\",\"version\":\"2.10.0\"},\"yn-3.1.1.tgz\":{\"integrity\":\"Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"531e328065acbb673b8ac1567bc62ed5896e266a95871a8ad9c2d735003901c0b741f6c636933b7eed18f1bff3d7aa572e7171658bd685dddf84163d0cb982e9\",\"name\":\"yn\",\"version\":\"3.1.1\"},\"yocto-queue-0.1.0.tgz\":{\"integrity\":\"rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9\",\"name\":\"yocto-queue\",\"version\":\"0.1.0\"},\"yup-1.7.1.tgz\":{\"integrity\":\"GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"18a1c55f69d7ba5dbfe03b5fc61a33bfbd358cb40775fe89df8603876704929aa8a3c95ee4c83afcbaddb1e54bac56ab985ca065395f2211f1fd029f6ff4165f\",\"name\":\"yup\",\"version\":\"1.7.1\"},\"zod-4.3.6.tgz\":{\"integrity\":\"rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"adfb65ae484764e7230f090696752d65992f68f1c2b03013a78a46a6e38e3036937430d717dd70b950c9a16a0fb0a5ffdd83d0e5f1ee1774938dc6322abf9086\",\"name\":\"zod\",\"version\":\"4.3.6\"},\"zod-validation-error-4.0.2.tgz\":{\"integrity\":\"Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"43afe764b7ba8f1b94f34a9bff8b89e2de6fd95119e389734233c385824dced450e30c9673a545dc3dca6ff7c0b8f7ad6509e14b78676a309ff42b167ac8212d\",\"name\":\"zod-validation-error\",\"version\":\"4.0.2\"},\"zwitch-2.0.4.tgz\":{\"integrity\":\"bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d7138711fe455984a657fd18cf11f94768a56151597ce67a14defe9bf1aa5f404735c7803ecc1c6367894df0ba8677a599ddd97df29638a3bd7b5459a83e9f8\",\"name\":\"zwitch\",\"version\":\"2.0.4\"}},\"store_version\":\"v10\"}",
+        "dest-filename": "pnpm-manifest.json",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "script",
+        "commands": [
+            "case \"$FLATPAK_ARCH\" in",
+            "\"i386\")",
+            "  export ELECTRON_BUILDER_ARCH_ARGS=\"--ia32\"",
+            "  ;;",
+            "\"x86_64\")",
+            "  export ELECTRON_BUILDER_ARCH_ARGS=\"--x64\"",
+            "  ;;",
+            "\"arm\")",
+            "  export ELECTRON_BUILDER_ARCH_ARGS=\"--armv7l\"",
+            "  ;;",
+            "\"aarch64\")",
+            "  export ELECTRON_BUILDER_ARCH_ARGS=\"--arm64\"",
+            "  ;;",
+            "esac"
+        ],
+        "dest-filename": "electron-builder-arch-args.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "script",
+        "commands": [
+            "version=$(node --version | sed \"s/^v//\")",
+            "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
+            "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
+            "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
+            "echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+        ],
+        "dest-filename": "setup_sdk_node_headers.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c\"",
+            "ln -s \"../SHASUMS256.txt-40.9.1\" \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c/SHASUMS256.txt\""
+        ],
+        "dest": "flatpak-node/cache/electron"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c\"",
+            "ln -s \"../electron-v40.9.1-linux-arm64.zip\" \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c/electron-v40.9.1-linux-arm64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c\"",
+            "ln -s \"../electron-v40.9.1-linux-armv7l.zip\" \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c/electron-v40.9.1-linux-armv7l.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c\"",
+            "ln -s \"../electron-v40.9.1-linux-x64.zip\" \"3fac7143cc71eb6a53e32a9075d30ffa2e84127ed1dd554dd067ba86befa848c/electron-v40.9.1-linux-x64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-arm64@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.21.5\"",
+            "ln -sf \"@esbuild/linux-arm64@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-arm64@0.25.12/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.25.12\"",
+            "ln -sf \"@esbuild/linux-arm64@0.25.12\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-arm@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-arm@0.21.5\"",
+            "ln -sf \"@esbuild/linux-arm@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-arm@0.25.12/bin/esbuild\" \"bin/@esbuild/linux-arm@0.25.12\"",
+            "ln -sf \"@esbuild/linux-arm@0.25.12\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-ia32@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.21.5\"",
+            "ln -sf \"@esbuild/linux-ia32@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "i386"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-ia32@0.25.12/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.25.12\"",
+            "ln -sf \"@esbuild/linux-ia32@0.25.12\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "i386"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-x64@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-x64@0.21.5\"",
+            "ln -sf \"@esbuild/linux-x64@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-x64@0.25.12/bin/esbuild\" \"bin/@esbuild/linux-x64@0.25.12\"",
+            "ln -sf \"@esbuild/linux-x64@0.25.12\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv40.9.1electron-v40.9.1-linux-arm64.zip\"",
+            "ln -s \"../electron-v40.9.1-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv40.9.1electron-v40.9.1-linux-arm64.zip/electron-v40.9.1-linux-arm64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv40.9.1electron-v40.9.1-linux-armv7l.zip\"",
+            "ln -s \"../electron-v40.9.1-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv40.9.1electron-v40.9.1-linux-armv7l.zip/electron-v40.9.1-linux-armv7l.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv40.9.1electron-v40.9.1-linux-x64.zip\"",
+            "ln -s \"../electron-v40.9.1-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv40.9.1electron-v40.9.1-linux-x64.zip/electron-v40.9.1-linux-x64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "python3 flatpak-node/populate_pnpm_store.py flatpak-node/pnpm-manifest.json flatpak-node/pnpm-tarballs flatpak-node/pnpm-store",
+            "echo \"store-dir=$PWD/flatpak-node/pnpm-store\" >> .npmrc",
+            "bash flatpak-node/setup_sdk_node_headers.sh"
+        ]
+    }
+]


### PR DESCRIPTION
Hi there. This is my first flatpak commit, so I'll be glad if it gets reviewed a bit more thoroughly.

I have checked the binaries on x86_64 — they work, and I've been able to connect the trackers. I haven't checked aarch64, but I also don't think I did anything to prevent it from building.

I guess it also needs some hooks for auto-updates — and I am not familiar yet how that works in flatpak.
Currently, you need to 
1. checkout the SlimeVR-Server, and run flatpak-node-generator against the latest pnpm-lock.yaml
`flatpak run --command=flatpak-node-generator org.flatpak.Builder pnpm SlimeVR-Server/pnpm-lock.yaml`
2. update [pnpm lock itself](https://github.com/cab404/dev.slimevr.SlimeVR/blob/master/dev.slimevr.SlimeVR.yml#L106) — since I come from nixos, and since `npm info` doesn't show a usable sha512, I just update it to `package.json→packageManager` and copy the hash from error. But I am sure there's a better, automated way of doing this.

